### PR TITLE
fix: replace functools.cache with lru_cache for Python 3.8 compat

### DIFF
--- a/src/vla_eval/cli/main.py
+++ b/src/vla_eval/cli/main.py
@@ -18,7 +18,7 @@ from vla_eval.orchestrator import Orchestrator
 logger = logging.getLogger(__name__)
 
 
-@functools.cache
+@functools.lru_cache(maxsize=None)
 def _stderr_console():
     """Return a shared Console that writes to stderr (lazy import)."""
     from rich.console import Console


### PR DESCRIPTION
## Summary

`functools.cache` (Python 3.9+) crashes on import in 6 benchmark containers that use Python 3.8:
- libero, libero_pro, libero_mem, calvin, rlbench, robocerebra

Replace with `functools.lru_cache(maxsize=None)` which is equivalent and available since Python 3.2.

**Affects published images**: `ghcr.io/allenai/vla-evaluation-harness/libero:0.0.2` etc. are broken — `vla-eval` cannot start at all in these containers.

## Test plan

- [x] `make check` passes
- [x] `make test` passes (159 passed)
- [x] Verified crash in `libero:0.0.2` container (Python 3.8)
- [x] Verified fix in rebuilt `libero:latest` container

🤖 Generated with [Claude Code](https://claude.com/claude-code)