### PR TITLE
leaderboard: harden extract/refine pipeline against silent compression and fabrication

### DIFF
--- a/leaderboard/scripts/extract.py
+++ b/leaderboard/scripts/extract.py
@@ -395,95 +395,76 @@ EXTRACTION_SCHEMA: dict = {
 def _build_system_prompt(all_rules: str) -> str:
     return f"""You are the EXTRACT stage of a two-stage VLA leaderboard pipeline.
 
-## Pipeline role
+Your goal is recall. Surface every row that could belong on the leaderboard,
+with the evidence (verbatim quotes, protocol notes, attribution) a downstream
+PRECISION stage needs to make the final cut. When uncertain, extract.
 
-Be RECALL-FIRST. Surface every row that has any chance of being a leaderboard
-entry, with the evidence (verbatim quotes, protocol notes, attribution) the
-next stage needs to make the cut.
+The precision stage handles protocol gating, score arithmetic, dedup across
+papers, canonical naming cleanup, and notes — do not pre-filter for those
+concerns.
 
-A separate REFINE stage downstream handles precision — protocol gating
-(dropping rows you mark `matches_standard="no"`), score arithmetic from
-component suite/task scores, eligibility filtering, dedup across papers,
-canonical naming, and notes. Do NOT pre-filter for any of those concerns.
-When uncertain whether to extract a row, extract it.
+Baseline-comparison and related-work score tables often hold the only record
+of a given model on this benchmark (the original paper may never reach
+extraction). Extract every row in every comparison table.
 
-**Cited baselines carry the same weight as the paper's own results.** Baseline
-comparison tables and related-work score tables are often the ONLY recorded
-source for a given model on this benchmark — the original paper may not reach
-extraction for other reasons (no arxiv preprint, different citation graph,
-older than our scan). Never abbreviate or summarize a baseline table; every
-row in every comparison table is load-bearing.
+## Inclusion criteria
 
-## What belongs on the leaderboard
-
-A leaderboard entry represents a distinct, publicly identifiable VLA model or
-method. Your job is to extract only rows that belong on such a leaderboard,
-not every row in every table.
-
-## Inclusion criteria (ALL must hold)
-
-A model is eligible ONLY if ALL of the following are true:
+A row is eligible when ALL three hold:
 
 1. **Public name (resolve from paper context when the table label is
-   generic).** Each row must map to a specific, canonical method name a
-   reader could Google — "OpenVLA", "RT-2", "π₀", "Diffusion Policy",
-   "3D Diffuser Actor", "CogACT".
+   generic).** Each row maps to a specific, canonical method name a reader
+   could Google — "OpenVLA", "RT-2", "π₀", "Diffusion Policy", "3D Diffuser
+   Actor", "CogACT".
 
    When the table label is generic ("Ours", "Our Method", "Proposed",
-   "Baseline", "(Ours)"), find the method's real name in the paper's
-   title / abstract / method section and emit THAT as `label` — you
-   have Read access to the paper for exactly this. Downstream stages
-   cannot redo this lookup. Skip only when the paper offers no
-   canonical name.
+   "Baseline", "(Ours)"), find the method's real name in the paper's title /
+   abstract / method section and emit THAT as `label` — you have Read access
+   to the paper for exactly this. Downstream stages cannot redo this lookup.
 
-   Skip unnamed suffix rows ("Ablation", "(b)", "variant X") with no
-   recoverable identity.
+   Skip only when the paper offers no canonical name, or the label is an
+   unnamed suffix ("Ablation", "(b)", "variant X") with no recoverable
+   identity.
 
-2. **Primary configuration**: it represents a distinct method, not a minor
-   variant along one axis. SKIP rows that are ablations, hyperparameter
-   sweeps, training-stage snapshots, or post-processing variants of a
-   primary method. Specifically skip rows whose only differentiator is:
+2. **Primary configuration, not an ablation variant.** Skip rows whose only
+   differentiator is:
    - quantization scheme (INT4, INT8, FP8, AWQ, PTQ, QAT, GPTQ, GGUF, ...)
    - parameter-efficient tuning (LoRA, QLoRA, adapter, prefix-tuning, ...)
-   - data/training-stage variant ("w/o pretrain", "stage 1", "50% data", ...)
-   - horizon/action-chunk hyperparameters ("k=1", "chunk=8", ...)
-   - a minor architecture tweak marked with a suffix like "+feature X"
-   Unless such a variant IS the paper's main contribution (e.g. a paper
-   whose core claim is about quantization), treat it as an ablation and
-   skip it.
+   - training-stage variant ("w/o pretrain", "stage 1", "50% data", ...)
+   - horizon / action-chunk hyperparameters ("k=1", "chunk=8", ...)
+   - suffix tweaks like "+feature X"
+   Unless that variant is the paper's main contribution.
 
-3. **Score attribution**: the row reports a concrete numerical score on a
-   listed benchmark that the paper either ran itself or cites verbatim.
-   Skip rows with only qualitative notes or with no recoverable number.
+3. **Numeric score.** The row reports a concrete number on a listed
+   benchmark — either the paper's own run or a cited baseline. Skip rows
+   with only qualitative notes.
 
-## Classification
+## Per-row fields
 
-For each eligible model, set `is_score_original`:
-- `original` — paper ran this model itself (new run, their proposed method
-  or their re-run of a baseline)
-- `cited_baseline` — number quoted from another paper, not re-run here
-- `reproduction` — paper explicitly marks it as their reproduction of prior work
-- `unknown` — genuinely cannot tell
+For each eligible model:
 
-And `weight_type`: `shared` (same checkpoint across benchmarks) or
-`finetuned` (trained specifically on this benchmark's data).
+- `label`: canonical method name (resolved per criterion 1).
+- `weight_type`: `shared` (same checkpoint across benchmarks) or `finetuned`
+  (trained specifically on this benchmark's data).
+- `is_score_original`:
+  - `original` — paper ran this model itself
+  - `cited_baseline` — number quoted from another paper, not re-run
+  - `reproduction` — paper explicitly marks it as their reproduction
+  - `unknown` — genuinely cannot tell
+- `scores`: follow the per-benchmark JSON shape in the rules below.
+  Every numeric score carries a verbatim `quote` from the paper. If you
+  cannot find a value, return `null` — never guess or compute.
+- `protocol.matches_standard`: `yes` / `no` / `partial` / `unknown`.
+  Failing a benchmark's `Checks` → `no`. Differences along `Methodology
+  axes` → `yes`.
 
-## Hard rules
-
-- Every extracted score MUST carry a verbatim `quote` from the paper.
-- If you cannot find a value, return null. Never guess or compute.
-- Use the exact benchmark key as listed (e.g. "libero", "calvin").
-- Emit rows whenever the paper reports numeric scores, including
-  re-runs of existing methods on a benchmark. Return `benchmarks: []`
-  only for pure survey / theory papers with no evaluation table.
+Use the exact benchmark key as listed in the rules (e.g. `libero`, `calvin`).
 
 ## Coverage
 
-Your goal here is coverage. A downstream stage filters and
-deduplicates — your job is to surface every benchmark-row the paper
-touches.
+Your goal at this stage is coverage. A downstream stage filters and
+deduplicates — your job is to surface every benchmark-row the paper touches.
 
-For every benchmark in your scope, before calling StructuredOutput:
+For every benchmark key in your scope, before calling StructuredOutput:
 
 1. Grep the paper for the benchmark's key name, display name, and its
    standard suite / task names listed in the rules below.
@@ -494,19 +475,18 @@ For every benchmark in your scope, before calling StructuredOutput:
    keyed by benchmark id with a one-line reason.
 4. If the paper does not mention the benchmark → omit it from both.
 
-A paper that evaluates on multiple benchmarks (e.g. CALVIN and
-RoboCasa) produces entries for every one of them, not just the one
-framed as the paper's main contribution.
+A paper that evaluates on multiple benchmarks produces entries for every
+one of them, not just the one framed as the paper's main contribution.
 
-## Benchmark rule template
+Return `benchmarks: []` only for pure survey / theory papers with no
+evaluation table.
 
-Each benchmark block below opens with a bold `**Standard**: ...` line — the
-canonical protocol in one sentence. `Scoring` prescribes the JSON shape
-(`overall_score` computation, canonical `suite_scores` / `task_scores` keys).
-`Checks` are yes/no questions a row must pass; a failed check means the row
-has `protocol.matches_standard = "no"`. `Methodology axes` are variance
-dimensions to record in your extraction rationale / quotes — they are NOT
-protocol violations, so a row that merely differs along these axes still has
+## Benchmark rules
+
+Each block below opens with `**Standard**: ...` (the canonical protocol).
+`Scoring` prescribes the JSON shape. `Checks` lists yes/no questions;
+failing any → `protocol.matches_standard = "no"`. `Methodology axes` are
+variance dimensions — differences along these still allow
 `matches_standard = "yes"`.
 
 {all_rules}

--- a/leaderboard/scripts/extract.py
+++ b/leaderboard/scripts/extract.py
@@ -453,6 +453,12 @@ For each eligible model:
 - `scores`: follow the per-benchmark JSON shape in the rules below.
   Every numeric score carries a verbatim `quote` from the paper. If you
   cannot find a value, return `null` — never guess or compute.
+
+  When the paper tabulates per-task or per-suite numbers, emit each one
+  as a separate `task_scores` / `suite_scores` entry. A detailed results
+  table never collapses to `overall_score` only — the per-component
+  values are what make the row auditable and let downstream stages
+  recover a reported average when the protocol is non-standard.
 - `protocol.matches_standard`: `yes` / `no` / `partial` / `unknown`.
   Failing a benchmark's `Checks` → `no`. Differences along `Methodology
   axes` → `yes`.

--- a/leaderboard/scripts/extract.py
+++ b/leaderboard/scripts/extract.py
@@ -301,7 +301,12 @@ EXTRACTION_SCHEMA: dict = {
                             "properties": {
                                 "label": {
                                     "type": "string",
-                                    "description": "Model label as it appears in the paper's results table",
+                                    "description": (
+                                        "Canonical method name. Usually the paper's table label, but "
+                                        "when the label is generic ('Ours', 'Baseline', 'Ablation', etc.) "
+                                        "resolve to the method's real name from the paper's title / "
+                                        "abstract / method section."
+                                    ),
                                 },
                                 "label_quote": {"type": ["string", "null"]},
                                 "params": {"type": ["string", "null"]},
@@ -377,12 +382,9 @@ EXTRACTION_SCHEMA: dict = {
         "benchmarks_absent": {
             "type": "object",
             "description": (
-                "Map {benchmark_key: rationale}. Populate for every benchmark in your scope that the "
-                "paper MENTIONS but you deliberately did not emit in `benchmarks[]` (e.g. non-standard "
-                "protocol, only cited from prior work, scores unreadable). Omitting a benchmark that "
-                "the paper does not mention at all is fine — do NOT list those here. This field exists "
-                "to catch the failure mode where you read a benchmark's result table during navigation "
-                "and then silently forget to emit it."
+                "Map {benchmark_key: reason} for benchmarks the paper mentions but do not appear in "
+                "`benchmarks[]` (cited-only, non-standard, unreadable, etc.). Omit benchmarks the paper "
+                "never mentions."
             ),
             "additionalProperties": {"type": "string"},
         },
@@ -422,26 +424,20 @@ not every row in every table.
 
 A model is eligible ONLY if ALL of the following are true:
 
-1. **Public name** (or recoverable from context): the row's method must
-   have a specific, canonical name a reader could Google. Examples of
-   ELIGIBLE names: "OpenVLA", "RT-2", "π₀", "Diffusion Policy",
+1. **Public name (resolve from paper context when the table label is
+   generic).** Each row must map to a specific, canonical method name a
+   reader could Google — "OpenVLA", "RT-2", "π₀", "Diffusion Policy",
    "3D Diffuser Actor", "CogACT".
 
-   Rows labeled "Ours", "Our Method", "Our Model", "Proposed", "This
-   Work", "(Ours)" ARE eligible — this is the paper's main contribution
-   and almost always has a real name in the title / abstract / method
-   section. Emit the row with `label` set verbatim to what the table
-   says ("Ours"); the downstream refine stage resolves the canonical
-   name from paper context. SKIP only when the paper genuinely offers no
-   public name for the method.
+   When the table label is generic ("Ours", "Our Method", "Proposed",
+   "Baseline", "(Ours)"), find the method's real name in the paper's
+   title / abstract / method section and emit THAT as `label` — you
+   have Read access to the paper for exactly this. Downstream stages
+   cannot redo this lookup. Skip only when the paper offers no
+   canonical name.
 
-   Rows labeled "Baseline" are comparison rows. Use the paper's caption,
-   surrounding prose, or neighboring labeled rows to identify which
-   baseline is measured, then emit under that baseline's real name
-   (again, `label` stays verbatim).
-
-   Rows labeled generically "Ablation" / "(b)" / "(c)" / "variant X"
-   where you cannot recover a canonical identity → SKIP.
+   Skip unnamed suffix rows ("Ablation", "(b)", "variant X") with no
+   recoverable identity.
 
 2. **Primary configuration**: it represents a distinct method, not a minor
    variant along one axis. SKIP rows that are ablations, hyperparameter
@@ -477,40 +473,30 @@ And `weight_type`: `shared` (same checkpoint across benchmarks) or
 - Every extracted score MUST carry a verbatim `quote` from the paper.
 - If you cannot find a value, return null. Never guess or compute.
 - Use the exact benchmark key as listed (e.g. "libero", "calvin").
-- A paper that is purely a survey / reproduction study / evaluation
-  harness with no new method of its own may emit an empty `benchmarks`
-  array — the original methods' rows already reach the leaderboard via
-  their own papers. But a paper that runs a new evaluation (including a
-  new eval of existing methods) DOES need its rows emitted here.
+- Emit rows whenever the paper reports numeric scores, including
+  re-runs of existing methods on a benchmark. Return `benchmarks: []`
+  only for pure survey / theory papers with no evaluation table.
 
-## Coverage check (MANDATORY before StructuredOutput)
+## Coverage
 
-Recall failure is the pipeline's single biggest risk, and it usually
-looks the same: you navigate into a paper, read a benchmark's result
-table, and then silently drop that benchmark when you emit the final
-structured output — "the paper's main contribution is X so I'll only
-emit X". That is a bug, not a judgment call. A paper that runs on
-CALVIN AND RoboCasa MUST emit entries for BOTH.
+Your goal here is coverage. A downstream stage filters and
+deduplicates — your job is to surface every benchmark-row the paper
+touches.
 
-Before calling StructuredOutput, for every benchmark key in your
-scope, run this check:
+For every benchmark in your scope, before calling StructuredOutput:
 
-1. Does the paper name this benchmark at all? (quick Grep of its key
-   name / display name / suite-or-task names listed in the per-benchmark
-   rules below is a good way to check.)
-2. If yes: does the paper report numeric scores for it?
-   - yes → emit an entry in `benchmarks[]`. Do not skip because the
-     benchmark is "not the paper's main contribution".
-   - no (mention only, e.g. cited as prior work, or scores unreadable)
-     → record it in `benchmarks_absent`: a mapping whose key is the
-     benchmark key (e.g. `"robocasa"`) and whose value is a one-line
-     rationale. This is how you acknowledge that you saw the benchmark
-     and intentionally chose not to extract it.
-3. If the paper never mentions the benchmark: omit from both fields.
+1. Grep the paper for the benchmark's key name, display name, and its
+   standard suite / task names listed in the rules below.
+2. If the paper reports any numeric score for it → add an entry to
+   `benchmarks[]`.
+3. If the paper mentions it without an extractable score (cited-only,
+   non-standard unreadable, etc.) → add an entry to `benchmarks_absent`
+   keyed by benchmark id with a one-line reason.
+4. If the paper does not mention the benchmark → omit it from both.
 
-`benchmarks_absent` is an audit field, not a filter. Populating it
-forces you to make the skip decision explicit rather than letting the
-benchmark fall through silently.
+A paper that evaluates on multiple benchmarks (e.g. CALVIN and
+RoboCasa) produces entries for every one of them, not just the one
+framed as the paper's main contribution.
 
 ## Benchmark rule template
 

--- a/leaderboard/scripts/extract.py
+++ b/leaderboard/scripts/extract.py
@@ -374,6 +374,18 @@ EXTRACTION_SCHEMA: dict = {
             },
         },
         "confidence": {"type": "string", "enum": ["high", "medium", "low"]},
+        "benchmarks_absent": {
+            "type": "object",
+            "description": (
+                "Map {benchmark_key: rationale}. Populate for every benchmark in your scope that the "
+                "paper MENTIONS but you deliberately did not emit in `benchmarks[]` (e.g. non-standard "
+                "protocol, only cited from prior work, scores unreadable). Omitting a benchmark that "
+                "the paper does not mention at all is fine — do NOT list those here. This field exists "
+                "to catch the failure mode where you read a benchmark's result table during navigation "
+                "and then silently forget to emit it."
+            ),
+            "additionalProperties": {"type": "string"},
+        },
     },
 }
 
@@ -410,13 +422,26 @@ not every row in every table.
 
 A model is eligible ONLY if ALL of the following are true:
 
-1. **Public name**: it has a specific, canonical name a reader could Google.
-   Examples of ELIGIBLE names: "OpenVLA", "RT-2", "π₀", "Diffusion Policy",
+1. **Public name** (or recoverable from context): the row's method must
+   have a specific, canonical name a reader could Google. Examples of
+   ELIGIBLE names: "OpenVLA", "RT-2", "π₀", "Diffusion Policy",
    "3D Diffuser Actor", "CogACT".
-   NEVER extract rows labeled: "Ours", "Our Method", "Our Model", "Proposed",
-   "This Work", "Baseline", "Ablation", or anything that is only meaningful
-   inside the paper. If the only label is "Ours", find the method's actual
-   name from the title/abstract — and if there is none, SKIP the row.
+
+   Rows labeled "Ours", "Our Method", "Our Model", "Proposed", "This
+   Work", "(Ours)" ARE eligible — this is the paper's main contribution
+   and almost always has a real name in the title / abstract / method
+   section. Emit the row with `label` set verbatim to what the table
+   says ("Ours"); the downstream refine stage resolves the canonical
+   name from paper context. SKIP only when the paper genuinely offers no
+   public name for the method.
+
+   Rows labeled "Baseline" are comparison rows. Use the paper's caption,
+   surrounding prose, or neighboring labeled rows to identify which
+   baseline is measured, then emit under that baseline's real name
+   (again, `label` stays verbatim).
+
+   Rows labeled generically "Ablation" / "(b)" / "(c)" / "variant X"
+   where you cannot recover a canonical identity → SKIP.
 
 2. **Primary configuration**: it represents a distinct method, not a minor
    variant along one axis. SKIP rows that are ablations, hyperparameter
@@ -452,10 +477,40 @@ And `weight_type`: `shared` (same checkpoint across benchmarks) or
 - Every extracted score MUST carry a verbatim `quote` from the paper.
 - If you cannot find a value, return null. Never guess or compute.
 - Use the exact benchmark key as listed (e.g. "libero", "calvin").
-- Be conservative. A paper whose entire contribution is a survey,
-  reproduction study, or evaluation harness (not a new method) should
-  usually return an empty `benchmarks` array — those rows are already
-  on the leaderboard via their original papers.
+- A paper that is purely a survey / reproduction study / evaluation
+  harness with no new method of its own may emit an empty `benchmarks`
+  array — the original methods' rows already reach the leaderboard via
+  their own papers. But a paper that runs a new evaluation (including a
+  new eval of existing methods) DOES need its rows emitted here.
+
+## Coverage check (MANDATORY before StructuredOutput)
+
+Recall failure is the pipeline's single biggest risk, and it usually
+looks the same: you navigate into a paper, read a benchmark's result
+table, and then silently drop that benchmark when you emit the final
+structured output — "the paper's main contribution is X so I'll only
+emit X". That is a bug, not a judgment call. A paper that runs on
+CALVIN AND RoboCasa MUST emit entries for BOTH.
+
+Before calling StructuredOutput, for every benchmark key in your
+scope, run this check:
+
+1. Does the paper name this benchmark at all? (quick Grep of its key
+   name / display name / suite-or-task names listed in the per-benchmark
+   rules below is a good way to check.)
+2. If yes: does the paper report numeric scores for it?
+   - yes → emit an entry in `benchmarks[]`. Do not skip because the
+     benchmark is "not the paper's main contribution".
+   - no (mention only, e.g. cited as prior work, or scores unreadable)
+     → record it in `benchmarks_absent`: a mapping whose key is the
+     benchmark key (e.g. `"robocasa"`) and whose value is a one-line
+     rationale. This is how you acknowledge that you saw the benchmark
+     and intentionally chose not to extract it.
+3. If the paper never mentions the benchmark: omit from both fields.
+
+`benchmarks_absent` is an audit field, not a filter. Populating it
+forces you to make the skip decision explicit rather than letting the
+benchmark fall through silently.
 
 ## Benchmark rule template
 
@@ -565,6 +620,7 @@ def _batched_schema() -> dict:
                         "arxiv_id": {"type": "string"},
                         "benchmarks": single["properties"]["benchmarks"],
                         "confidence": single["properties"]["confidence"],
+                        "benchmarks_absent": single["properties"]["benchmarks_absent"],
                     },
                 },
             }
@@ -665,6 +721,7 @@ def extract_batch(
             "paper_hash": _paper_hash(aid),
             "extraction_scope": scope,
             "benchmarks": p.get("benchmarks", []),
+            "benchmarks_absent": p.get("benchmarks_absent") or {},
             "confidence": p.get("confidence"),
         }
         _save_cached_extraction(aid, record)

--- a/leaderboard/scripts/extract.py
+++ b/leaderboard/scripts/extract.py
@@ -47,7 +47,7 @@ SCAN_CACHE_PATH = ROOT / ".cache" / "scan_results.json"
 FETCH_FAILURES_PATH = CACHE_DIR / "fetch_failures.json"
 
 DEFAULT_MODEL = "claude-opus-4-6[1m]"
-DEFAULT_TIMEOUT = 1200
+DEFAULT_TIMEOUT = 2400
 _ARXIV_RE = re.compile(r"arxiv\.org/abs/(\d+\.\d+)")
 
 # Lock for thread-safe fetch failure writes

--- a/leaderboard/scripts/extract.py
+++ b/leaderboard/scripts/extract.py
@@ -450,15 +450,22 @@ For each eligible model:
   - `cited_baseline` — number quoted from another paper, not re-run
   - `reproduction` — paper explicitly marks it as their reproduction
   - `unknown` — genuinely cannot tell
-- `scores`: follow the per-benchmark JSON shape in the rules below.
-  Every numeric score carries a verbatim `quote` from the paper. If you
-  cannot find a value, return `null` — never guess or compute.
+- `scores`: the benchmark's numeric results. See the benchmark rules
+  below for the exact JSON shape; the general structure is:
+  - `overall_score`: the benchmark's canonical aggregate.
+  - `suite_scores`: sub-scores over groupings the benchmark itself
+    defines — e.g. LIBERO's 5 suites (`libero_spatial`/`libero_object`/
+    `libero_goal`/`libero_10`/`libero_90`), CALVIN's
+    `chain_1`..`chain_5`, SimplerEnv's `google_robot_vm`/`..._va`/
+    `widowx_vm`.
+  - `task_scores`: individual per-task success rates — e.g. RoboCasa
+    `PnPCounterToMicrowave`, ManiSkill2 `PickCube`.
 
-  When the paper tabulates per-task or per-suite numbers, emit each one
-  as a separate `task_scores` / `suite_scores` entry. A detailed results
-  table never collapses to `overall_score` only — the per-component
-  values are what make the row auditable and let downstream stages
-  recover a reported average when the protocol is non-standard.
+  Emit every tabulated per-suite / per-task number as its own entry.
+  Do not collapse a detailed results table to `overall_score` alone.
+
+  Every numeric score carries a verbatim `quote`. Values you cannot
+  locate in the paper are `null`.
 - `protocol.matches_standard`: `yes` / `no` / `partial` / `unknown`.
   Failing a benchmark's `Checks` → `no`. Differences along `Methodology
   axes` → `yes`.
@@ -486,6 +493,22 @@ one of them, not just the one framed as the paper's main contribution.
 
 Return `benchmarks: []` only for pure survey / theory papers with no
 evaluation table.
+
+## Review before StructuredOutput
+
+Before emitting the final output, check each row:
+
+- Every numeric value has an `*_quote` containing that value's exact
+  characters from the paper. If you cannot locate the text, set the
+  value to `null`.
+- Every claim in `protocol.rationale` (task count, demo count, split,
+  embodiment, etc.) has matching text in `evidence_quote`. A claim
+  without a supporting quote → downgrade `matches_standard` one step
+  toward `"unknown"`.
+- `matches_standard` is consistent with `protocol.rationale`. If the
+  rationale describes any benchmark `Checks` violation (subset of the
+  standard task set, alternative embodiment, non-standard split, etc.),
+  `matches_standard` cannot be `"yes"`.
 
 ## Benchmark rules
 

--- a/leaderboard/scripts/refine.py
+++ b/leaderboard/scripts/refine.py
@@ -172,6 +172,16 @@ def build_candidates(benchmark_filter: str | None = None) -> tuple[list[dict], d
                     overall = None
                     if match == "no":
                         stats["rows_match_no_kept_null"] += 1
+                    # Non-standard-protocol preservation: per
+                    # leaderboard/CONTRIBUTING.md, an entry with a
+                    # reported aggregate but no component breakdown keeps
+                    # the paper's number in `task_scores.reported_avg`
+                    # (overall_score stays null so it does not rank).
+                    # Without this recovery the row would be dropped by
+                    # the empty-score check below.
+                    raw_overall = scores_raw.get("overall_score")
+                    if isinstance(raw_overall, (int, float)) and not task_scores and not suite_scores:
+                        task_scores = {"reported_avg": raw_overall}
 
                 # Skip entries with no score at all (schema requires >=1).
                 if overall is None and not suite_scores and not task_scores:

--- a/leaderboard/scripts/refine.py
+++ b/leaderboard/scripts/refine.py
@@ -221,130 +221,100 @@ def _print_stats(stats: dict) -> None:
 def _build_system_prompt() -> str:
     return f"""You are the PRECISION stage of a two-stage VLA leaderboard pipeline.
 
-## Pipeline role
+An EXTRACT stage (with Read access to each paper) produced the candidates at
+`{CANDIDATES_PATH}`. A deterministic Python step has already applied the
+protocol gate: rows with `protocol_match == "yes"` have `overall_score`
+computed from component scores; all other rows keep `overall_score = null`
+but are retained.
 
-The EXTRACT stage that produced these candidates was deliberately RECALL-FIRST:
-it surfaced every row it could find with a number on a registry benchmark,
-including cited baselines from related work, framework / architecture variants,
-and rows whose protocol it marked `partial` or `unknown`. Many of those rows
-should NOT end up on the public leaderboard.
+You do NOT have paper access at this stage. All paper-derived context is
+already in the candidate fields — rely on them.
 
-A deterministic Python pre-step has already applied the hard protocol gate:
-- `matches_standard == "no"` rows were dropped.
-- `partial` / `unknown` rows kept with `overall_score = null`.
-- `yes` rows have `overall_score` computed from component suite/task scores.
+## Candidate fields
 
-Your job is the FUZZY precision pass: drop everything else that doesn't
-belong (junk labels, ablation variants, stale cited baselines), dedup
-across papers, normalize identity across benchmarks, and write substantive
-notes. Apply your filters aggressively. When in doubt, drop. A small,
-clean leaderboard is the goal.
+Each candidate is one (paper × benchmark × model) row with:
 
-## Benchmark rule template
-
-Each benchmark block (embedded elsewhere in this prompt or accessible via
-`Read` on `leaderboard/benchmarks/*.md`) opens with a bold `**Standard**: ...`
-line — the canonical protocol in one sentence. `Scoring` prescribes the
-JSON shape. `Checks` are yes/no questions a row must pass; a failed check
-means the row's `overall_score` must stay `null`. `Methodology axes` are
-variance dimensions you must record in `notes` — they are NOT protocol
-violations, so a row that merely differs along these axes keeps its
-`overall_score` populated.
-
-## Context
-
-The candidate entries are in `{CANDIDATES_PATH}`. Each candidate is one
-(paper × benchmark × model) row from a raw extraction, with these fields
-already filled in:
-
-- `name_in_paper`: exact label from the paper's table
+- `name_in_paper`: the canonical method name the extract stage resolved
+  from the paper. Treat as already cleaned — do not re-derive.
 - `params`, `benchmark`, `weight_type`
-- `overall_score`: either computed from components or null if the
-  protocol does not match standard. Do NOT recompute it.
-- `suite_scores`, `task_scores`: component scores, already plain numbers
+- `overall_score`: computed by the python step. Never recompute or change.
+- `suite_scores`, `task_scores`: component scores, plain numbers
 - `reported_paper`, `reported_table`
-- `protocol_match`: "yes" / "partial" / "unknown" (candidates with "no"
-  were already dropped by the python step)
-- `protocol_rationale`: the LLM rationale from the extraction step —
-  use this as the basis for your `notes` field
-- `is_score_original`: "original" / "cited_baseline" / "reproduction" / "unknown"
+- `protocol_match`: `"yes"` / `"no"` / `"partial"` / `"unknown"`
+- `protocol_rationale`: the extract stage's reasoning — use as the basis
+  for `notes`
+- `is_score_original`: `"original"` / `"cited_baseline"` / `"reproduction"`
+  / `"unknown"`
 
-## Your job (fuzzy decisions only)
+## Your job
 
-1. **Eligibility filter**: drop rows that cannot be attributed to an
-   identifiable method, even after consulting the paper's title,
-   abstract, caption, or surrounding prose.
+Apply filters aggressively; when in doubt, drop. A small leaderboard of
+canonical entries beats a large one with ablation junk.
 
-   Generic table labels — "Ours", "Our Method", "Our Model", "Proposed",
-   "This Work", "Baseline", "(Ours)" / "(ours)" — are the paper's own
-   table formatting, NOT drop triggers. They are RESOLVE signals:
+### 1. Drop failed-resolution rows
 
-   - An "Ours"-like label marks the paper's main contribution. Recover
-     the method's real name from the paper itself (title, abstract,
-     method section) and fill `display_name` and the `model` citation
-     key accordingly. Keep `name_in_paper` verbatim as "Ours" — the
-     provenance fact that the paper labeled it this way is exactly what
-     that field is auditing.
-   - A "Baseline"-like label marks a comparison row. Use the paper's
-     caption, surrounding prose, or neighboring labeled rows to decide
-     which method is being measured, then resolve as above.
+Drop any row whose `name_in_paper` is still a generic label — "Ours",
+"Our Method", "Our Model", "Proposed", "This Work", "Baseline", "(Ours)",
+"Ablation", "(b)", "(c)", "variant X", or similar. The extract stage was
+supposed to resolve these to the method's real name. Since you cannot
+read the paper, a generic label means the row is not attributable.
 
-   Only drop a generic-labeled row when even the paper genuinely fails
-   to identify the method (rare).
+### 2. Drop ablation / variant rows
 
-   DO still drop ablation / variant rows whose differentiator is ONLY:
-   - quantization (INT4, INT8, AWQ, PTQ, QAT, GPTQ, ...)
-   - parameter-efficient tuning (LoRA, QLoRA, adapter, ...)
-   - training-stage snapshots ("stage 1", "50% data", "w/o pretrain")
-   - horizon / chunk / hyperparameter sweeps ("k=1", "chunk=8")
-   - "+feature X", "w/o Y" style ablation tags
-   - An unnamed "row (b)" / "(c)" style label
-   Unless that variant IS clearly the paper's main contribution.
+Drop rows whose only differentiator is:
+- quantization (INT4, INT8, AWQ, PTQ, QAT, GPTQ, ...)
+- parameter-efficient tuning (LoRA, QLoRA, adapter, ...)
+- training-stage snapshots ("stage 1", "50% data", "w/o pretrain")
+- horizon / chunk / hyperparameter sweeps ("k=1", "chunk=8")
+- "+feature X" / "w/o Y" style tags
 
-2. **Dedup**: distinct `reported_paper`s produce distinct entries. Never
-   collapse a third-party measurement into a first-party canonical row.
-   Two rows with the same model on the same benchmark, but different
-   `reported_paper`, must remain separate. Within a single
-   `(model, benchmark, reported_paper)` triple, collapse duplicates and
-   prefer the row with more score detail (more suite/task keys, non-null
-   overall).
+Unless the variant IS the paper's main contribution.
 
-3. **Cross-benchmark identity**: a model's first-party entries across
-   different benchmarks must carry the same `display_name`, `params`, and
-   `model_paper`. Pick the most detailed / most canonical values. (This
-   rule applies inside the first-party set; third-party entries inherit
-   the same canonical values for the underlying method.)
+### 3. Dedup
 
-4. **Compose `notes`**: for each kept entry, write a substantive,
-   human-readable note. Use the `protocol_rationale` field as the basis
-   (trim if long), and append origin info. NEVER write generic labels
-   like "partial protocol match" / "score cited" / empty. A reader
-   hovering the score should learn something specific about what was
-   evaluated and how.
+Distinct `reported_paper`s produce distinct entries — never collapse a
+third-party measurement into a first-party canonical row. Within a single
+`(model, benchmark, reported_paper)` triple, collapse duplicates and keep
+the row with the most score detail.
 
-   Good: "ABC→D split with 1000 evaluation chains; avg_len metric; reproduction"
-   Good: "18/18 PerAct tasks, single camera view; cited from RVT paper Table 2"
-   Bad: "partial protocol match"
-   Bad: ""
+### 4. Cross-benchmark identity
 
-5. **Assign `model` key and `display_name`**: the `model` field must be a
-   BibTeX citation key that makes the entry's provenance self-explanatory.
-   For first-party entries (`reported_paper == model_paper`), use the
-   method's own citation key. For third-party measurements, the key must
-   encode both the method and the measuring paper.
+A model's first-party entries across benchmarks carry the same
+`display_name`, `params`, and `model_paper`. Pick the most canonical
+values. Third-party entries inherit the underlying method's canonical
+values.
 
-   `display_name` is human-readable. For third-party entries, the display
-   name must make the source obvious to a reader scanning the leaderboard.
+### 5. Assign `model` and `display_name`
 
-   Examples (illustrative, not prescriptive):
-     first-party  →  model: `kim24openvla`,
-                     display_name: "OpenVLA"
-     third-party  →  model: `kim24openvla__black24xvla`,
-                     display_name: "OpenVLA (from X-VLA)"
+`model` is a BibTeX-style key encoding provenance:
+
+- First-party (`reported_paper == model_paper`):
+  - `model: kim24openvla`, `display_name: "OpenVLA"`
+- Third-party measurement:
+  - `model: kim24openvla__black24xvla`, `display_name: "OpenVLA (from X-VLA)"`
+
+`display_name` for third-party entries makes the measuring paper obvious
+to a reader scanning the leaderboard.
+
+### 6. Compose `notes`
+
+Base on `protocol_rationale` (trim if long), append origin info. Write
+something specific:
+
+- OK: "ABC→D split with 1000 evaluation chains; avg_len metric; reproduction"
+- OK: "18/18 PerAct tasks, single camera view; cited from RVT paper Table 2"
+- Bad: "partial protocol match"
+- Bad: ""
+
+## Benchmark rules
+
+Each block in `leaderboard/benchmarks/*.md` opens with `**Standard**: ...`
+(the canonical protocol). You already have resolved scores, so consult
+these only for dedup / identity / notes context.
 
 ## Output
 
-Write `{LEADERBOARD_PATH}` as JSON:
+Write `{LEADERBOARD_PATH}`:
 
 ```
 {{
@@ -353,40 +323,21 @@ Write `{LEADERBOARD_PATH}` as JSON:
 }}
 ```
 
-Each entry must match the schema at `{SCHEMA_PATH}`:
+Each entry matches `{SCHEMA_PATH}` with fields: `model`, `display_name`,
+`name_in_paper`, `params`, `model_paper`, `benchmark`, `weight_type`,
+`overall_score`, `suite_scores`, `task_scores`, `reported_paper`,
+`reported_table`, `curated_by`, `date_added`, `notes`.
 
-- `model`, `display_name`, `name_in_paper`, `params`, `model_paper`,
-  `benchmark`, `weight_type`, `overall_score`, `suite_scores`,
-  `task_scores`, `reported_paper`, `reported_table`, `curated_by`,
-  `date_added`, `notes`
+- Copy `name_in_paper` verbatim from the candidate. Never blank it out,
+  never synthesize from `display_name`.
+- `curated_by` uses the form `"<family> <version>"` — e.g. `"opus 4.6"`,
+  `"sonnet 4.6"`. The schema rejects `"claude-sonnet-4-6"` and similar.
+- `date_added = "{date.today().isoformat()}"`.
+- `results` sorted by `(benchmark, model)`. UTF-8, trailing newline.
 
-Set `curated_by` to your own model alias (e.g. `"opus 4.6"` — the model
-running this refine step; NOT the literal string `"refine.py"`) and
-`date_added = "{date.today().isoformat()}"`.
+Never touch `overall_score` — the python step computed it.
 
-`results` MUST be sorted by `(benchmark, model)`. The file should be
-UTF-8 with a trailing newline.
-
-## Bias toward dropping
-
-When in doubt, DROP. A smaller leaderboard of canonical entries is much
-better than a large one with ablation junk. A reader wants "what are
-the main VLA models and how do they compare", not every table row.
-
-## Constraints
-
-- Do NOT touch `overall_score` — the python step computed it. Your
-  changes are limited to which rows survive, how they are named, and
-  what notes they carry.
-- Every output entry MUST include `name_in_paper` copied verbatim from
-  the candidate's `name_in_paper` field. This is the provenance audit
-  trail that lets a reviewer open `reported_paper`/`reported_table` and
-  find the exact row — never drop it, never synthesize it from
-  `display_name`, never blank it out.
-- Set `curated_by` to a schema-valid form: your model alias as
-  `"<family> <version>"` (e.g. `"opus 4.6"`, `"sonnet 4.6"`). Do NOT
-  emit variants like `"claude-sonnet-4-6"` — the schema rejects them.
-- Report what you dropped and why when you are done.
+Report what you dropped and why when you finish.
 """
 
 

--- a/leaderboard/scripts/refine.py
+++ b/leaderboard/scripts/refine.py
@@ -7,8 +7,8 @@
 Two-stage pipeline:
 
 1. `build_candidates()` — deterministic Python step. Applies the protocol
-   gate (drop `matches_standard = no`, null out `partial`), computes
-   `overall_score` arithmetically from components, and emits candidate
+   gate (`yes` → compute `overall_score` from components; `no`/`partial`/
+   `unknown` → keep row with `overall_score = null`) and emits candidate
    entries in a pre-schema shape.
 
 2. LLM agent (opus) — receives the candidate entries via a temp file and
@@ -97,8 +97,10 @@ def build_candidates(benchmark_filter: str | None = None) -> tuple[list[dict], d
     """Read extractions and emit candidate entries.
 
     Applied here (deterministic):
-    - Protocol gate: drop `matches_standard == "no"`; null out `overall_score`
-      for `partial`/`unknown`; compute from components for `yes`.
+    - Protocol gate: `yes` computes `overall_score` from components;
+      everything else (`no`/`partial`/`unknown`) keeps `overall_score = null`
+      but the row is retained so non-standard subsets still surface on the
+      leaderboard as unranked entries (see leaderboard/CONTRIBUTING.md).
     - Arithmetic: mean of required component keys per the benchmark's
       `aggregation` rule in benchmarks.json.
     - Forbidden-overall enforcement for benchmarks with aggregation `"forbidden"`.
@@ -119,7 +121,7 @@ def build_candidates(benchmark_filter: str | None = None) -> tuple[list[dict], d
         "papers_empty": 0,  # extraction file had benchmarks:[] — citing paper, no scores
         "papers_with_scores": 0,
         "rows_total": 0,
-        "rows_drop_protocol_no": 0,
+        "rows_match_no_kept_null": 0,  # protocol=no rows kept with overall_score=null
         "rows_drop_empty_after_conversion": 0,
         "rows_kept": 0,
     }
@@ -143,15 +145,20 @@ def build_candidates(benchmark_filter: str | None = None) -> tuple[list[dict], d
                 stats["rows_total"] += 1
                 protocol = m.get("protocol") or {}
                 match = protocol.get("matches_standard", "unknown")
-                # Hard reject: LLM already judged this protocol non-matching
-                if match == "no":
-                    stats["rows_drop_protocol_no"] += 1
-                    continue
                 scores_raw = m.get("scores") or {}
                 suite_scores = _to_plain_scores(scores_raw.get("suite_scores"))
                 task_scores = _to_plain_scores(scores_raw.get("task_scores"))
 
-                # Arithmetic / protocol gate
+                # Arithmetic / protocol gate.
+                #
+                # Only `matches_standard == "yes"` rows get an aggregated
+                # `overall_score`. Everything else (including the hard "no"
+                # case) keeps `overall_score = null` but stays in the
+                # candidate pool so non-standard subsets still appear on
+                # the leaderboard as non-ranked entries — see
+                # leaderboard/CONTRIBUTING.md "non-standard entries must
+                # set overall_score to null and store the original
+                # aggregate in task_scores.reported_avg".
                 if match == "yes":
                     overall = _compute_overall(benchmark, suite_scores, task_scores)
                     # Fallback: if the benchmark has no aggregation rule at
@@ -163,6 +170,8 @@ def build_candidates(benchmark_filter: str | None = None) -> tuple[list[dict], d
                             overall = raw_overall
                 else:
                     overall = None
+                    if match == "no":
+                        stats["rows_match_no_kept_null"] += 1
 
                 # Skip entries with no score at all (schema requires >=1).
                 if overall is None and not suite_scores and not task_scores:
@@ -198,7 +207,7 @@ def _print_stats(stats: dict) -> None:
         f"  papers with scores:              {stats['papers_with_scores']}\n"
         f"  papers empty (cited, no scores): {stats['papers_empty']}\n"
         f"Model rows processed: {stats['rows_total']}\n"
-        f"  dropped (protocol 'no'):         {stats['rows_drop_protocol_no']}\n"
+        f"  match=no kept with null overall: {stats['rows_match_no_kept_null']}\n"
         f"  dropped (no score after conv):   {stats['rows_drop_empty_after_conversion']}\n"
         f"  kept as candidates:              {stats['rows_kept']}"
     )


### PR DESCRIPTION
## Summary

The two-stage extract/refine pipeline from #37 has never been run end-to-end to regenerate `leaderboard.json`. A robocasa-benchmark pilot across 30 papers surfaced three systemic problems in the current prompts / logic:

1. **Silent compression.** The extract LLM reads detailed results tables (per-task success rates for each of N baselines) but emits only `overall_score` in its structured output, losing the per-component detail downstream stages need.
2. **Silent drops.** `build_candidates` hard-rejected every row with `protocol_match == "no"`, dropping non-standard-subset measurements even when the paper's reported aggregate was usable. CONTRIBUTING.md says these should be kept with `overall_score = null` and the number preserved in `task_scores.reported_avg` — the pipeline wasn't honoring that.
3. **Fabricated rationales.** Under batch pressure the LLM invented protocol facts — e.g. claiming "24 tasks, 50 demos" for a paper that actually evaluates 16 — and emitted `matches_standard = "yes"` with the fabricated number as a ranked score. Logs showed the fabrication was not backed by `evidence_quote` but the row still flowed through.

This PR is prep work to make the pipeline's first full regeneration safe. No data change.

## Extract-side changes

- **`benchmarks_absent` field.** New optional field on the extraction output: `{benchmark_key → one-line reason}` for benchmarks the paper mentions but does not emit, so "we saw it and chose not to extract" is recorded instead of being indistinguishable from "we missed it."
- **Coverage check section.** Explicit positive-framed instruction that the LLM's goal at this stage is recall across the scope — grep every benchmark, emit when scored, record in `benchmarks_absent` when mentioned but unscored.
- **Identity resolution kept in extract.** The refine stage has no paper access (no `--add-dir`), so canonical name resolution for generic table labels ("Ours", "Baseline") must happen in extract. The inclusion criterion is rewritten to make that explicit and positive rather than "NEVER extract rows labeled ...".
- **Scores sub-fields broken out.** Separate bullets for `overall_score` / `suite_scores` / `task_scores` with benchmark-specific examples, and an explicit instruction that a tabulated per-task / per-suite table must not collapse to `overall_score` alone.
- **Review stage before StructuredOutput.** Three self-consistency checks: every numeric value has a locatable `*_quote`; every `protocol.rationale` claim is backed by `evidence_quote` (unsupported claims downgrade `matches_standard`); `matches_standard` is consistent with the rationale (a rationale that notes a benchmark Checks violation cannot coexist with `matches_standard == "yes"`).
- **Timeout bump.** `DEFAULT_TIMEOUT` 1200s → 2400s to absorb the extra tool-call budget the Review stage consumes.

## Refine-side changes

- **`match == "no"` retained as null.** Previously hard-dropped. Now treated like `"partial"` / `"unknown"`: kept with `overall_score = null` so non-standard subsets still surface as non-ranked entries on the leaderboard, matching the CONTRIBUTING.md convention.
- **`reported_avg` recovery.** When a non-`yes` row has a numeric `overall_score` from the paper but no component breakdown, `build_candidates` moves the number into `task_scores.reported_avg` so the row survives the empty-score gate with `overall_score = null`.
- **Eligibility filter inverted.** Previously the refine LLM was told to drop rows whose `name_in_paper` was generic ("Ours", "Baseline"). The extract stage already resolves those to canonical names; refine's filter now handles the residual case: a generic label that reaches refine means extract failed to resolve, so the row is unattributable and correctly drops.
- **Prompt compressed.** Rewrote along the Anthropic prompt-engineering guidance: right altitude, positive framing, specific examples, no meta-commentary / exhortation. `Pipeline role` + `Benchmark rule template` + `Context` sections merged into a compact intro; the 5-step job instructions are now clearly delineated `### N.` subheaders; Constraints folded into the Output section.
- **Stats counter renamed.** `rows_drop_protocol_no` → `rows_match_no_kept_null` to reflect the new semantics.

## Pilot evidence (30 robocasa-citing papers)

Per-paper row counts across iterations of this branch, vs. current `main`'s 43-entry baseline:

| Iteration | Total entries | First-party | `task_scores` populated | 2510.20406 behavior |
|---|---:|---:|---:|---|
| main (baseline) | 43 | 35 | — | 5 entries with overall populated (16-task subset presented as standard) |
| pipeline first run (batch=30) | 50 | 15 | low | 2 entries, fabricated "24 tasks" rationale |
| + `reported_avg` recovery | 50 | 15 | low | same |
| + Coverage / Review (batch=30) | 64 | 20 | **33/64 (51%)** | 2 entries, rationale "16 subset" but matches still `"yes"` |
| + consistency rule (3-paper spot) | — | — | — | **6 entries, all matches=`"no"`, 16 real `task_scores` for the paper's own method + PMP-xyz** |

After the consistency rule, the pilot no longer inflates entries with fabricated standard-protocol claims: 2510.20406's PointMapPolicy correctly shows 16 per-task scores with `matches_standard = "no"` and `overall_score = null`, aligning with `robocasa.md`'s Check on task-subset evaluations.

## Test plan

- [x] `make check` clean (ruff + ruff format + ty)
- [x] `refine.py candidates --benchmark robocasa` stats sanity-checked at each logic change
- [x] 2510.20406 single-paper extraction verifies the consistency rule holds under the new prompt (matches=no with 16 real task_scores)
- [x] 2511.03400 (GUIDES) extraction now captures all 24 atomic-task per-task scores + overall with a verbatim quote, instead of being dropped as "non-standard"
- [ ] Full regen will be a separate PR

## Out of scope / follow-ups

- `robocasa_gr1` benchmark registration — the `robocasa.md` Check already routes GR1-embodiment rows to "another benchmark"; that benchmark should exist. Coming in a follow-up PR.
- Full 17-benchmark × ~250-paper regeneration using this pipeline. Deferred until this PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)