### PR TITLE
fix: unnorm actions for starvla

### DIFF
--- a/configs/model_servers/starvla_groot_simpler.yaml
+++ b/configs/model_servers/starvla_groot_simpler.yaml
@@ -5,6 +5,7 @@
 script: "src/vla_eval/model_servers/starvla.py"
 args:
   checkpoint: StarVLA/Qwen-GR00T-Bridge-RT-1
+  unnorm_key: oxe_bridge
   use_bf16: true
   chunk_size: 1
   port: 8000

--- a/src/vla_eval/model_servers/starvla.py
+++ b/src/vla_eval/model_servers/starvla.py
@@ -60,9 +60,10 @@ class StarVLAModelServer(PredictModelServer):
     chunk_size = 1
     action_ensemble: str = "newest"
 
-    def __init__(self, checkpoint: str, *, use_bf16: bool = False) -> None:
+    def __init__(self, checkpoint: str, *, unnorm_key: str | None = None, use_bf16: bool = False) -> None:
         super().__init__()
         self.checkpoint = checkpoint
+        self.unnorm_key = unnorm_key
         self.use_bf16 = use_bf16
         self._model = None
 
@@ -258,7 +259,22 @@ class StarVLAModelServer(PredictModelServer):
             self._model = self._model.to(torch.bfloat16)
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self._model = self._model.to(device).eval()
-        logger.info("Model loaded on %s", device)
+
+        # Resolve unnorm_key and cache action stats for unnormalization.
+        # get_action_stats() is mis-decorated as @classmethod in starVLA,
+        # so we access norm_stats on the instance directly.
+        norm_stats = self._model.norm_stats
+        unnorm_key = self.unnorm_key
+        if unnorm_key is None:
+            if len(norm_stats) != 1:
+                raise ValueError(
+                    f"Model trained on multiple datasets, pass unnorm_key from: {list(norm_stats.keys())}"
+                )
+            unnorm_key = next(iter(norm_stats))
+        if unnorm_key not in norm_stats:
+            raise ValueError(f"unnorm_key={unnorm_key!r} not found, available: {list(norm_stats.keys())}")
+        self._action_stats = norm_stats[unnorm_key]["action"]
+        logger.info("Model loaded on %s (unnorm_key=%s)", device, unnorm_key)
 
     def predict(self, obs: Observation, ctx: SessionContext) -> Action:
         from PIL import Image as PILImage
@@ -298,6 +314,12 @@ class StarVLAModelServer(PredictModelServer):
 
         # First batch item
         actions = np.asarray(actions[0])
+
+        # Unnormalize: map [-1, 1] back to original action space using q01/q99 stats
+        from starVLA.model.framework.base_framework import baseframework
+
+        actions = baseframework.unnormalize_actions(actions, self._action_stats)
+
         return {"actions": actions}
 
 
@@ -307,6 +329,9 @@ if __name__ == "__main__":
         "--checkpoint",
         required=True,
         help="HuggingFace model ID (e.g. StarVLA/Qwen-PI-Bridge-RT-1) or local path to .pt file",
+    )
+    parser.add_argument(
+        "--unnorm_key", default=None, help="Dataset key for action unnormalization (auto-detected if single dataset)"
     )
     parser.add_argument("--chunk_size", type=int, default=1, help="Action chunk size (replan steps)")
     parser.add_argument("--action_ensemble", default="newest")
@@ -321,7 +346,7 @@ if __name__ == "__main__":
         format="%(asctime)s %(levelname)-8s %(name)s: %(message)s",
     )
 
-    server = StarVLAModelServer(args.checkpoint, use_bf16=args.use_bf16)
+    server = StarVLAModelServer(args.checkpoint, unnorm_key=args.unnorm_key, use_bf16=args.use_bf16)
     server.chunk_size = args.chunk_size
     server.action_ensemble = args.action_ensemble
 


### PR DESCRIPTION
## Summary
  Fix StarVLA model server to unnormalize actions before sending them to the benchmark.

### Action unnormalization
  - StarVLA's `predict()` was returning raw normalized actions (mapped to `[-1, 1]`), which the benchmark played directly — resulting in near-zero movements
  - Add `unnorm_key` parameter to select the correct dataset normalization stats (e.g. `oxe_bridge`)
  - Auto-detect `unnorm_key` when the model was trained on a single dataset; raise a clear error for multi-dataset models
  - Cache `norm_stats` at model load time and call `baseframework.unnormalize_actions()` at inference time to map actions back to the original action space

### Config update
  - Set `unnorm_key: oxe_bridge` in `starvla_groot_simpler.yaml` for the Bridge RT-1 checkpoint

### Test
  - [x] `make check` — ruff + ty passes
  - [x] `pytest` — all tests pass
  - [x] Run StarVLA (Qwen-GR00T-Bridge-RT-1) on SIMPLER — verify actions are in the correct range and the robot moves meaningfully
