### PR TITLE
fix: restore logging after starVLA hijacks it

### DIFF
--- a/src/vla_eval/model_servers/starvla.py
+++ b/src/vla_eval/model_servers/starvla.py
@@ -38,7 +38,9 @@ Supported frameworks (auto-detected from checkpoint config):
 
 from __future__ import annotations
 
+import contextlib
 import logging
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
@@ -52,23 +54,27 @@ from vla_eval.model_servers.predict import PredictModelServer
 logger = logging.getLogger(__name__)
 
 
-def _restore_logging(level: int) -> None:
-    """Undo starVLA's logging hijack.
+@contextlib.contextmanager
+def _block_logging_hijack() -> Iterator[None]:
+    """Prevent starVLA from clobbering the caller's logging configuration.
 
     starVLA's ``overwatch.py`` calls ``logging.config.dictConfig()`` with
-    ``disable_existing_loggers: True`` at import time, which sets
-    ``disabled = True`` on every pre-existing logger and replaces root
-    handlers with a ``RichHandler``.
+    ``disable_existing_loggers: True`` at import time, which disables every
+    pre-existing logger and replaces root handlers with a ``RichHandler``.
+
+    Instead of restoring after the fact (brittle, misses exception paths),
+    we monkey-patch ``logging.config.dictConfig`` to be a no-op for the
+    duration of the import/load sequence so the caller's config is never
+    touched.
     """
-    # Restore root handler (dictConfig replaces it with RichHandler).
-    logging.basicConfig(
-        force=True, level=level,
-        format="%(asctime)s %(levelname)-8s %(name)s: %(message)s",
-    )
-    # Re-enable all loggers that dictConfig disabled.
-    for lg in logging.root.manager.loggerDict.values():
-        if isinstance(lg, logging.Logger):
-            lg.disabled = False
+    import logging.config
+
+    _real_dictConfig = logging.config.dictConfig
+    logging.config.dictConfig = lambda *_a, **_kw: None  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        logging.config.dictConfig = _real_dictConfig
 
 
 class StarVLAModelServer(PredictModelServer):
@@ -138,17 +144,16 @@ class StarVLAModelServer(PredictModelServer):
             return
         import torch
 
-        _saved_log_level = logging.getLogger().level
-
-        from starVLA.model.framework.base_framework import baseframework
-
         ckpt_path = self._resolve_checkpoint(self.checkpoint)
 
         # ------------------------------------------------------------------
-        # Monkey-patches to work around upstream starVLA incompatibilities.
-        # All patches are collected in *_patches* and restored in the
+        # Block starVLA's logging hijack for the entire import/load sequence.
+        # All monkey-patches are collected in *_patches* and restored in the
         # ``finally`` block so the global state is never left dirty.
         # ------------------------------------------------------------------
+        with _block_logging_hijack():
+            from starVLA.model.framework.base_framework import baseframework
+
         _patches: list[tuple] = []  # (obj, attr_name, original_value)
 
         # 1) flash_attention_2 → kernels-community/flash-attn2
@@ -284,7 +289,8 @@ class StarVLAModelServer(PredictModelServer):
         _qfast_mod.get_action_model = _patched_fast_gam
 
         try:
-            self._model = baseframework.from_pretrained(ckpt_path)
+            with _block_logging_hijack():
+                self._model = baseframework.from_pretrained(ckpt_path)
         finally:
             for obj, attr, orig in reversed(_patches):
                 setattr(obj, attr, orig)
@@ -308,9 +314,6 @@ class StarVLAModelServer(PredictModelServer):
         if unnorm_key not in norm_stats:
             raise ValueError(f"unnorm_key={unnorm_key!r} not found, available: {list(norm_stats.keys())}")
         self._action_stats = norm_stats[unnorm_key]["action"]
-
-        # Restore logging after all starVLA operations are done.
-        _restore_logging(_saved_log_level)
         logger.info("Model loaded on %s (unnorm_key=%s)", device, unnorm_key)
 
     def get_observation_params(self) -> dict[str, Any]:

--- a/src/vla_eval/model_servers/starvla.py
+++ b/src/vla_eval/model_servers/starvla.py
@@ -52,6 +52,25 @@ from vla_eval.model_servers.predict import PredictModelServer
 logger = logging.getLogger(__name__)
 
 
+def _restore_logging(level: int) -> None:
+    """Undo starVLA's logging hijack.
+
+    starVLA's ``overwatch.py`` calls ``logging.config.dictConfig()`` with
+    ``disable_existing_loggers: True`` at import time, which sets
+    ``disabled = True`` on every pre-existing logger and replaces root
+    handlers with a ``RichHandler``.
+    """
+    # Restore root handler (dictConfig replaces it with RichHandler).
+    logging.basicConfig(
+        force=True, level=level,
+        format="%(asctime)s %(levelname)-8s %(name)s: %(message)s",
+    )
+    # Re-enable all loggers that dictConfig disabled.
+    for lg in logging.root.manager.loggerDict.values():
+        if isinstance(lg, logging.Logger):
+            lg.disabled = False
+
+
 class StarVLAModelServer(PredictModelServer):
     """Generic starVLA model server for all Qwen* frameworks."""
 
@@ -118,10 +137,12 @@ class StarVLAModelServer(PredictModelServer):
         if self._model is not None:
             return
         import torch
+
+        _saved_log_level = logging.getLogger().level
+
         from starVLA.model.framework.base_framework import baseframework
 
         ckpt_path = self._resolve_checkpoint(self.checkpoint)
-        logger.info("Loading starVLA model from checkpoint: %s", ckpt_path)
 
         # ------------------------------------------------------------------
         # Monkey-patches to work around upstream starVLA incompatibilities.
@@ -287,6 +308,9 @@ class StarVLAModelServer(PredictModelServer):
         if unnorm_key not in norm_stats:
             raise ValueError(f"unnorm_key={unnorm_key!r} not found, available: {list(norm_stats.keys())}")
         self._action_stats = norm_stats[unnorm_key]["action"]
+
+        # Restore logging after all starVLA operations are done.
+        _restore_logging(_saved_log_level)
         logger.info("Model loaded on %s (unnorm_key=%s)", device, unnorm_key)
 
     def get_observation_params(self) -> dict[str, Any]:


### PR DESCRIPTION
starVLA disable existing loggers during import, silently dropping all log records: [url](https://github.com/starVLA/starVLA/blob/3994acd4629333ad1724b826e67b9c20e9d68c1c/starVLA/training/trainer_utils/overwatch.py#L22).
Add `_restore_logging()` that undoes this after model loading: resets manager.disable, replaces root handlers, and re-enables all disabled loggers.

## Summary

<!-- What does this PR do? -->

## Checklist

- [x] I have read the relevant contributing guide ([CONTRIBUTING.md](https://github.com/allenai/vla-evaluation-harness/blob/main/CONTRIBUTING.md) or [leaderboard/CONTRIBUTING.md](https://github.com/allenai/vla-evaluation-harness/blob/main/leaderboard/CONTRIBUTING.md))

**Code changes:**
- [x] `make check` passes (ruff + ty)
- [x] `make test` passes (pytest)
- [x] Smoke-tested affected configs (if benchmarks, model servers, or Docker were changed)
- [x] I have updated relevant documentation (if applicable)

<!-- Delete whichever section doesn't apply to your PR. -->
