### PR TITLE
leaderboard: fix benchmarks.json drift + build script idempotency

### DIFF
--- a/leaderboard/data/benchmarks.json
+++ b/leaderboard/data/benchmarks.json
@@ -2637,6 +2637,7 @@
       "PosttrainPnPNovelFromTrayToTieredbasketSplitA",
       "PosttrainPnPNovelFromTrayToTieredshelfSplitA"
     ],
+    "papers_reviewed": [],
     "detail_notes": "Standard: 24 pick-and-place tasks (6 standard + 18 post-training novel SplitA variants) on a <strong>Fourier GR1 humanoid</strong> tabletop setup, introduced in the <a href='https://arxiv.org/abs/2503.14734'>GR00T N1 paper</a>. Protocol is 100 trials per task, reporting the max over the last 5 checkpoints. Distinct benchmark from the original RoboCasa (Mobile Franka in kitchen) — do not conflate. Training demo budgets vary (30 / 100 / 300 demos per task in the paper's sweeps; 1000 per task in NVIDIA's released teleop dataset)."
   },
   "robocerebra": {

--- a/leaderboard/scripts/build_benchmarks_json.py
+++ b/leaderboard/scripts/build_benchmarks_json.py
@@ -100,8 +100,13 @@ def build(preserve_papers_reviewed: bool = True) -> dict:
         bm_key = fm.pop("benchmark", None) or f.stem
         if bm_key in out:
             raise ValueError(f"{f}: duplicate benchmark key {bm_key!r}")
-        if preserve_papers_reviewed and bm_key in papers_by_key:
-            fm.setdefault("papers_reviewed", papers_by_key[bm_key])
+        if preserve_papers_reviewed:
+            # Always set the field so the output is idempotent even for
+            # benchmarks newly introduced by this build (otherwise a first
+            # build would omit the key and a second build — triggered
+            # e.g. by CI's --check pass — would add `"papers_reviewed": []`
+            # and register a spurious drift).
+            fm.setdefault("papers_reviewed", papers_by_key.get(bm_key, []))
         out[bm_key] = _ordered(fm)
 
     ordered = {k: out[k] for k in sorted(out)}


### PR DESCRIPTION
## Summary

CI on #41 failed with `benchmarks.json is out of sync with md sources`. Root cause was a non-idempotent build script combined with a first-run artifact in the committed data.

### The idempotency bug

`build_benchmarks_json.py` preserves `papers_reviewed` (owned by `update_coverage.py`) across builds via:

```py
if preserve_papers_reviewed and bm_key in papers_by_key:
    fm.setdefault("papers_reviewed", papers_by_key[bm_key])
```

For benchmarks that didn't appear in the existing `benchmarks.json`, `bm_key in papers_by_key` is `False` and the field was skipped entirely. So:

- **First build** (after adding a new md file): output has no `papers_reviewed` for the new benchmark.
- **Second build** (or CI `--check`): same md sources, but now the already-written `benchmarks.json` contains the new benchmark, so `papers_by_key` picks it up with `[]`, and `setdefault` writes `"papers_reviewed": []` to the output. Two different outputs from the same md sources → `--check` flags drift.

### The committed-data symptom

#41's `benchmarks.json` was the first-build output, so `robocasa_gr1` had no `papers_reviewed` field. CI rebuilt locally, got the second-build output with `"papers_reviewed": []`, and raised the drift error.

## Fix

1. `setdefault("papers_reviewed", papers_by_key.get(bm_key, []))` — always populate the field, new benchmarks get `[]`. Added a comment pointing at this CI-failure scenario so the next person editing the script doesn't re-break it.
2. Rerun `build_benchmarks_json.py`, committing the `"papers_reviewed": []` that was missing for `robocasa_gr1`.

## Verification

```
$ uv run leaderboard/scripts/build_benchmarks_json.py --check
OK: benchmarks.json in sync with 18 benchmarks.

$ uv run leaderboard/scripts/build_benchmarks_json.py --check   # idempotent second pass
OK: benchmarks.json in sync with 18 benchmarks.

$ make check
All checks passed!
```

## Test plan

- [x] `build_benchmarks_json.py --check` passes on first run
- [x] Still passes on a second back-to-back run (confirms idempotency)
- [x] `validate.py` still passes on the 670 existing entries
- [x] `make check` clean
- [ ] CI Leaderboard Validate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)