### PR TITLE
feat: add MME-VLA model server and RoboMME baseline configs

### DIFF
--- a/configs/model_servers/mme_vla/_base.yaml
+++ b/configs/model_servers/mme_vla/_base.yaml
@@ -1,0 +1,13 @@
+# MME-VLA model server — shared base for all RoboMME baselines
+# Paper: https://arxiv.org/abs/2603.04639
+# Code: https://github.com/RoboMME/robomme_policy_learning
+# Weights: https://huggingface.co/Yinpei/mme_vla_suite
+script: "src/vla_eval/model_servers/mme_vla.py"
+args:
+  image_key: "observation/image"
+  wrist_image_key: "observation/wrist_image"
+  state_key: "observation/state"
+  state_dim: 8
+  image_resolution: 224
+  chunk_size: 16
+  port: 8000

--- a/configs/model_servers/mme_vla/framesamp_context.yaml
+++ b/configs/model_servers/mme_vla/framesamp_context.yaml
@@ -1,0 +1,7 @@
+# FrameSamp + Context (perceptual memory) — RoboMME
+# Reported: 30.68% avg success rate
+extends: _base.yaml
+args:
+  config_name: mme_vla_suite
+  checkpoint: Yinpei/mme_vla_suite/perceptual-framesamp-context
+  use_history: true

--- a/configs/model_servers/mme_vla/framesamp_expert.yaml
+++ b/configs/model_servers/mme_vla/framesamp_expert.yaml
@@ -1,0 +1,7 @@
+# FrameSamp + Expert (perceptual memory) — RoboMME
+# Reported: 36.25% avg success rate
+extends: _base.yaml
+args:
+  config_name: mme_vla_suite
+  checkpoint: Yinpei/mme_vla_suite/perceptual-framesamp-expert
+  use_history: true

--- a/configs/model_servers/mme_vla/framesamp_modul.yaml
+++ b/configs/model_servers/mme_vla/framesamp_modul.yaml
@@ -1,0 +1,7 @@
+# FrameSamp + Modulation (perceptual memory) — RoboMME
+# Best non-oracle variant. Reported: 44.51% avg success rate
+extends: _base.yaml
+args:
+  config_name: mme_vla_suite
+  checkpoint: Yinpei/mme_vla_suite/perceptual-framesamp-modul
+  use_history: true

--- a/configs/model_servers/mme_vla/pi05_baseline.yaml
+++ b/configs/model_servers/mme_vla/pi05_baseline.yaml
@@ -1,0 +1,7 @@
+# π₀.5 baseline (no memory) — RoboMME
+# Reported: 17.93% avg success rate
+extends: _base.yaml
+args:
+  config_name: pi05_baseline
+  checkpoint: Yinpei/pi05_baseline
+  use_history: false

--- a/configs/model_servers/mme_vla/rmt_context.yaml
+++ b/configs/model_servers/mme_vla/rmt_context.yaml
@@ -1,0 +1,7 @@
+# RMT + Context (recurrent memory) — RoboMME
+# Reported: 19.46% avg success rate
+extends: _base.yaml
+args:
+  config_name: mme_vla_suite
+  checkpoint: Yinpei/mme_vla_suite/recurrent-rmt-context
+  use_history: true

--- a/configs/model_servers/mme_vla/rmt_expert.yaml
+++ b/configs/model_servers/mme_vla/rmt_expert.yaml
@@ -1,0 +1,7 @@
+# RMT + Expert (recurrent memory) — RoboMME
+# Reported: 18.15% avg success rate
+extends: _base.yaml
+args:
+  config_name: mme_vla_suite
+  checkpoint: Yinpei/mme_vla_suite/recurrent-rmt-expert
+  use_history: true

--- a/configs/model_servers/mme_vla/rmt_modul.yaml
+++ b/configs/model_servers/mme_vla/rmt_modul.yaml
@@ -1,0 +1,7 @@
+# RMT + Modulation (recurrent memory) — RoboMME
+# Reported: 20.17% avg success rate
+extends: _base.yaml
+args:
+  config_name: mme_vla_suite
+  checkpoint: Yinpei/mme_vla_suite/recurrent-rmt-modul
+  use_history: true

--- a/configs/model_servers/mme_vla/symbolic_grounded.yaml
+++ b/configs/model_servers/mme_vla/symbolic_grounded.yaml
@@ -1,0 +1,7 @@
+# GroundSG + QwenVL (symbolic memory) — RoboMME
+# Reported: 32.70% avg success rate
+extends: _base.yaml
+args:
+  config_name: mme_vla_suite
+  checkpoint: Yinpei/mme_vla_suite/symbolic-grounded-subgoal
+  use_history: true

--- a/configs/model_servers/mme_vla/symbolic_simple.yaml
+++ b/configs/model_servers/mme_vla/symbolic_simple.yaml
@@ -1,0 +1,7 @@
+# SimpleSG + QwenVL (symbolic memory) — RoboMME
+# Reported: 29.00% avg success rate
+extends: _base.yaml
+args:
+  config_name: mme_vla_suite
+  checkpoint: Yinpei/mme_vla_suite/symbolic-simple-subgoal
+  use_history: true

--- a/configs/model_servers/mme_vla/tokendrop_context.yaml
+++ b/configs/model_servers/mme_vla/tokendrop_context.yaml
@@ -1,0 +1,7 @@
+# TokenDrop + Context (perceptual memory) — RoboMME
+# Reported: 34.50% avg success rate
+extends: _base.yaml
+args:
+  config_name: mme_vla_suite
+  checkpoint: Yinpei/mme_vla_suite/perceptual-tokendrop-context
+  use_history: true

--- a/configs/model_servers/mme_vla/tokendrop_expert.yaml
+++ b/configs/model_servers/mme_vla/tokendrop_expert.yaml
@@ -1,0 +1,7 @@
+# TokenDrop + Expert (perceptual memory) — RoboMME
+# Reported: 34.86% avg success rate
+extends: _base.yaml
+args:
+  config_name: mme_vla_suite
+  checkpoint: Yinpei/mme_vla_suite/perceptual-tokendrop-expert
+  use_history: true

--- a/configs/model_servers/mme_vla/tokendrop_modul.yaml
+++ b/configs/model_servers/mme_vla/tokendrop_modul.yaml
@@ -1,0 +1,7 @@
+# TokenDrop + Modulation (perceptual memory) — RoboMME
+# Reported: 38.04% avg success rate
+extends: _base.yaml
+args:
+  config_name: mme_vla_suite
+  checkpoint: Yinpei/mme_vla_suite/perceptual-tokendrop-modul
+  use_history: true

--- a/configs/model_servers/mme_vla/ttt_context.yaml
+++ b/configs/model_servers/mme_vla/ttt_context.yaml
@@ -1,0 +1,7 @@
+# TTT + Context (recurrent memory) — RoboMME
+# Reported: 22.28% avg success rate
+extends: _base.yaml
+args:
+  config_name: mme_vla_suite
+  checkpoint: Yinpei/mme_vla_suite/recurrent-ttt-context
+  use_history: true

--- a/configs/model_servers/mme_vla/ttt_expert.yaml
+++ b/configs/model_servers/mme_vla/ttt_expert.yaml
@@ -1,0 +1,7 @@
+# TTT + Expert (recurrent memory) — RoboMME
+# Reported: 22.35% avg success rate
+extends: _base.yaml
+args:
+  config_name: mme_vla_suite
+  checkpoint: Yinpei/mme_vla_suite/recurrent-ttt-expert
+  use_history: true

--- a/configs/model_servers/mme_vla/ttt_modul.yaml
+++ b/configs/model_servers/mme_vla/ttt_modul.yaml
@@ -1,0 +1,7 @@
+# TTT + Modulation (recurrent memory) — RoboMME
+# Reported: 21.97% avg success rate
+extends: _base.yaml
+args:
+  config_name: mme_vla_suite
+  checkpoint: Yinpei/mme_vla_suite/recurrent-ttt-modul
+  use_history: true

--- a/docs/reproductions/README.md
+++ b/docs/reproductions/README.md
@@ -2,43 +2,67 @@
 
 Systematic verification that vla-eval reproduces published VLA model scores across codebases and benchmarks.
 
-## Summary
+## Core Benchmarks
 
-| Codebase | Model | LIBERO | CALVIN | SE WidowX VM | SE GR VM | SE GR VA | RoboTwin | Other |
-|----------|-------|:------:|:------:|:------------:|:--------:|:--------:|:--------:|:-----:|
-| [openvla/openvla](https://github.com/openvla/openvla) | [OpenVLA](https://arxiv.org/abs/2406.09246) | ✅<br>**76.2%** / [76.5%](https://huggingface.co/openvla/openvla-7b) | · | · | · | · | · | |
-| [Physical-Intelligence/openpi](https://github.com/Physical-Intelligence/openpi) | [π₀.₅](https://arxiv.org/abs/2410.24164) | ✅<br>**97.7%** / [96.9%](https://huggingface.co/collections/physical-intelligence/openpi-6752e26cfc04d5f5013709ef) | · | · | · | · | · | |
-| [microsoft/CogACT](https://github.com/microsoft/CogACT) | [CogACT](https://arxiv.org/abs/2411.19650) | · | · | ⬜<br>[51.3%](https://huggingface.co/CogACT/CogACT-Base) | ⬜<br>[74.8%](https://huggingface.co/CogACT/CogACT-Base) | ⬜<br>[61.3%](https://huggingface.co/CogACT/CogACT-Base) | · | |
-| [moojink/openvla-oft](https://github.com/moojink/openvla-oft) | [OpenVLA-OFT](https://arxiv.org/abs/2502.19645) | ✅<br>**96.7%** / [97.1%](https://huggingface.co/moojink/openvla-7b-oft-finetuned-libero-spatial-object-goal-10) | · | · | · | · | · | |
-| [NVIDIA/Isaac-GR00T](https://github.com/NVIDIA/Isaac-GR00T) | [GR00T N1](https://arxiv.org/abs/2503.14734) | 🟡<br>**94.9%** / [97.0%¹](https://huggingface.co/0xAnkitSingh/GR00T-N1.6-LIBERO) | · | 🔧<br>**29.6%** / [57.1%](https://huggingface.co/nvidia/GR00T-N1.6-bridge) | 🟡<br>**59.7%** / [67.7%](https://huggingface.co/nvidia/GR00T-N1.6-fractal) | · | · | |
-| [Physical-Intelligence/real-time-chunking-kinetix](https://github.com/Physical-Intelligence/real-time-chunking-kinetix) | [RTC](https://arxiv.org/abs/2506.07339) | · | · | · | · | · | · | Kinetix: ckpt |
-| [baaivision/UniVLA](https://github.com/baaivision/UniVLA) | [UniVLA](https://arxiv.org/abs/2506.19850) | ⬜<br>[95.5%](https://huggingface.co/Yuqi1997/UniVLA/tree/main/UNIVLA_LIBERO_VIDEO_BS192_8K) | ⬜<br>[4.63](https://huggingface.co/Yuqi1997/UniVLA/tree/main/UNIVLA_CALVIN_ABCD_VIDEO_BS192_8K) | ⬜<br>[69.8%](https://huggingface.co/Yuqi1997/UniVLA/tree/main/UNIVLA_SIMPLER_BRIDGE_VIDEO_BS128_20K) | · | · | · | |
-| [2toinf/X-VLA](https://github.com/2toinf/X-VLA) | [X-VLA](https://arxiv.org/abs/2510.10274) | ✅<br>**97.4%** / [98.1%](https://huggingface.co/2toINF/X-VLA-Libero) | ✅<br>**4.30** / [4.43](https://huggingface.co/2toINF/X-VLA-Calvin-ABC_D) | ✅<br>**94.8%** / [95.8%](https://huggingface.co/2toINF/X-VLA-WidowX) | ⬜<br>[80.4%](https://huggingface.co/2toINF/X-VLA-WidowX) | ⬜<br>[75.7%](https://huggingface.co/2toINF/X-VLA-WidowX) | ⬜<br>[70/39%](https://huggingface.co/2toINF/X-VLA-WidowX) | VLABench: 51.1% |
-| [Dexmal/dexbotic](https://github.com/Dexmal/dexbotic) | [DB-CogACT](https://arxiv.org/abs/2510.23511) | ✅<br>**94.7%** / [94.9%](https://huggingface.co/Dexmal/libero-db-cogact) | ✅<br>**4.02** / [4.06](https://huggingface.co/Dexmal/calvin-db-cogact) | 🟡<br>**63.5%** / [69.5%](https://huggingface.co/Dexmal/simpler-db-cogact) | · | · | ⬜<br>[58.5%](https://huggingface.co/Dexmal/robotwin-db-cogact) | [MS2: 58%](https://huggingface.co/Dexmal/maniskill2-db-cogact) |
-| | [DB-π₀](https://arxiv.org/abs/2510.23511) | ⬜<br>[93.9%](https://huggingface.co/Dexmal/libero-db-pi0) | · | · | · | · | · | [MS2: 65%](https://huggingface.co/Dexmal/maniskill2-db-pi0) |
-| | [DB-OFT](https://arxiv.org/abs/2510.23511) | · | ⬜<br>[3.54](https://huggingface.co/Dexmal/calvin-db-oft) | ⬜<br>[76.4%](https://huggingface.co/Dexmal/simpler-db-oft) | · | · | · | [MS2: 63%](https://huggingface.co/Dexmal/maniskill2-db-oft) |
-| | [DB-MemVLA](https://arxiv.org/abs/2510.23511) | ⬜<br>[97.0%](https://huggingface.co/Dexmal/libero-db-memvla) | · | ⬜<br>[84.4%](https://huggingface.co/Dexmal/simpler-db-memvla) | · | · | · | |
-| | [DB-GR00TN1](https://arxiv.org/abs/2510.23511) | ⬜<br>94.8%† | · | · | · | · | · | |
-| [starVLA/starVLA](https://github.com/starVLA/starVLA) | Q2.5-FAST | ⬜<br>[95.2%](https://huggingface.co/StarVLA/Qwen2.5-VL-FAST-LIBERO-4in1) | · | ✅<br>**64.6%** / [58.6%](https://huggingface.co/StarVLA/Qwen-FAST-Bridge-RT-1) | · | · | · | |
-| | Qwen3-FAST | ⬜<br>95.4%† | · | ⬜<br>31.6%† | · | · | · | |
-| | Qwen3-OFT | ✅<br>**96.8%** / [97.8%²](https://huggingface.co/StarVLA/Qwen3-VL-OFT-LIBERO-4in1) | · | ⬜<br>[42.7%](https://huggingface.co/StarVLA/Qwen3VL-OFT-Bridge-RT-1) | · | · | ⬜<br>[50.4%](https://huggingface.co/StarVLA/Qwen3-VL-OFT-RoboTwin2-All) | |
-| | Qwen3-PI | ⬜<br>[95.7%](https://huggingface.co/StarVLA/Qwen3-VL-PI-LIBERO-4in1) | · | ⬜<br>60.9%† | · | · | · | |
-| | Qwen3-GR00T | ⬜<br>96.5%† | ⬜<br>3.76† | ✅<br>**66.7%** / [65.3%](https://huggingface.co/StarVLA/Qwen3VL-GR00T-Bridge-RT-1) | · | · | · | |
+| Codebase | Model | LIBERO | CALVIN | SE WidowX VM | SE GR VM | SE GR VA |
+|----------|-------|:------:|:------:|:------------:|:--------:|:--------:|
+| [openvla/openvla](https://github.com/openvla/openvla) | [OpenVLA](https://arxiv.org/abs/2406.09246) | ✅<br>**76.2%** / [76.5%](https://huggingface.co/openvla/openvla-7b) | · | · | · | · |
+| [Physical-Intelligence/openpi](https://github.com/Physical-Intelligence/openpi) | [π₀.₅](https://arxiv.org/abs/2410.24164) | ✅<br>**97.7%** / [96.9%](https://huggingface.co/collections/physical-intelligence/openpi-6752e26cfc04d5f5013709ef) | · | · | · | · |
+| [microsoft/CogACT](https://github.com/microsoft/CogACT) | [CogACT](https://arxiv.org/abs/2411.19650) | · | · | ⬜<br>[51.3%](https://huggingface.co/CogACT/CogACT-Base) | ⬜<br>[74.8%](https://huggingface.co/CogACT/CogACT-Base) | ⬜<br>[61.3%](https://huggingface.co/CogACT/CogACT-Base) |
+| [moojink/openvla-oft](https://github.com/moojink/openvla-oft) | [OpenVLA-OFT](https://arxiv.org/abs/2502.19645) | ✅<br>**96.7%** / [97.1%](https://huggingface.co/moojink/openvla-7b-oft-finetuned-libero-spatial-object-goal-10) | · | · | · | · |
+| [NVIDIA/Isaac-GR00T](https://github.com/NVIDIA/Isaac-GR00T) | [GR00T N1](https://arxiv.org/abs/2503.14734) | 🟡<br>**94.9%** / [97.0%¹](https://huggingface.co/0xAnkitSingh/GR00T-N1.6-LIBERO) | · | 🔧<br>**29.6%** / [57.1%](https://huggingface.co/nvidia/GR00T-N1.6-bridge) | 🟡<br>**59.7%** / [67.7%](https://huggingface.co/nvidia/GR00T-N1.6-fractal) | · |
+| [baaivision/UniVLA](https://github.com/baaivision/UniVLA) | [UniVLA](https://arxiv.org/abs/2506.19850) | ⬜<br>[95.5%](https://huggingface.co/Yuqi1997/UniVLA/tree/main/UNIVLA_LIBERO_VIDEO_BS192_8K) | ⬜<br>[4.63](https://huggingface.co/Yuqi1997/UniVLA/tree/main/UNIVLA_CALVIN_ABCD_VIDEO_BS192_8K) | ⬜<br>[69.8%](https://huggingface.co/Yuqi1997/UniVLA/tree/main/UNIVLA_SIMPLER_BRIDGE_VIDEO_BS128_20K) | · | · |
+| [2toinf/X-VLA](https://github.com/2toinf/X-VLA) | [X-VLA](https://arxiv.org/abs/2510.10274) | ✅<br>**97.4%** / [98.1%](https://huggingface.co/2toINF/X-VLA-Libero) | ✅<br>**4.30** / [4.43](https://huggingface.co/2toINF/X-VLA-Calvin-ABC_D) | ✅<br>**94.8%** / [95.8%](https://huggingface.co/2toINF/X-VLA-WidowX) | ⬜<br>[80.4%](https://huggingface.co/2toINF/X-VLA-WidowX) | ⬜<br>[75.7%](https://huggingface.co/2toINF/X-VLA-WidowX) |
+| [Dexmal/dexbotic](https://github.com/Dexmal/dexbotic) | [DB-CogACT](https://arxiv.org/abs/2510.23511) | ✅<br>**94.7%** / [94.9%](https://huggingface.co/Dexmal/libero-db-cogact) | ✅<br>**4.02** / [4.06](https://huggingface.co/Dexmal/calvin-db-cogact) | 🟡<br>**63.5%** / [69.5%](https://huggingface.co/Dexmal/simpler-db-cogact) | · | · |
+| | [DB-π₀](https://arxiv.org/abs/2510.23511) | ⬜<br>[93.9%](https://huggingface.co/Dexmal/libero-db-pi0) | · | · | · | · |
+| | [DB-OFT](https://arxiv.org/abs/2510.23511) | · | ⬜<br>[3.54](https://huggingface.co/Dexmal/calvin-db-oft) | ⬜<br>[76.4%](https://huggingface.co/Dexmal/simpler-db-oft) | · | · |
+| | [DB-MemVLA](https://arxiv.org/abs/2510.23511) | ⬜<br>[97.0%](https://huggingface.co/Dexmal/libero-db-memvla) | · | ⬜<br>[84.4%](https://huggingface.co/Dexmal/simpler-db-memvla) | · | · |
+| | [DB-GR00TN1](https://arxiv.org/abs/2510.23511) | ⬜<br>94.8%† | · | · | · | · |
+| [starVLA/starVLA](https://github.com/starVLA/starVLA) | Q2.5-FAST | ⬜<br>[95.2%](https://huggingface.co/StarVLA/Qwen2.5-VL-FAST-LIBERO-4in1) | · | ✅<br>**64.6%** / [58.6%](https://huggingface.co/StarVLA/Qwen-FAST-Bridge-RT-1) | · | · |
+| | Qwen3-FAST | ⬜<br>95.4%† | · | ⬜<br>31.6%† | · | · |
+| | Qwen3-OFT | ✅<br>**96.8%** / [97.8%²](https://huggingface.co/StarVLA/Qwen3-VL-OFT-LIBERO-4in1) | · | ⬜<br>[42.7%](https://huggingface.co/StarVLA/Qwen3VL-OFT-Bridge-RT-1) | · | · |
+| | Qwen3-PI | ⬜<br>[95.7%](https://huggingface.co/StarVLA/Qwen3-VL-PI-LIBERO-4in1) | · | ⬜<br>60.9%† | · | · |
+| | Qwen3-GR00T | ⬜<br>96.5%† | ⬜<br>3.76† | ✅<br>**66.7%** / [65.3%](https://huggingface.co/StarVLA/Qwen3VL-GR00T-Bridge-RT-1) | · | · |
 
-SE = SimplerEnv. SE GR = Google Robot VM. MS2 = ManiSkill2.
+SE = SimplerEnv. SE GR = Google Robot VM.
 
-**Status:** ✅ Reproduced · 🟡 Approximate (≤5pp) · 🔧 WIP · ⬜ Not attempted · `·` No score / no checkpoint
+¹ Community checkpoint (not official NVIDIA). ² Spatial suite only (reported 97.8%); 4-suite avg is 96.6%. † Checkpoint not publicly available on HuggingFace.
+
+## Other Benchmarks
+
+| Codebase | Model | RoboTwin | RoboMME | ManiSkill2 | Kinetix | VLABench |
+|----------|-------|:--------:|:-------:|:----------:|:-------:|:--------:|
+| [2toinf/X-VLA](https://github.com/2toinf/X-VLA) | [X-VLA](https://arxiv.org/abs/2510.10274) | ⬜<br>[70/39%](https://huggingface.co/2toINF/X-VLA-WidowX) | · | · | · | ⬜<br>51.1% |
+| [Dexmal/dexbotic](https://github.com/Dexmal/dexbotic) | [DB-CogACT](https://arxiv.org/abs/2510.23511) | ⬜<br>[58.5%](https://huggingface.co/Dexmal/robotwin-db-cogact) | · | ⬜<br>[58%](https://huggingface.co/Dexmal/maniskill2-db-cogact) | · | · |
+| | [DB-π₀](https://arxiv.org/abs/2510.23511) | · | · | ⬜<br>[65%](https://huggingface.co/Dexmal/maniskill2-db-pi0) | · | · |
+| | [DB-OFT](https://arxiv.org/abs/2510.23511) | · | · | ⬜<br>[63%](https://huggingface.co/Dexmal/maniskill2-db-oft) | · | · |
+| [starVLA/starVLA](https://github.com/starVLA/starVLA) | Qwen3-OFT | ⬜<br>[50.4%](https://huggingface.co/StarVLA/Qwen3-VL-OFT-RoboTwin2-All) | · | · | · | · |
+| [Physical-Intelligence/rtc](https://github.com/Physical-Intelligence/real-time-chunking-kinetix) | [RTC](https://arxiv.org/abs/2506.07339) | · | · | · | ⬜ ckpt | · |
+| [RoboMME/robomme_policy_learning](https://github.com/RoboMME/robomme_policy_learning) | [MME-VLA π₀.5](https://arxiv.org/abs/2603.04639) | · | ✅<br>**25.5%** / [22.7%](https://huggingface.co/Yinpei/pi05_baseline)¹ | · | · | · |
+| | [MME-VLA FrameSamp](https://arxiv.org/abs/2603.04639) | · | ⬜<br>[44.5%](https://huggingface.co/Yinpei/mme_vla_suite) | · | · | · |
+
+¹ Counting suite only (4/16 tasks). Full 4-suite evaluation pending.
 
 **Cell format:** status / [reported%](HF checkpoint link). Bold = our reproduced score.
 
-¹ Community checkpoint (not official NVIDIA). ² Spatial suite only (reported 97.8%); 4-suite avg is 96.6%. † Checkpoint not publicly available on HuggingFace. Per-model details in linked docs below.
+**Status:** ✅ within 95% CI · 🟡 outside CI but ≤5pp · 🔧 in progress or >5pp with known cause · ⬜ not attempted · `·` no score / no checkpoint. CI is binomial at p=0.95 (±1.9pp for 500 episodes).
 
-Per-codebase details: [openvla](openvla.md) · [openpi](openpi.md) · [cogact](cogact.md) · [oft](oft.md) · [groot](groot.md) · [rtc](rtc.md) · [xvla](xvla.md) · [dexbotic](dexbotic.md) · [starvla](starvla.md)
+## Benchmarks with No Model Coverage Yet
 
-## Verdict Criteria
+Integrated in vla-eval: RLBench, RoboCasa, Mikasa, RoboCerebra, LIBERO-90, LIBERO-Pro.
 
-Binomial 95% CI for 500 episodes/suite (±1.9pp at p=0.95):
-✅ within CI · 🟡 outside CI, ≤5pp · 🔧 in progress or >5pp with known cause · ⬜ not yet attempted.
+## Per-Codebase Details
+
+- [openvla/openvla](https://github.com/openvla/openvla): [openvla.md](openvla.md)
+- [Physical-Intelligence/openpi](https://github.com/Physical-Intelligence/openpi): [openpi.md](openpi.md)
+- [microsoft/CogACT](https://github.com/microsoft/CogACT): [cogact.md](cogact.md)
+- [moojink/openvla-oft](https://github.com/moojink/openvla-oft): [oft.md](oft.md)
+- [NVIDIA/Isaac-GR00T](https://github.com/NVIDIA/Isaac-GR00T): [groot.md](groot.md)
+- [Physical-Intelligence/rtc](https://github.com/Physical-Intelligence/real-time-chunking-kinetix): [rtc.md](rtc.md)
+- [2toinf/X-VLA](https://github.com/2toinf/X-VLA): [xvla.md](xvla.md)
+- [Dexmal/dexbotic](https://github.com/Dexmal/dexbotic): [dexbotic.md](dexbotic.md)
+- [starVLA/starVLA](https://github.com/starVLA/starVLA): [starvla.md](starvla.md)
+- [RoboMME/robomme\_policy\_learning](https://github.com/RoboMME/robomme_policy_learning): [robomme.md](robomme.md)
 
 ## Files
 

--- a/docs/reproductions/robomme.md
+++ b/docs/reproductions/robomme.md
@@ -1,0 +1,86 @@
+# MME-VLA — Reproduction Report (RoboMME)
+
+Memory-augmented VLA models from the RoboMME benchmark. [GitHub](https://github.com/RoboMME/robomme_policy_learning) |
+[Paper](https://arxiv.org/abs/2603.04639) | [Weights](https://huggingface.co/Yinpei/mme_vla_suite) | pi0.5-based (JAX).
+
+## Results Summary
+
+| Variant | Memory Type | Reproduced | Reported | Verdict |
+|---------|-------------|:----------:|:--------:|:-------:|
+| π₀.5 baseline | None | **25.5%** (counting) | 22.72% (counting) | ✅ |
+| FrameSamp+Modul | Perceptual | — | 44.51% | ⬜ |
+| FrameSamp+Context | Perceptual | — | 30.68% | ⬜ |
+| FrameSamp+Expert | Perceptual | — | 36.25% | ⬜ |
+| TokenDrop+Modul | Perceptual | — | 38.04% | ⬜ |
+| TokenDrop+Context | Perceptual | — | 34.50% | ⬜ |
+| TokenDrop+Expert | Perceptual | — | 34.86% | ⬜ |
+| SimpleSG+QwenVL | Symbolic | — | 29.00% | ⬜ |
+| GroundSG+QwenVL | Symbolic | — | 32.70% | ⬜ |
+| TTT+Context | Recurrent | — | 22.28% | ⬜ |
+| TTT+Modul | Recurrent | — | 21.97% | ⬜ |
+| TTT+Expert | Recurrent | — | 22.35% | ⬜ |
+| RMT+Context | Recurrent | — | 19.46% | ⬜ |
+| RMT+Modul | Recurrent | — | 20.17% | ⬜ |
+| RMT+Expert | Recurrent | — | 18.15% | ⬜ |
+
+Reported scores are averages over 9 runs (3 checkpoints × 3 seeds, 50 episodes/task).
+
+### π₀.5 Baseline (no memory)
+
+| | |
+|---|---|
+| **Checkpoint** | [`Yinpei/pi05_baseline`](https://huggingface.co/Yinpei/pi05_baseline) |
+| **Server config** | [`configs/model_servers/mme_vla/pi05_baseline.yaml`](../../configs/model_servers/mme_vla/pi05_baseline.yaml) |
+| **Benchmark config** | [`configs/robomme_counting.yaml`](../../configs/robomme_counting.yaml) |
+| **Results** | [`results/robomme-pi05-baseline/`](../../results/robomme-pi05-baseline/) |
+
+Counting suite: 4 tasks × 50 episodes = 200 total. No memory — ignores conditioning video.
+
+| Task | Reproduced | Reported |
+|------|:----------:|:--------:|
+| BinFill | 22.0% | — |
+| PickXtimes | 36.0% | — |
+| SwingXtimes | 40.0% | — |
+| StopCube | 4.0% | — |
+| **Average** | **25.5%** | **22.72%** |
+
+Single run (1 seed). Paper reports 9-run average (3 ckpts × 3 seeds).
+Difference (+2.8pp) is not statistically significant (z=0.94, p=0.348). Reproduced.
+
+### FrameSamp+Modul (best non-oracle)
+
+| | |
+|---|---|
+| **Checkpoint** | [`Yinpei/mme_vla_suite/perceptual-framesamp-modul`](https://huggingface.co/Yinpei/mme_vla_suite) |
+| **Server config** | [`configs/model_servers/mme_vla/framesamp_modul.yaml`](../../configs/model_servers/mme_vla/framesamp_modul.yaml) |
+| **Benchmark config** | [`configs/robomme_eval.yaml`](../../configs/robomme_eval.yaml) |
+| **Results** | `data/mme-vla-robomme/` (pending) |
+
+Uses conditioning video via `add_buffer` to populate perceptual memory before inference.
+
+## Configuration Notes
+
+- **Framework**: All models use the `mme_vla_suite` package (extended OpenPI, JAX-based). Requires `mme-vla-suite` pip dependency, NOT the standard `openpi` package.
+- **State truncation**: RoboMME benchmark sends 9D state (8 joint + 1 gripper). Models expect 8D. The model server truncates `state[:8]` automatically.
+- **Video history**: Conditioning video (motion planning demo) is sent on the first observation only via `video_history`. Memory-augmented models convert this to an `add_buffer` call. The baseline ignores it.
+- **Prompt casing**: Task descriptions are lowercased to match the upstream training convention.
+- **Action space**: 8D absolute joint angles (7 arm joints + 1 gripper). `chunk_size=10`.
+- **Image resolution**: 224×224 (SigLIP2 encoder input).
+- **Evaluation protocol**: Paper uses 50 episodes per task, max 1300 steps, `test` split.
+
+## Per-Suite Reported Scores (%)
+
+From Table 3 of the paper (averaged over 9 runs):
+
+| Variant | Counting | Permanence | Reference | Imitation | **Average** |
+|---------|:--------:|:----------:|:---------:|:---------:|:-----------:|
+| π₀.5 baseline | 22.72 | 13.67 | 11.39 | 23.94 | **17.93** |
+| FrameSamp+Modul | 47.89 | 36.00 | 41.83 | 52.33 | **44.51** |
+| TokenDrop+Modul | 44.06 | 29.00 | 33.50 | 45.61 | **38.04** |
+| GroundSG+QwenVL | 53.89 | 18.67 | 26.33 | 31.89 | **32.70** |
+
+## Known Limitations
+
+- Some recurrent checkpoints (TTT, RMT variants) may not be fully released on HuggingFace yet.
+- Video history frames do not include per-frame proprioceptive state; zero-filled instead. This matches the default config (`use_state_emb=False`) but may slightly affect variants trained with state embeddings.
+- The `mme_vla_suite` package pins a specific JAX version with CUDA 12. Ensure the host GPU driver is compatible.

--- a/src/vla_eval/model_servers/mme_vla.py
+++ b/src/vla_eval/model_servers/mme_vla.py
@@ -1,0 +1,344 @@
+# /// script
+# requires-python = "~=3.11"
+# dependencies = [
+#     "vla-eval",
+#     "openpi",
+#     "numpy>=1.24",
+#     "huggingface_hub",
+#     "pytest",
+#     "chex",
+# ]
+#
+# [tool.uv.sources]
+# vla-eval = { path = "../../..", editable = true }
+# openpi = { git = "https://github.com/RoboMME/robomme_policy_learning.git", rev = "main" }
+#
+# [tool.uv]
+# exclude-newer = "2026-04-06T00:00:00Z"
+# ///
+"""MME-VLA model server for RoboMME baselines.
+
+Loads MME-VLA suite checkpoints (pi0.5 baseline + memory-augmented
+variants) and runs inference in-process.  Supports the ``video_history``
+conditioning protocol used by the RoboMME benchmark.
+
+Memory-augmented models (FrameSamp, TokenDrop, TTT, RMT) receive the
+conditioning video via ``add_buffer`` on the first observation of each
+episode.  The baseline pi0.5 model ignores video history.
+
+The ``openpi`` PEP 723 dependency installs the RoboMME fork of OpenPI,
+which includes both the ``openpi`` and ``mme_vla_suite`` Python modules.
+Two configs are registered: ``pi05_baseline`` (no memory) and
+``mme_vla_suite`` (all 14 memory-augmented variants — the specific
+architecture is determined by the checkpoint's saved config).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import pathlib
+import subprocess
+import sys
+from typing import Any
+
+import numpy as np
+
+from vla_eval.model_servers.base import SessionContext
+from vla_eval.model_servers.predict import PredictModelServer
+from vla_eval.specs import IMAGE_RGB, LANGUAGE, RAW, DimSpec
+from vla_eval.types import Action, Observation
+
+logger = logging.getLogger(__name__)
+
+# The RoboMME fork of OpenPI ships both ``openpi`` and ``mme_vla_suite``
+# under ``src/``, but hatchling only builds the ``openpi`` wheel.  We
+# shallow-clone the repo once at runtime so ``mme_vla_suite`` is importable.
+_MME_VLA_REPO = "https://github.com/RoboMME/robomme_policy_learning.git"
+_MME_VLA_REV = "main"
+_MME_VLA_CACHE = os.path.join(os.environ.get("XDG_CACHE_HOME", os.path.expanduser("~/.cache")), "vla-eval/mme-vla")
+
+
+def _ensure_mme_vla_suite() -> None:
+    """Make the ``mme_vla_suite`` package importable."""
+    try:
+        import mme_vla_suite  # noqa: F401
+
+        return
+    except ImportError:
+        pass
+
+    src_dir = os.path.join(_MME_VLA_CACHE, "src")
+    if not os.path.isdir(os.path.join(src_dir, "mme_vla_suite")):
+        logger.info("Cloning mme_vla_suite from %s …", _MME_VLA_REPO)
+        subprocess.check_call(
+            ["git", "clone", "--depth", "1", "--branch", _MME_VLA_REV, _MME_VLA_REPO, _MME_VLA_CACHE],
+        )
+
+    # Append (not insert) so the installed openpi wheel still takes priority
+    sys.path.append(src_dir)
+    import mme_vla_suite  # noqa: F401, F811
+
+    logger.info("mme_vla_suite loaded from %s", src_dir)
+
+
+class MmeVlaModelServer(PredictModelServer):
+    """MME-VLA suite model server for RoboMME evaluation.
+
+    Handles both the pi0.5 baseline (no memory) and all 14
+    memory-augmented variants from the MME-VLA paper.
+
+    Args:
+        config_name: MME-VLA config — ``"pi05_baseline"`` or
+            ``"mme_vla_suite"`` (memory variants).
+        checkpoint: HuggingFace model ID or local path.  For the
+            multi-variant repo, use ``Yinpei/mme_vla_suite/subdir``.
+        use_history: Enable memory lifecycle (reset + add_buffer).
+            Must be ``True`` for all memory-augmented variants.
+        image_key: Key for the front camera in the OpenPI obs dict.
+        wrist_image_key: Key for the wrist camera (``None`` to disable).
+        state_key: Key for proprioceptive state (``None`` to disable).
+        state_dim: Truncate benchmark state to this dimension.
+            RoboMME sends 9D; models expect 8D.
+        image_resolution: Resize images to this square resolution.
+        chunk_size: Number of actions per inference call.
+        action_ensemble: Ensemble strategy for overlapping chunks.
+    """
+
+    def __init__(
+        self,
+        config_name: str = "pi05_baseline",
+        checkpoint: str | None = None,
+        use_history: bool = False,
+        image_key: str = "observation/image",
+        wrist_image_key: str | None = "observation/wrist_image",
+        state_key: str | None = "observation/state",
+        state_dim: int = 8,
+        image_resolution: int | None = 224,
+        *,
+        chunk_size: int = 10,
+        action_ensemble: str = "newest",
+        **kwargs: Any,
+    ) -> None:
+        if use_history and kwargs.get("max_batch_size", 1) > 1:
+            raise ValueError("use_history=True is incompatible with max_batch_size > 1 (memory is per-session)")
+        super().__init__(chunk_size=chunk_size, action_ensemble=action_ensemble, **kwargs)
+        self.config_name = config_name
+        self.checkpoint = checkpoint
+        self.use_history = use_history
+        self.image_key = image_key
+        self.wrist_image_key = None if wrist_image_key in (None, "None", "none") else wrist_image_key
+        self.state_key = None if state_key in (None, "None", "none") else state_key
+        self.state_dim = state_dim
+        self.image_resolution = image_resolution
+        self._policy: Any = None
+        self._state_warned = False
+
+    # ------------------------------------------------------------------
+    # Model loading
+    # ------------------------------------------------------------------
+
+    def _resolve_checkpoint(self) -> str:
+        """Resolve checkpoint to a local directory containing ``params/`` and ``assets/``."""
+        if self.checkpoint is None:
+            raise ValueError("checkpoint must be specified for MME-VLA models")
+
+        # Already a local path with params/
+        if os.path.isdir(self.checkpoint) and os.path.isdir(os.path.join(self.checkpoint, "params")):
+            return self.checkpoint
+
+        from huggingface_hub import snapshot_download
+
+        # Handle 3-segment paths: org/repo/subdir
+        parts = self.checkpoint.split("/")
+        if len(parts) >= 3:
+            repo_id = "/".join(parts[:2])
+            subdir = "/".join(parts[2:])
+            local = snapshot_download(repo_id)
+            dl_path = os.path.join(local, subdir)
+        else:
+            dl_path = snapshot_download(self.checkpoint)
+
+        return self._find_or_extract_checkpoint(dl_path)
+
+    @staticmethod
+    def _find_or_extract_checkpoint(dl_path: str) -> str:
+        """Find checkpoint root (containing ``params/``) inside *dl_path*.
+
+        HuggingFace repos may ship checkpoints as zip files with an
+        internal directory tree.  This method extracts the zip if needed
+        and walks the result to locate the ``params/`` directory.
+        """
+        # Direct match
+        if os.path.isdir(os.path.join(dl_path, "params")):
+            return dl_path
+
+        # Look for zip files to extract
+        import glob
+        import zipfile
+
+        zips = glob.glob(os.path.join(dl_path, "**/*.zip"), recursive=True)
+        if not zips:
+            zips = glob.glob(os.path.join(dl_path, "*.zip"))
+
+        extract_base = os.path.join(dl_path, "_extracted")
+        for zf in zips:
+            extract_dir = os.path.join(extract_base, pathlib.Path(zf).stem)
+            if not os.path.isdir(extract_dir):
+                logger.info("Extracting checkpoint: %s", zf)
+                with zipfile.ZipFile(zf, "r") as z:
+                    z.extractall(extract_dir)
+
+        # Walk to find the directory that contains params/
+        search_root = extract_base if os.path.isdir(extract_base) else dl_path
+        for root, dirs, _files in os.walk(search_root):
+            if "params" in dirs:
+                logger.info("Found checkpoint root: %s", root)
+                return root
+
+        raise FileNotFoundError(f"No params/ directory found in {dl_path}")
+
+    def _load_model(self) -> None:
+        if self._policy is not None:
+            return
+
+        _ensure_mme_vla_suite()
+
+        from mme_vla_suite.policies import policy_config
+        from mme_vla_suite.training import config as _config
+
+        logger.info("Loading MME-VLA config: %s", self.config_name)
+        config = _config.get_config(self.config_name)
+
+        checkpoint = pathlib.Path(self._resolve_checkpoint())
+        logger.info("Loading policy from checkpoint: %s", checkpoint)
+        self._policy = policy_config.create_trained_policy(config, checkpoint)
+        logger.info("MME-VLA policy loaded successfully.")
+
+    # ------------------------------------------------------------------
+    # Image helpers
+    # ------------------------------------------------------------------
+
+    def _maybe_resize(self, img: np.ndarray) -> np.ndarray:
+        if self.image_resolution is None or img.shape[:2] == (self.image_resolution, self.image_resolution):
+            return img
+        from PIL import Image
+
+        pil = Image.fromarray(img)
+        pil = pil.resize((self.image_resolution, self.image_resolution), Image.Resampling.BILINEAR)
+        return np.asarray(pil)
+
+    # ------------------------------------------------------------------
+    # Video history → add_buffer
+    # ------------------------------------------------------------------
+
+    def _process_video_history(self, obs: Observation) -> None:
+        """Convert ``video_history`` frames into the policy's memory buffer.
+
+        The ``MME_VLA_Policy.add_buffer`` expects:
+            images: ``(T, 1, H, W, 3)`` uint8 — the extra axis is ``num_views``
+            state:  ``(T, state_dim)`` float32
+            exec_start_idx: int — index where execution starts (= len of demo)
+        """
+        frames = obs.get("video_history", [])
+        if not frames:
+            return
+
+        resized = [self._maybe_resize(np.asarray(f, dtype=np.uint8)) for f in frames]
+        images = np.stack(resized)[:, np.newaxis]  # (T, 1, H, W, 3)
+
+        buffer_obs = {
+            "images": images,
+            "state": np.zeros((len(frames), self.state_dim), dtype=np.float32),
+            "exec_start_idx": len(frames),  # execution starts after the demo
+        }
+
+        assert self._policy is not None
+        self._policy.add_buffer(buffer_obs)
+        logger.debug("Added %d video history frames to memory buffer", len(frames))
+
+    # ------------------------------------------------------------------
+    # Specs and params
+    # ------------------------------------------------------------------
+
+    def get_observation_params(self) -> dict[str, Any]:
+        params: dict[str, Any] = {}
+        if self.wrist_image_key:
+            params["send_wrist_image"] = True
+        if self.state_key:
+            params["send_state"] = True
+        if self.use_history:
+            params["send_video_history"] = True
+        return params
+
+    def get_action_spec(self) -> dict[str, DimSpec]:
+        return {"actions": RAW}
+
+    def get_observation_spec(self) -> dict[str, DimSpec]:
+        spec: dict[str, DimSpec] = {"image": IMAGE_RGB}
+        if self.state_key:
+            spec["state"] = RAW
+        spec["language"] = LANGUAGE
+        return spec
+
+    # ------------------------------------------------------------------
+    # Episode lifecycle
+    # ------------------------------------------------------------------
+
+    async def on_episode_start(self, config: dict[str, Any], ctx: SessionContext) -> None:
+        await super().on_episode_start(config, ctx)
+        if self.use_history and self._policy is not None and hasattr(self._policy, "reset"):
+            self._policy.reset()
+
+    # ------------------------------------------------------------------
+    # Inference
+    # ------------------------------------------------------------------
+
+    def predict(self, obs: Observation, ctx: SessionContext) -> Action:
+        self._load_model()
+        assert self._policy is not None
+
+        # Handle video history on first observation
+        if self.use_history and ctx.is_first and obs.get("video_history"):
+            self._process_video_history(obs)
+
+        # Build OpenPI observation dict
+        openpi_obs: dict[str, Any] = {}
+
+        # Images
+        images_dict = obs.get("images", {})
+        img_list = list(images_dict.values()) if isinstance(images_dict, dict) else []
+        base_img = np.asarray(img_list[0], dtype=np.uint8) if img_list else np.zeros((256, 256, 3), dtype=np.uint8)
+        base_img = self._maybe_resize(base_img)
+        openpi_obs[self.image_key] = base_img
+
+        if self.wrist_image_key:
+            wrist_img = np.asarray(img_list[1], dtype=np.uint8) if len(img_list) > 1 else np.zeros_like(base_img)
+            wrist_img = self._maybe_resize(wrist_img)
+            openpi_obs[self.wrist_image_key] = wrist_img
+
+        # Prompt (lowercase to match upstream convention)
+        openpi_obs["prompt"] = obs.get("task_description", "").lower()
+
+        # State (truncate to model's expected dimension)
+        if self.state_key:
+            raw_state = obs.get("states", obs.get("state"))
+            if raw_state is not None:
+                state = np.asarray(raw_state, dtype=np.float64)
+                if state.shape[0] > self.state_dim:
+                    if not self._state_warned:
+                        logger.info("Truncating state from %dD to %dD", state.shape[0], self.state_dim)
+                        self._state_warned = True
+                    state = state[: self.state_dim]
+                openpi_obs[self.state_key] = state
+            else:
+                openpi_obs[self.state_key] = np.zeros(self.state_dim, dtype=np.float64)
+
+        result = self._policy.infer(openpi_obs)
+        return {"actions": result["actions"]}
+
+
+if __name__ == "__main__":
+    from vla_eval.model_servers.serve import run_server
+
+    run_server(MmeVlaModelServer)


### PR DESCRIPTION
## Summary

- Add `MmeVlaModelServer` for all 15 RoboMME baselines (pi0.5 + 14 memory-augmented variants)
- 16 config files in `configs/model_servers/mme_vla/`
- Reproduction doc `docs/reproductions/robomme.md` with Counting suite results
- Split reproduction README tables into Core Benchmarks vs Other Benchmarks

## Key features

- `video_history` → `add_buffer` conversion for memory-augmented models (first model server to support conditioning video)
- HuggingFace checkpoint auto-download with zip extraction
- State dimension truncation (9D benchmark → 8D model)
- `chunk_size=16` matching upstream evaluation protocol

## Reproduction result

pi0.5 baseline on Counting suite: **25.5%** vs paper's **22.72%** (z=0.94, p=0.348 — within 95% CI).

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (256/256)
- [x] `vla-eval test -c configs/model_servers/mme_vla/pi05_baseline.yaml` smoke test passes
- [x] Full Counting suite evaluation (200 episodes) reproduces paper scores