### PR TITLE
leaderboard/maniskill2: add aggregation rule + align task key casing

### DIFF
--- a/leaderboard/benchmarks/maniskill2.md
+++ b/leaderboard/benchmarks/maniskill2.md
@@ -9,12 +9,6 @@ metric:
   - 0
   - 100
   higher_is_better: true
-suites:
-- PickClutterYCB
-- PickCube
-- PickSingleEGAD
-- PickSingleYCB
-- StackCube
 tasks:
 - AssemblingKits
 - CloseCabinetDoor
@@ -40,15 +34,23 @@ tasks:
 - TurnFaucetLeft
 - TurnFaucetRight
 - Write
+aggregation:
+  container: task_scores
+  keys:
+  - PickCube
+  - StackCube
+  - PickSingleYCB
+  - PickSingleEGAD
+  - PickClutterYCB
 detail_notes: "Task subsets vary significantly — 14+ different combinations exist across papers. The most common 5-task set (PickCube, StackCube, PickSingleYCB, PickSingleEGAD, PickClutterYCB) covers ~24% of entries. A second common 5-task set (Fill, Hang, PickCube, PickSingleYCB, StackCube) covers ~19%. <strong>Scores across different task subsets are not directly comparable.</strong> Averaging methods also vary (weighted vs arithmetic). Check notes for which tasks were evaluated. <strong>Only entries using the standard 5-task set have a sortable overall score</strong> — other task subsets are shown but not ranked."
 ---
 
-**Standard**: ManiSkill2 5-task set (PickCube, StackCube, PickSingleYCB, PickSingleEGAD, PickClutterYCB); `overall_score` = mean success rate across the 5 tasks.
+**Standard**: ManiSkill2 5-task set (`PickCube`, `StackCube`, `PickSingleYCB`, `PickSingleEGAD`, `PickClutterYCB`); `overall_score` = arithmetic mean across those 5 tasks, and `null` for any other subset.
 
 ## Scoring
-- `overall_score`: arithmetic mean over the 5 standard tasks; `null` if the task set differs.
-- `suite_scores`: not used.
-- `task_scores`: per-task success rates keyed `pick_cube`, `stack_cube`, `pick_single_ycb`, `pick_single_egad`, `pick_clutter_ycb` (snake_case).
+- `overall_score`: arithmetic mean over the 5 standard `task_scores` keys; `null` if any of the 5 is missing or a different subset is used.
+- `suite_scores`: not used — ManiSkill2 has no canonical sub-suites at this level.
+- `task_scores`: per-task success rates keyed by the PascalCase task name exactly as it appears in the ManiSkill2 codebase (`PickCube`, `StackCube`, `PickSingleYCB`, `PickSingleEGAD`, `PickClutterYCB`, and any of the other names listed in `tasks` above).
 
 ## Checks
 - Does the entry use exactly the 5 standard tasks? Other subsets → `null`.

--- a/leaderboard/data/benchmarks.json
+++ b/leaderboard/data/benchmarks.json
@@ -1309,13 +1309,6 @@
       ],
       "higher_is_better": true
     },
-    "suites": [
-      "PickClutterYCB",
-      "PickCube",
-      "PickSingleEGAD",
-      "PickSingleYCB",
-      "StackCube"
-    ],
     "tasks": [
       "AssemblingKits",
       "CloseCabinetDoor",
@@ -1342,6 +1335,16 @@
       "TurnFaucetRight",
       "Write"
     ],
+    "aggregation": {
+      "container": "task_scores",
+      "keys": [
+        "PickCube",
+        "StackCube",
+        "PickSingleYCB",
+        "PickSingleEGAD",
+        "PickClutterYCB"
+      ]
+    },
     "papers_reviewed": [
       "2301.04195",
       "2302.04659",

--- a/leaderboard/data/leaderboard.json
+++ b/leaderboard/data/leaderboard.json
@@ -6379,18 +6379,18 @@
       "benchmark": "maniskill2",
       "weight_type": "finetuned",
       "overall_score": 53.2,
-      "suite_scores": {
+      "reported_paper": "https://arxiv.org/abs/2508.13103",
+      "reported_table": "Table I",
+      "notes": "Camera coordinate system (best variant). Also evaluated with robot coordinate: 45.2% overall (PickCube 71.0%, StackCube 62.0%, PickSingleYCB 30.0%, PickClutterYCB 15.0%, PickSingleEGAD 48.0%). Trained from scratch on ManiSkill2 dataset with Droid pretraining.",
+      "curated_by": "opus 4.6",
+      "date_added": "2026-03-04",
+      "task_scores": {
         "PickCube": 88.0,
         "StackCube": 65.0,
         "PickSingleYCB": 46.0,
         "PickClutterYCB": 19.0,
         "PickSingleEGAD": 48.0
-      },
-      "reported_paper": "https://arxiv.org/abs/2508.13103",
-      "reported_table": "Table I",
-      "notes": "Camera coordinate system (best variant). Also evaluated with robot coordinate: 45.2% overall (PickCube 71.0%, StackCube 62.0%, PickSingleYCB 30.0%, PickClutterYCB 15.0%, PickSingleEGAD 48.0%). Trained from scratch on ManiSkill2 dataset with Droid pretraining.",
-      "curated_by": "opus 4.6",
-      "date_added": "2026-03-04"
+      }
     },
     {
       "model": "oft_dexbotic_paper",


### PR DESCRIPTION
## Summary

Gives ManiSkill2 an enforced aggregation contract for the first time, and cleans up a silent inconsistency between its md spec and the live data. Part of the leaderboard regeneration prep series (after #38).

- **Frontmatter: add `aggregation` rule** pointing at `task_scores` with the 5 standard task keys (`PickCube`, `StackCube`, `PickSingleYCB`, `PickSingleEGAD`, `PickClutterYCB`). `refine.py` already reads these rules from `benchmarks.json` to compute `overall_score` automatically, and `validate.py` uses them to catch drift.
- **Scoring section: reconcile docs with data.** The old md body prescribed snake_case keys (`pick_cube`, ...) but 100% of live entries use ManiSkill2's PascalCase. Align docs to the data; document that `suite_scores` is unused.
- **Drop the `suites` list** from frontmatter. It previously repeated the 5 standard tasks but maniskill2 stores per-task numbers in `task_scores`, so `suites` was dead metadata.
- **Data fix**: one entry (`oc_vla`) had its 5 standard-task scores in `suite_scores` instead of `task_scores`. Move them so the new aggregation rule sees them.

## Impact on existing entries

| Status | Count | Effect |
|---|---|---|
| Has `overall_score` + all 5 std tasks | 13 | Aggregation check now enforced — all 13 match mean within ±0.25 tolerance |
| `overall_score=null` (non-standard subset) | 41 | Unchanged — rule skips entries missing any of the 5 keys |

No entry loses a score. One entry's container changes shape (documented above).

## Verification

```
$ uv run leaderboard/scripts/build_benchmarks_json.py --check
OK: benchmarks.json in sync with 17 benchmarks.

$ uv run leaderboard/scripts/validate.py
OK: 670 results across 556 models and 17 benchmarks

$ make check
All checks passed!
```

## Test plan

- [x] `build_benchmarks_json.py --check` in sync
- [x] `validate.py` passes (includes new aggregation rule check)
- [x] `make check` clean (ruff + ty)
- [x] Manual: all 13 maniskill2 entries with `overall_score` match arithmetic mean of the 5 std tasks within ±0.25
- [ ] CI `leaderboard-validate.yml` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)