### PR TITLE
fix: reproduce published benchmark scores for all supported models

### DIFF
--- a/docs/reproductions/data/oft-libero/merged_libero_spatial.json
+++ b/docs/reproductions/data/oft-libero/merged_libero_spatial.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49288b2a2c5a9030c3215365e27ac5bab1606a37f8d066b0a5aa1ba2fb64ff45
+size 87593

--- a/docs/reproductions/data/oft-libero/shards/LIBEROBenchmark_libero_spatial_shard0of3.json
+++ b/docs/reproductions/data/oft-libero/shards/LIBEROBenchmark_libero_spatial_shard0of3.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c3fde7f1ee9e78c67c1ff8fb8be73e94c27915606291604845f8acdc26d82b2
+size 31349

--- a/docs/reproductions/data/oft-libero/shards/LIBEROBenchmark_libero_spatial_shard1of3.json
+++ b/docs/reproductions/data/oft-libero/shards/LIBEROBenchmark_libero_spatial_shard1of3.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5c23635b49c2cd6a0d672ac3af4a934218f5cf1f8dd8af322bc3ade026ae7af
+size 31367

--- a/docs/reproductions/data/oft-libero/shards/LIBEROBenchmark_libero_spatial_shard2of3.json
+++ b/docs/reproductions/data/oft-libero/shards/LIBEROBenchmark_libero_spatial_shard2of3.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4fe16a28abc64c3c2fc1a5d18e869260d4e55675da5e1442257bc7c316439681
+size 31167

--- a/docs/reproductions/reproduced-performance.md
+++ b/docs/reproductions/reproduced-performance.md
@@ -32,7 +32,7 @@ Seed=7, num_steps_wait=10, max_steps per suite (Spatial=220, Object=280, Goal=30
 | X-VLA (0.9B) | 98.0% | 98.0% | 98.0% | 94.8% | **97.2%** | 98.1% | Reproduced |
 | Pi0.5 | 98.0% | 99.6% | 98.6% | 94.6% | **97.7%** | 96.9% | Reproduced |
 | GR00T N1.6 | 96.6% | 98.4% | 96.8% | 87.8% | **94.9%** | 97.0% | Approximate (−2.1pp) |
-| OFT (joint) | — | — | — | — | **—** | ~96.8% | In progress |
+| OFT (joint) | 94.0% | — | — | — | **—** | ~96.8% | Spatial only (−3.6pp) |
 
 Each value = successful episodes / total episodes (500 per suite).
 Raw result JSONs: [`data/`](data/).


### PR DESCRIPTION
## Goal

Fix all model server bugs and reproduce every supported model's published benchmark scores.

## Stage 1 — LIBERO Results

| Model | Reproduced | Reported | Verdict |
|-------|:----------:|:--------:|:-------:|
| X-VLA (0.9B) | **97.2%** | 98.1% | Reproduced |
| Pi0.5 | **97.7%** | 96.9% | Reproduced |
| GR00T N1.6 | **94.9%** | 97.0% | Approximate (−2.1pp) |
| OFT (joint) | — | ~96.8% | In progress |

Full details: [`docs/reproductions/reproduced-performance.md`](docs/reproductions/reproduced-performance.md)

## Bug Fixes

| Bug | Impact | Fix |
|-----|--------|-----|
| `raw_obs` quaternion ≠ `controller` rotation matrix (~90° frame diff) | X-VLA 42% → 98% | Benchmark sends both sources; model server chooses |
| StarVLA gripper polarity `2x-1` inverted | Gripper open/close swapped | Changed to `1-2x` |
| GR00T missing gripper inversion | ~1% success | `invert_gripper` flag |
| X-VLA wrist image flipped (trained on unflipped) | Performance degradation | `unflip_wrist` in model server |
| OFT `num_images_in_input=1` (should be 2) | Missing wrist image | Fixed in `_base.yaml` |
| Pi0 default `pi0_fast_libero` (wrong model) | Wrong checkpoint | Changed to `pi05_libero` |
| Smoke test `success` check broken | All smoke tests failing | Read `metrics.success` |
| Shard merge dropped `server_info`, timestamps | Provenance lost | Fixed in `merge.py` |
| Missing `subname` in per-suite configs | Shard filename collisions | Added to all per-suite configs |

## Infrastructure

- **HELLO observation negotiation**: Model servers auto-declare required benchmark params
- **`run_server(cls)`**: Auto-argparse from `__init__` signature (−370 lines boilerplate)
- **CLI**: `--server-url`, `--param`, `--address`, `--arg`
- **`bench_demand.py`**: Resource monitoring (CPU/GPU/RAM median+peak)
- **Config cleanup**: Removed `eval_runs/`, redundant RTC configs

## Verification

- `make check`: all pass (ruff + format + ty)
- `make test`: 198 pass, 1 skipped
- Server smoke tests: 11/12 pass (RTC: no checkpoint)
- Benchmark smoke test (LIBERO): pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)