### PR TITLE
leaderboard: register robocasa_gr1 as a distinct benchmark

### DIFF
--- a/leaderboard/benchmarks/robocasa.md
+++ b/leaderboard/benchmarks/robocasa.md
@@ -20,7 +20,7 @@ detail_notes: "Standard: 24 atomic tasks (<a href='https://arxiv.org/abs/2406.02
 - `task_scores`: per-task success rates keyed by the atomic task name when the paper tabulates them.
 
 ## Checks
-- Is the embodiment a Mobile Franka robot in a RoboCasa kitchen environment? Alternative embodiments or environments (GR1 Tabletop humanoid, other tabletop variants, non-kitchen scenes) are NOT this benchmark — `overall_score` must be `null`, and the row likely belongs to a different benchmark.
+- Is the embodiment a Mobile Franka robot in a RoboCasa kitchen environment? A Fourier GR1 humanoid tabletop evaluation is the separate `robocasa_gr1` benchmark — route the row there. Other alternative embodiments or environments (non-kitchen scenes, other tabletop variants) are NOT this benchmark either; set `overall_score = null` and route to the correct benchmark if one exists.
 - Does the entry evaluate the full 24 atomic tasks? Subsets (< 24), supersets (composite + atomic), or relabeled sets → `overall_score = null`.
 - Are `demos_per_task`, `trials_per_task`, and demo source recorded in `notes` when the paper states them?
 

--- a/leaderboard/benchmarks/robocasa_gr1.md
+++ b/leaderboard/benchmarks/robocasa_gr1.md
@@ -1,0 +1,56 @@
+---
+benchmark: robocasa_gr1
+display_name: RoboCasa-GR1
+paper_url: https://arxiv.org/abs/2503.14734
+metric:
+  name: success_rate
+  unit: '%'
+  range:
+  - 0
+  - 100
+  higher_is_better: true
+tasks:
+- PnPCupToDrawerClose
+- PnPPotatoToMicrowaveClose
+- PnPMilkToMicrowaveClose
+- PnPBottleToCabinetClose
+- PnPWineToCabinetClose
+- PnPCanToDrawerClose
+- PosttrainPnPNovelFromCuttingboardToBasketSplitA
+- PosttrainPnPNovelFromCuttingboardToCardboardboxSplitA
+- PosttrainPnPNovelFromCuttingboardToPanSplitA
+- PosttrainPnPNovelFromCuttingboardToPotSplitA
+- PosttrainPnPNovelFromCuttingboardToTieredbasketSplitA
+- PosttrainPnPNovelFromPlacematToBasketSplitA
+- PosttrainPnPNovelFromPlacematToBowlSplitA
+- PosttrainPnPNovelFromPlacematToPlateSplitA
+- PosttrainPnPNovelFromPlacematToTieredshelfSplitA
+- PosttrainPnPNovelFromPlateToBowlSplitA
+- PosttrainPnPNovelFromPlateToCardboardboxSplitA
+- PosttrainPnPNovelFromPlateToPanSplitA
+- PosttrainPnPNovelFromPlateToPlateSplitA
+- PosttrainPnPNovelFromTrayToCardboardboxSplitA
+- PosttrainPnPNovelFromTrayToPlateSplitA
+- PosttrainPnPNovelFromTrayToPotSplitA
+- PosttrainPnPNovelFromTrayToTieredbasketSplitA
+- PosttrainPnPNovelFromTrayToTieredshelfSplitA
+detail_notes: "Standard: 24 pick-and-place tasks (6 standard + 18 post-training novel SplitA variants) on a <strong>Fourier GR1 humanoid</strong> tabletop setup, introduced in the <a href='https://arxiv.org/abs/2503.14734'>GR00T N1 paper</a>. Protocol is 100 trials per task, reporting the max over the last 5 checkpoints. Distinct benchmark from the original RoboCasa (Mobile Franka in kitchen) — do not conflate. Training demo budgets vary (30 / 100 / 300 demos per task in the paper's sweeps; 1000 per task in NVIDIA's released teleop dataset)."
+---
+
+**Standard**: 24 tabletop pick-and-place tasks (6 "standard" + 18 "post-training novel" SplitA variants) on a Fourier GR1 humanoid, introduced in GR00T N1 ([2503.14734](https://arxiv.org/abs/2503.14734)); `overall_score` = mean success rate across the 24 tasks, with 100 trials per task and the max of the last 5 checkpoints taken.
+
+## Scoring
+- `overall_score`: arithmetic mean of success rates over all 24 tasks; `null` if the evaluated set is not the full 24.
+- `suite_scores`: not used — the benchmark has no canonical sub-suite grouping.
+- `task_scores`: per-task success rates keyed by the environment name from the [robocasa-gr1-tabletop-tasks repo](https://github.com/robocasa/robocasa-gr1-tabletop-tasks) (e.g. `PnPCupToDrawerClose`, `PosttrainPnPNovelFromPlateToBowlSplitA`). Many papers report only the overall mean — in that case leave `task_scores` empty and the paper's reported aggregate ends up in `task_scores.reported_avg` automatically when the protocol is non-standard.
+
+## Checks
+- Is the embodiment a Fourier GR1 humanoid on a tabletop? Alternative embodiments (e.g. Mobile Franka in RoboCasa kitchen) belong to the original `robocasa` benchmark, not this one — set `matches_standard = "no"` and route accordingly.
+- Does the entry evaluate all 24 tasks (6 standard + 18 post-training novel)? Subsets (e.g. only the 6 standard tasks, or only the post-training novel set) → `overall_score = null`.
+- Is the evaluation 100 trials per task with the max of the last 5 checkpoints? Deviations (lower trial count, single-checkpoint rollout) go in `notes`.
+
+## Methodology axes (record in `notes`, do not null)
+- Training demo budget: 30 / 100 / 300 demos per task are the GR00T N1 paper's sweep points; 1000 per task is the NVIDIA teleop dataset. All budgets within the 24-task protocol are valid; record `demos_per_task` so readers can account for it. Scores across different budgets are not directly comparable.
+- Trial count per task: 100 is the paper's standard. Record deviations.
+- Training data source: human teleop (1000 demos/task NVIDIA set), machine-generated (MimicGen), or paper-specific mixes. Record when disclosed.
+- `weight_type`: `shared` (same checkpoint across benchmarks) vs `finetuned` (trained on this benchmark's data).

--- a/leaderboard/data/benchmarks.json
+++ b/leaderboard/data/benchmarks.json
@@ -2599,6 +2599,46 @@
     ],
     "detail_notes": "Standard: 24 atomic tasks (<a href='https://arxiv.org/abs/2406.02523'>2406.02523</a>). <strong>Training data varies widely</strong> (50–300 demos/task). Check <em>notes</em> for <code>demos_per_task</code> and <code>task_count</code>. Scores from different training budgets are not directly comparable."
   },
+  "robocasa_gr1": {
+    "display_name": "RoboCasa-GR1",
+    "paper_url": "https://arxiv.org/abs/2503.14734",
+    "metric": {
+      "name": "success_rate",
+      "unit": "%",
+      "range": [
+        0,
+        100
+      ],
+      "higher_is_better": true
+    },
+    "tasks": [
+      "PnPCupToDrawerClose",
+      "PnPPotatoToMicrowaveClose",
+      "PnPMilkToMicrowaveClose",
+      "PnPBottleToCabinetClose",
+      "PnPWineToCabinetClose",
+      "PnPCanToDrawerClose",
+      "PosttrainPnPNovelFromCuttingboardToBasketSplitA",
+      "PosttrainPnPNovelFromCuttingboardToCardboardboxSplitA",
+      "PosttrainPnPNovelFromCuttingboardToPanSplitA",
+      "PosttrainPnPNovelFromCuttingboardToPotSplitA",
+      "PosttrainPnPNovelFromCuttingboardToTieredbasketSplitA",
+      "PosttrainPnPNovelFromPlacematToBasketSplitA",
+      "PosttrainPnPNovelFromPlacematToBowlSplitA",
+      "PosttrainPnPNovelFromPlacematToPlateSplitA",
+      "PosttrainPnPNovelFromPlacematToTieredshelfSplitA",
+      "PosttrainPnPNovelFromPlateToBowlSplitA",
+      "PosttrainPnPNovelFromPlateToCardboardboxSplitA",
+      "PosttrainPnPNovelFromPlateToPanSplitA",
+      "PosttrainPnPNovelFromPlateToPlateSplitA",
+      "PosttrainPnPNovelFromTrayToCardboardboxSplitA",
+      "PosttrainPnPNovelFromTrayToPlateSplitA",
+      "PosttrainPnPNovelFromTrayToPotSplitA",
+      "PosttrainPnPNovelFromTrayToTieredbasketSplitA",
+      "PosttrainPnPNovelFromTrayToTieredshelfSplitA"
+    ],
+    "detail_notes": "Standard: 24 pick-and-place tasks (6 standard + 18 post-training novel SplitA variants) on a <strong>Fourier GR1 humanoid</strong> tabletop setup, introduced in the <a href='https://arxiv.org/abs/2503.14734'>GR00T N1 paper</a>. Protocol is 100 trials per task, reporting the max over the last 5 checkpoints. Distinct benchmark from the original RoboCasa (Mobile Franka in kitchen) — do not conflate. Training demo budgets vary (30 / 100 / 300 demos per task in the paper's sweeps; 1000 per task in NVIDIA's released teleop dataset)."
+  },
   "robocerebra": {
     "display_name": "RoboCerebra",
     "paper_url": "https://arxiv.org/abs/2506.06677",


### PR DESCRIPTION
## Summary

Recent NVIDIA GR00T N1 / N1.5 / N1.6 papers evaluate on a setup they call **RoboCasa-GR1** / **GR-1 Tabletop Tasks**: a Fourier GR1 humanoid doing tabletop pick-and-place. It's distinct from the original RoboCasa benchmark (Nasiriany et al. 2024, Mobile Franka in kitchen) in every dimension that matters:

| | `robocasa` | `robocasa_gr1` (new) |
|---|---|---|
| Origin paper | [Nasiriany 2024](https://arxiv.org/abs/2406.02523) | [Bjorck 2025 — GR00T N1](https://arxiv.org/abs/2503.14734) |
| Robot | Mobile Franka (arm + wheels) | Fourier GR1 humanoid (bimanual) |
| Environment | Kitchen scenes | Tabletop |
| Tasks | 24 atomic kitchen tasks | 24 pick-and-place tasks (6 standard + 18 post-training novel SplitA) |
| Protocol | 24-task mean, variable trials | 100 trials/task, max of last 5 checkpoints |
| Official env | — | [robocasa/robocasa-gr1-tabletop-tasks](https://github.com/robocasa/robocasa-gr1-tabletop-tasks) |

`robocasa.md`'s Check already flagged GR1 embodiment rows as NOT the robocasa benchmark and told the extractor to route them elsewhere — but that "elsewhere" didn't exist. This PR registers it.

## Changes

- **`benchmarks/robocasa_gr1.md`**: canonical protocol frontmatter + the standard Standard / Scoring / Checks / Methodology-axes sections. Tasks list is the verbatim 24 environment names from the official GR00T-team repo (6 standard PnP + 18 post-training novel `SplitA` variants).
- **`robocasa.md`**: tightened the first Check bullet — GR1 rows route explicitly to `robocasa_gr1`, not a vague "different benchmark".
- **`benchmarks.json`**: rebuilt via `build_benchmarks_json.py`. Registry now has 18 benchmarks.

## Not in this PR

No data migration. The existing `leaderboard.json` has ~11 entries currently filed under `robocasa` that are actually RoboCasa-GR1 measurements (2601.14133 TwinBrainVLA, 2601.15197 LangForce, 2602.12215 LDA-1B, 2604.11757 StarVLA, etc.). That cleanup lands in a follow-up PR once this registration is merged and the regeneration / extraction run can route new rows correctly.

## Verification

```
$ uv run leaderboard/scripts/build_benchmarks_json.py
Wrote leaderboard/data/benchmarks.json (18 benchmarks).

$ uv run leaderboard/scripts/validate.py
OK: 670 results across 556 models and 18 benchmarks

$ make check
All checks passed!
```

## Test plan

- [x] `build_benchmarks_json.py` succeeds with 18 benchmarks
- [x] `validate.py` passes (existing 670 entries still validate against the expanded registry)
- [x] `make check` clean (ruff + ruff format + ty)
- [x] robocasa.md Check cross-references `robocasa_gr1` by key
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)