### PR TITLE
leaderboard: schema-SoT pipeline + pilot-verified refactor

### DIFF
--- a/leaderboard/CONTRIBUTING.md
+++ b/leaderboard/CONTRIBUTING.md
@@ -9,96 +9,56 @@ Data is split into focused files under `leaderboard/data/`:
 | File | Contents |
 |------|----------|
 | `leaderboard.json` | Curated entries (`last_updated` + `results[]`) |
-| `benchmarks.json` | Benchmark registry (metrics, suites, tasks, display config) |
-| `leaderboard.schema.json` | JSON Schema for leaderboard.json |
-| `benchmarks.schema.json` | JSON Schema for benchmarks.json |
+| `benchmarks.json` | Benchmark registry (build artifact — see below) |
 | `citations.json` | Per-paper citation counts from Semantic Scholar |
 | `coverage.json` | Per-benchmark coverage stats |
+| `extractions.json` | Packed per-paper extractions (optional, for reproducibility) |
 
-Per-benchmark protocol notes (standard split, metric formula, common
-deviations) live alongside the registry at `leaderboard/benchmarks/{key}.md`.
+### Schemas (single source of truth)
 
-### Benchmarks
+Every field in the data files is defined in a JSON Schema with inline descriptions. Consult the schema before writing code, prompts, or docs — do not re-describe field semantics elsewhere.
 
-17 benchmarks: LIBERO, LIBERO-Plus, LIBERO-Pro, LIBERO-Mem, CALVIN, SimplerEnv, RLBench, ManiSkill2, RoboCasa, RoboTwin v1, RoboTwin v2, VLABench, MIKASA-Robo, Kinetix, RoboCerebra, RoboArena, RoboChallenge.
+| Schema | Covers |
+|--------|--------|
+| `leaderboard.schema.json` | `leaderboard.json` — final curated entries |
+| `benchmarks.schema.json` | `benchmarks.json` — registry shape |
+| `extraction.schema.json` | One paper's extract.py output. `extractions.json` is an array of these. |
+| `candidates.schema.json` | `.cache/refine_candidates.json` — refine-stage input |
 
-Each benchmark declares its metric, range, and optionally `suites`/`tasks` in `benchmarks.json`. See `leaderboard/benchmarks/{key}.md` for the protocol and risky-pattern notes for each benchmark.
+Per-benchmark protocol (Standard / Scoring / Checks / Methodology) lives in `leaderboard/benchmarks/{key}.md`. Frontmatter compiles into `benchmarks.json`; the markdown body is the LLM-facing protocol prose consumed by `extract.py` and `refine.py`.
 
-**`benchmarks.json` is a build artifact — never edit it directly.** Each benchmark's configuration (display_name, metric, suites, tasks, aggregation rule, detail_notes, etc.) lives in the YAML frontmatter of `leaderboard/benchmarks/{key}.md`. The markdown body of the same file holds the LLM-consumed protocol prose (Standard / Scoring / Checks / Methodology).
-
-After editing any frontmatter, rebuild `benchmarks.json`:
+**`benchmarks.json` is a build artifact — never edit it directly.** After editing any frontmatter, rebuild:
 
 ```
 python leaderboard/scripts/build_benchmarks_json.py
 ```
 
-CI runs `build_benchmarks_json.py --check` on every PR — if the committed `benchmarks.json` diverges from the md sources, the PR fails. The only field in `benchmarks.json` that is NOT sourced from md is `papers_reviewed`, which is owned by `update_coverage.py` and preserved across builds.
-
-### Result Fields
-
-Each result is **self-contained** — model metadata is inlined:
-
-```json
-{
-  "model": "openvla",  "display_name": "OpenVLA",  "params": "7B",
-  "model_paper": "https://arxiv.org/abs/2406.09246",
-  "benchmark": "libero",  "weight_type": "finetuned",
-  "overall_score": 85.7,
-  "suite_scores": { "libero_spatial": 84.0, "libero_object": 88.0 },
-  "reported_paper": "https://arxiv.org/abs/2406.09246",
-  "reported_table": "Table 1",
-  "curated_by": "opus 4.6",  "date_added": "2026-03-02"
-}
-```
-
-**Required**: `model`, `display_name`, `benchmark`, `weight_type`, `curated_by`, `date_added`
-
-**Key fields**:
-
-| Field | Meaning | Null when |
-|-------|---------|-----------|
-| `model_paper` | Paper that **introduces the model** (architecture, training) | No arxiv paper (proprietary models) |
-| `reported_paper` | Paper where this **specific score was reported** | Score from official leaderboard API |
-| `overall_score` | Aggregate score (controls ranking) | Non-standard protocol (→ `null`), or only per-suite scores available |
-| `params` | Parameter count (e.g. `"7B"`) | Unknown |
-
-- `model_paper` / `reported_paper` must be **full URLs** (`https://arxiv.org/abs/...`), not bare IDs — bare IDs render as broken links.
-- `weight_type`: `"shared"` (same checkpoint across benchmarks) or `"finetuned"` (trained on this benchmark).
-- `curated_by`: AI-extracted → model name (`"opus 4.6"`); human-verified → GitHub handle (`"@user"`).
-- `notes`: Free-text for caveats (non-standard eval, different task subset, etc.).
-- `overall_score` must only be set when the entry uses the benchmark's **standard evaluation protocol**. Entries using non-standard task subsets, different task counts, or incompatible evaluation setups must set `overall_score` to `null` and store the original aggregate in `task_scores.reported_avg` — this prevents misleading rankings while preserving the data. See [Benchmark-Specific Caveats](#benchmark-specific-caveats) for each benchmark's standard protocol.
-- `validate.py` enforces: every entry must have at least one score (`overall_score`, `suite_scores`, or `task_scores`). For non-standard entries (`overall_score: null`), task/suite key names are not validated against the declared list since they use different protocols.
-
-## Score Provenance
-
-`model` keys use BibTeX citation key form. First-party entries use the method's own key (e.g. `kim24openvla`). Third-party measurements combine the method key with the measuring paper's key (e.g. `kim24openvla__black24xvla`) so every reproduction stays as its own row.
-
-| Scenario | `model_paper` | `reported_paper` | `model` key | `display_name` |
-|----------|--------------|----------------|-------------|----------------|
-| Authors evaluate their own model | Model's paper | Same paper | `{method_bib}` (e.g. `kim24openvla`) | `OpenVLA` |
-| Paper B re-trains/fine-tunes Model A from scratch | Model A's paper | Paper B | `{method_bib}__{B_bib}` (e.g. `kim24openvla__black24xvla`) | `OpenVLA (from X-VLA)` |
-| Paper B downloads Model A's checkpoint and evaluates as-is | Model A's paper | Paper B | `{method_bib}__{B_bib}` (e.g. `kim24openvla__black24xvla`) | `OpenVLA (from X-VLA)` |
-| Paper B cites Paper A's score without re-running | Model A's paper | Paper A (original) | `{method_bib}` (collapses to first-party) | `OpenVLA` |
-
-**Rules**:
-- Distinct `reported_paper`s always produce **distinct rows**. Never collapse a third-party measurement into a first-party canonical row.
-- Citation-only rows (Paper B quoting Paper A without re-running) intentionally collapse to first-party because the measurement itself is the original — `reported_paper` should point at the original paper, not the citing one.
-- The leaderboard frontend hides third-party rows by default behind an "Official results only" toggle, so the leaderboard stays clean while preserving variance for readers who want it.
-- **Non-standard evaluation protocols** (different task subsets, custom metrics, modified benchmarks) must NOT be filed under the standard benchmark. Either create a separate benchmark or omit the entry.
+CI runs `build_benchmarks_json.py --check` on every PR — if the committed `benchmarks.json` diverges from the md sources, the PR fails. The only field not sourced from md is `papers_reviewed`, which is owned by `update_coverage.py` and preserved across builds.
 
 ## How to Add Results
 
-1. **Add entries** to the `results` array (sorted by `benchmark, model`). Keep `display_name` and `params` consistent across entries for the same model.
+1. **Add entries** to the `results` array (sorted by `benchmark, model`). Field shape and provenance rules are in `leaderboard.schema.json`; attribution cases (first-party vs third-party) are in `candidates.schema.json`'s `row_type` field description.
 
-2. **Update `last_updated`**: Set `last_updated` in `leaderboard.json` to today's date (`YYYY-MM-DD`) when adding or modifying result data. This is displayed on the frontend and must reflect the latest data change.
+2. **Update `last_updated`**: Set `last_updated` in `leaderboard.json` to today's date (`YYYY-MM-DD`) when adding or modifying result data.
 
 3. **Validate**: `python leaderboard/scripts/validate.py`
    - Auto-fix sort order and formatting: `python leaderboard/scripts/validate.py --fix`
 
 4. **Update coverage** (optional): `python leaderboard/scripts/update_coverage.py [--fetch]`
-   - `papers_reviewed` lists all arxiv IDs reviewed per benchmark (with or without results).
 
 5. **Test locally**: `cd leaderboard/site && python -m http.server`
+
+## Automated Extraction Pipeline
+
+Paper-sourced entries are produced by:
+
+```
+extract.py scan             # discover citing papers per benchmark
+extract.py run --from-scan  # per-paper LLM extraction → .cache/extractions/
+refine.py main              # protocol gate + per-benchmark LLM refinement → leaderboard.json
+```
+
+Field semantics live in the schema files above. `extract.py` and `refine.py` both load their respective schemas at runtime — the prompts reference the schema, not duplicate its field rules.
 
 ## Official Leaderboard Policy
 
@@ -110,147 +70,6 @@ Benchmarks with `official_leaderboard` in their registry entry require **API-syn
 - **`pages.yml`**: Deploys to GitHub Pages on push to main; regenerates `coverage.json` and `citations.json`
 - **`update-data.yml`**: Syncs external leaderboard sources weekly (Monday 06:00 UTC) and opens a PR with updates. Can also be triggered manually via `workflow_dispatch`.
 
-## Benchmark-Specific Caveats
+## Benchmark Protocols
 
-### SimplerEnv
-
-- **Standard protocol**: 3 independent evaluation dimensions — **never average across them**. `overall_score` = always `null`; use `suite_scores` only. Store the paper's reported aggregate (if any) in `task_scores.reported_avg` per the global rule (see Result Fields).
-
-| Dimension | Robot | Protocol | Benchmark key |
-|-----------|-------|----------|---------------|
-| Google Robot VM | Google Robot | Visual Matching | `suite_scores.google_robot_vm` |
-| Google Robot VA | Google Robot | Variant Aggregation | `suite_scores.google_robot_va` |
-| WidowX VM | WidowX (Bridge) | Visual Matching | `suite_scores.widowx_vm` |
-- **Google Robot VM standardization**: `suite_scores.google_robot_vm` must always store the **3-task average** (Pick Coke Can, Move Near, Open/Close Drawer) for consistent ranking. Papers reporting 4 tasks (adding Place Apple in Drawer) should store the 4th task in `task_scores.place_apple_in_drawer_vm` and note the original 4-task average in `notes`. This ensures apples-to-apples comparison since 3-task is the dominant protocol (used by ~80% of papers).
-- **Google Robot VA standardization**: `suite_scores.google_robot_va` follows the same rule — always store the **3-task average** (Pick Coke Can, Move Near, Open/Close Drawer). Papers reporting 4 tasks store the 4th in `task_scores.place_apple_in_drawer_va`. This ensures VM and VA scores are directly comparable.
-- **task_scores protocol suffix**: All SimplerEnv `task_scores` keys **must** end with `_vm` or `_va` to indicate the evaluation protocol (e.g., `pick_coke_can_vm`, `move_near_va`). WidowX tasks always use `_vm`. `validate.py` enforces this. This prevents ambiguity since VM and VA evaluate the same tasks under different protocols with different scores.
-- Don't confuse real-robot scores (e.g. OpenVLA's 12-task real eval) with SimplerEnv simulation.
-
-### CALVIN
-
-- **Standard protocol**: ABC→D split (train on A/B/C, eval on D), 1000 eval chains. ABCD→D inflates scores — do not add.
-- Metric: avg completed subtasks in chain of 5 (0–5), not success rate.
-- Record deviations from 1000 chains in `notes`.
-
-### LIBERO
-
-- **Standard protocol**: 4-suite average (`spatial`, `object`, `goal`, `10`). Always include `suite_scores`. A 5th suite (`90`) exists but many papers skip it.
-- `overall_score` = arithmetic mean of the **4 standard suites only** (`spatial`, `object`, `goal`, `10`). Do NOT include `90` in the overall mean even when reported — store it in `suite_scores.libero_90` only. Entries reporting only a subset of the 4 standard suites must set `overall_score = null`.
-- LIBERO-Plus, LIBERO-Pro and LIBERO-Mem are **separate benchmarks**.
-
-### LIBERO-Plus
-
-- Robustness benchmark ([2510.13626](https://arxiv.org/abs/2510.13626)) with **7 perturbation dimensions**: Camera, Robot, Language, Light, Background, Noise, Layout.
-- Models are trained on standard LIBERO and evaluated **zero-shot** under perturbations.
-- `overall_score` = arithmetic mean of **all 7** perturbation dimensions. Always include `suite_scores`. Entries with fewer than 7 dimensions must set `overall_score = null`.
-- `weight_type`: `"shared"` for zero-shot models (LIBERO-trained); `"finetuned"` for models trained on LIBERO-Plus data.
-- Some papers (e.g. JEPA-VLA) use reduced training data (1/10 LIBERO) — record in `notes`.
-
-### LIBERO-Pro
-
-- Robustness benchmark ([2510.03827](https://arxiv.org/abs/2510.03827)) evaluating generalization under perturbations across LIBERO suites.
-- **Standard protocol**: 4 suites × 5 core perturbations = **20 cells**.
-  - Suites: `goal`, `spatial`, `long`, `object`
-  - Core perturbations: `original` (ori), `object_swap` (obj), `position` (pos), `semantic` (sem), `task`
-  - Optional 6th perturbation: `environment` (env) — only available for `object` suite
-- **suite_scores key format**: `{suite}_{perturbation}` (e.g., `goal_ori`, `spatial_obj`, `long_pos`). Use canonical short names: `ori`, `obj`, `pos`, `sem`, `task`, `env`.
-- `overall_score` = arithmetic mean of the **20 core cells only** (excluding optional `env`). Set `overall_score = null` if any of the 20 core cells are absent.
-- Non-standard perturbation types (e.g., `lang_aug`, `vision_aug`) should NOT be filed under `libero_pro`. Use a separate benchmark or omit.
-- 50 evaluation episodes per task, consistent with standard LIBERO.
-
-### LIBERO-Mem
-
-- Memory benchmark ([2511.11478](https://arxiv.org/abs/2511.11478)) with **10 tasks** (T1–T10) across 4 types: OM (T1–T2), OS (T3–T5), OR (T6–T8), OO (T9–T10).
-- **Metric**: subgoal completion rate (%), NOT task success rate. 20 rollouts per task.
-- `overall_score` = unweighted arithmetic mean of T1–T10. Always include `task_scores`.
-- Models using oracle subgoal information must note this in `notes`.
-
-### ManiSkill2
-
-- **Standard protocol**: 5-task set (PickCube, StackCube, PickSingleYCB, PickSingleEGAD, PickClutterYCB). `overall_score` = `null` for other task subsets.
-- Always record the averaging method (weighted vs arithmetic) in `notes`. If unknown, note `'averaging method unknown'`.
-
-### RLBench
-
-- **Standard protocol**: 18-task PerAct subset ([2209.05451](https://arxiv.org/abs/2209.05451)), 249 total language-goal variations across the 18 tasks, 25 evaluation episodes per task (450 total), 100 training demos per task.
-- `overall_score` = mean success rate across 18 tasks. Set `overall_score = null` for non-18-task evaluations. Always record task count in `notes`.
-- **Variation count matters**: Multi-variation (e.g. 25 per task) vs single variation significantly affects scores. Record variation count in `notes` when known.
-- Entries using single-task learning (training a separate policy per task) are not comparable to multi-task entries. Note the training regime.
-
-### RoboCasa
-
-- **Standard protocol**: 24 atomic tasks from the RoboCasa benchmark ([2406.02523](https://arxiv.org/abs/2406.02523)). `overall_score` = mean success rate across evaluated tasks.
-- **Training data varies widely** (50–300 demos/task across papers). Always record `demos_per_task` and `task_count` in `notes`. Scores from different training budgets are not directly comparable.
-- Entries evaluating non-standard task counts (e.g., 8 tasks, composite tasks) should note the deviation. Prefer `overall_score = null` for significantly non-standard subsets.
-- Record episode count when known.
-
-### RoboTwin
-
-- **v1 and v2 are separate benchmarks**. v1 = `robotwin_v1` ([2409.02920](https://arxiv.org/abs/2409.02920), ECCV 2024), v2 = `robotwin_v2` ([2506.18088](https://arxiv.org/abs/2506.18088), 2025).
-- **v2 standard protocol**: `overall_score` = always `null`; use `suite_scores: {"easy": X, "hard": Y}`. Report both Easy (clean scenes) and Hard (5-axis domain randomization) when available.
-- **v1**: No standard task set — entries evaluate 4–17 tasks. Set `overall_score = null` unless the entry matches the original paper's exact task set. Always record task count in `notes`. Entries with different task counts are not comparable.
-- **v2**: Task counts vary (3–50). Record task count in `notes`.
-- Do not file CVPR 2025 Challenge results under standard v2 (different protocol).
-- **Two v2 training protocols exist** — scores across them are **not comparable**:
-
-  | | Protocol A (official) | Protocol B (Motus-style) |
-  |---|---|---|
-  | Source | [2506.18088](https://arxiv.org/abs/2506.18088) | [2512.13030](https://arxiv.org/abs/2512.13030) |
-  | Training | Single-task, 50 clean demos/task | Multi-task, 50 clean + 500 DR demos/task |
-  | Training data | 2,500 total | 27,500 total (11×) |
-  | Hard/Rand meaning | OOD generalization (never seen DR) | In-distribution (trained on DR) |
-  | Typical Easy/Hard gap | 3–10× (e.g. 55% / 5%) | Near-zero (e.g. 93% / 92%) |
-
-  Always record which protocol in `notes` (prefix with `Protocol A` or `Protocol B`).
-
-### MIKASA-Robo
-
-- **Standard protocol**: 5-task VLA evaluation ([2502.10550](https://arxiv.org/abs/2502.10550)): ShellGameTouch, InterceptMedium, RememberColor3, RememberColor5, RememberColor9. Endorsed as the standard by MemoryVLA (ICLR 2026). 100 evaluation episodes per task.
-- `overall_score` = arithmetic mean of 5 task success rates. Always include `task_scores`.
-- Entries using non-standard task sets (e.g., ELMUR 4-task: RC3/5/9 + TakeItBack) must set `overall_score = null`. Store the paper's reported aggregate in `suite_scores.reported_avg`.
-- Some scores are third-party reproductions (e.g. MemoryVLA paper). Check `notes`.
-
-### RoboCerebra
-
-- Embodied reasoning benchmark ([2506.06677](https://arxiv.org/abs/2506.06677)) with **6 evaluation dimensions**: ideal, memory_execution, memory_exploration, mix, observation_mismatching, random_disturbance.
-- `overall_score` = arithmetic mean of all 6 dimensions. Set `overall_score = null` if fewer than 6 dimensions are reported. Always include `suite_scores` when available.
-- **Architecture types**: Entries include end-to-end VLAs, hierarchical systems (VLM planner + controller), and oracle (GT-Plan) upper bounds. These are not directly comparable. Note the architecture type in `notes`.
-- Oracle entries (GT-Plan + VLA) represent non-deployable upper bounds. They should be clearly marked.
-- Typical scores: 5–20%. Small absolute differences may be meaningful. All current entries are from the original paper (600 rollouts, same protocol).
-
-### Kinetix
-
-- **Not the Kinetix simulator** — it's the 12-task eval protocol from the RTC paper ([2506.07339](https://arxiv.org/abs/2506.07339)). State-based, no vision/language.
-- Scores depend on `(inference_delay d, execution_horizon e)` settings. Always record both in `notes`.
-- Entries at different `d` values are **not directly comparable** (e.g., d=0 scores ~11pp higher than d=4 for the same method). Prefer grouping by `d` when comparing.
-
-### VLABench
-
-- Official 6-track evaluation system ([OpenMOSS/VLABench](https://github.com/OpenMOSS/VLABench)):
-  - Track 1: `in_distribution` — task learning ability
-  - Track 2: `cross_category` — object generalization
-  - Track 3: `common_sense` — common sense understanding
-  - Track 4: `semantic_instruction` — complex instruction understanding
-  - Track 5: `cross_task` — skill transfer (kept open, not included in standard)
-  - Track 6: `unseen_texture` — visual robustness (optional)
-- **Two metrics**: IS (Intention Score, approached correct object) and PS (Progress Score, task completion). IS ≥ PS always.
-- **Leaderboard standard**: `overall_score` = **Track 1-4 PS average**. Track 5-6 and IS values go in `suite_scores` as supplementary data.
-- **Canonical suite_scores keys**: Use the track-based naming: `in_dist_IS`, `in_dist_PS`, `cross_category_IS`, `cross_category_PS`, `commonsense_IS`, `commonsense_PS`, `semantic_instruction_IS`, `semantic_instruction_PS`, `unseen_texture_IS`, `unseen_texture_PS`. Pre-track-system entries (2412.18194) use legacy keys (`seen_base`, `unseen_commonsense`, etc.) with `overall_score: null`.
-- Original VLABench paper (2412.18194) uses a pre-track-system IS-based protocol (seen/unseen × base/commonsense). These entries have `overall_score: null`.
-- Non-standard task subsets (e.g. cherry-picked tasks outside the official tracks) must NOT be filed under `vlabench`.
-- Different papers evaluating the same model produce different scores due to fine-tuning setup and eval seeds. Use separate `model` keys per source paper (e.g. `pi0_acot_vlabench`, `pi0_xvla_vlabench`).
-
-### RoboArena
-
-- Elo-based pairwise comparison benchmark. Scores are Elo ratings (not success rates). Higher is better.
-- All entries are API-synced (`curated_by` ends with `-api`). Manual entries are not accepted.
-- Entries with fewer than 15 pairwise evaluations have high variance (std > 120 Elo) and should be interpreted cautiously.
-
-### RoboChallenge
-
-- Multi-task challenge benchmark with two scores: `overall_score` (success rate, binary task completion) and `suite_scores.progress_score` (partial credit for sub-goal progress).
-- All entries are API-synced. Manual entries are not accepted.
-
-## Schema
-
-JSON Schema: `leaderboard/data/schema.json`. Key nullable types: `overall_score`, `reported_paper`, `reported_table`, `params`, `model_paper` — all `["string"|"number", "null"]`.
+Per-benchmark Standard, Scoring, Checks, and Methodology axes live in `leaderboard/benchmarks/{key}.md`. That file is the single source — this document does not mirror it.

--- a/leaderboard/data/candidates.schema.json
+++ b/leaderboard/data/candidates.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Refine-stage candidates",
+  "description": "Array of candidate rows produced by build_candidates(), consumed by the refine LLM. One element per (paper × benchmark × model row) surviving the deterministic gate.",
+  "type": "array",
+  "items": {"$ref": "#/$defs/Candidate"},
+  "$defs": {
+    "Candidate": {
+      "type": "object",
+      "required": [
+        "benchmark",
+        "name_in_paper",
+        "weight_type",
+        "overall_score",
+        "suite_scores",
+        "task_scores",
+        "reported_paper",
+        "protocol_match",
+        "protocol_rationale",
+        "is_score_original",
+        "model_paper",
+        "cited_paper",
+        "row_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "benchmark": {"type": "string"},
+        "name_in_paper": {
+          "type": "string",
+          "description": "Copy verbatim to the final entry's name_in_paper."
+        },
+        "params": {"type": ["string", "null"]},
+        "weight_type": {"type": "string", "enum": ["shared", "finetuned"]},
+        "overall_score": {
+          "type": ["number", "null"],
+          "description": "Computed by build_candidates from the benchmark's aggregation rule. Pass through unchanged."
+        },
+        "suite_scores": {"type": "object", "additionalProperties": {"type": "number"}},
+        "task_scores": {
+          "type": "object",
+          "description": "May contain 'reported_avg' holding the paper's own aggregate when it could not be used as overall_score.",
+          "additionalProperties": {"type": "number"}
+        },
+        "reported_paper": {
+          "type": "string",
+          "format": "uri",
+          "description": "Set by build_candidates per row_type. Override only when a collapse_candidate fails cross-check (demote to third_party: set back to the citing paper's URL)."
+        },
+        "reported_table": {"type": ["string", "null"]},
+        "protocol_match": {"type": "string", "enum": ["yes", "no", "partial", "unknown"]},
+        "protocol_rationale": {
+          "type": "string",
+          "description": "Primary source for composing `notes`. Trim for length; do not embellish."
+        },
+        "is_score_original": {"type": "string", "enum": ["original", "cited_baseline", "reproduction", "unknown"]},
+        "model_paper": {
+          "type": ["string", "null"],
+          "format": "uri",
+          "description": "URL from extract's resolution. Copy to the final entry. Override only when the same name_in_paper carries conflicting model_paper across candidates: pick the majority value and record the conflict in notes. Leave null as null."
+        },
+        "cited_paper": {
+          "type": ["string", "null"],
+          "format": "uri",
+          "description": "Source URL for this specific score. Use to set the model key suffix and to mention non-arxiv sources in notes. Not stored on the final entry."
+        },
+        "row_type": {
+          "type": "string",
+          "enum": ["first_party", "third_party"],
+          "description": "Attribution case set by build_candidates.\n\nfirst_party: citing paper IS model_paper and is_score_original='original'. Final entry: model = {citing_bib}, display_name = the method's canonical name, reported_paper = citing URL.\n\nthird_party: every other case. Pick reported_paper and the model key suffix from cited_paper's shape:\n  - cited_paper is an arxiv URL: reported_paper = cited_paper URL; model = {method_bib}__{cited_bib}; display_name = 'Method (from CitedPaper)'. The measuring paper gets credit.\n  - cited_paper is non-arxiv or null: reported_paper = citing URL; model = {method_bib}__{citing_bib}; display_name = 'Method (from CitingPaper)'. When cited_paper is a non-arxiv URL (github, tech report, blog), mention that URL in notes. Do not attribute a number to model_paper when the model's own paper does not contain it."
+        }
+      }
+    }
+  }
+}

--- a/leaderboard/data/candidates.schema.json
+++ b/leaderboard/data/candidates.schema.json
@@ -66,7 +66,7 @@
         "row_type": {
           "type": "string",
           "enum": ["first_party", "third_party"],
-          "description": "Attribution case set by build_candidates.\n\nfirst_party: citing paper IS model_paper and is_score_original='original'. Final entry: model = {citing_bib}, display_name = the method's canonical name, reported_paper = citing URL.\n\nthird_party: every other case. Pick reported_paper and the model key suffix from cited_paper's shape:\n  - cited_paper is an arxiv URL: reported_paper = cited_paper URL; model = {method_bib}__{cited_bib}; display_name = 'Method (from CitedPaper)'. The measuring paper gets credit.\n  - cited_paper is non-arxiv or null: reported_paper = citing URL; model = {method_bib}__{citing_bib}; display_name = 'Method (from CitingPaper)'. When cited_paper is a non-arxiv URL (github, tech report, blog), mention that URL in notes. Do not attribute a number to model_paper when the model's own paper does not contain it."
+          "description": "Attribution case set by build_candidates.\n\nfirst_party: citing paper IS model_paper AND is_score_original='original'. Emit model={method_bib}, display_name=method name, reported_paper=citing URL.\n\nthird_party: everything else. If cited_paper is an arxiv URL: reported_paper=cited_paper, model={method_bib}__{cited_bib}, display_name='Method (from CitedPaper)'. Otherwise: reported_paper=citing URL, model={method_bib}__{citing_bib}, display_name='Method (from CitingPaper)'; non-arxiv cited_paper goes in notes.\n\nModel bibkey: firstauthor+year+shortname, lowercase, no separators (e.g. 'kim2024openvla'). Match the format used elsewhere in leaderboard.json for the same method."
         }
       }
     }

--- a/leaderboard/data/extraction.schema.json
+++ b/leaderboard/data/extraction.schema.json
@@ -99,7 +99,7 @@
         },
         "task_scores": {
           "type": "object",
-          "description": "Per-task scores (e.g. RoboCasa atomic tasks, MIKASA T1–T10). Same shape as suite_scores.",
+          "description": "Per-task scores keyed by task name. Keys match the benchmark's declared tasks for standard protocols; non-standard protocols may include additional keys — keep them under the paper's verbatim names. Same shape as suite_scores.",
           "additionalProperties": {
             "type": "object",
             "required": ["value", "quote"],

--- a/leaderboard/data/extraction.schema.json
+++ b/leaderboard/data/extraction.schema.json
@@ -80,7 +80,7 @@
     "Scores": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Shape of required keys is prescribed by leaderboard/benchmarks/{bm}.md's Scoring section.",
+      "description": "Required keys follow leaderboard/benchmarks/{bm}.md's Scoring section. All numeric values are in the benchmark's declared metric.range (benchmarks.json). Convert from paper's original scale when needed (typically 0-1 → 0-100 for % benchmarks).",
       "properties": {
         "overall_score": {"type": ["number", "null"], "description": "Paper's reported aggregate. null when absent or not locatable."},
         "overall_score_quote": {"type": ["string", "null"]},

--- a/leaderboard/data/extraction.schema.json
+++ b/leaderboard/data/extraction.schema.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Per-paper extraction",
+  "description": "One paper's extraction. Stored as .cache/extractions/{arxiv_id}.json; data/extractions.json is a plain array of these. Each row in `benchmarks[].models[]` becomes one candidate for refine.",
+  "type": "object",
+  "required": ["arxiv_id", "extracted_at", "paper_hash", "extraction_scope", "benchmarks"],
+  "additionalProperties": false,
+  "properties": {
+    "arxiv_id": {"type": "string", "description": "arxiv id, matches the paper at .cache/papers/{arxiv_id}/paper.md."},
+    "extracted_at": {"type": "string", "format": "date-time"},
+    "model_used": {"type": "string"},
+    "paper_hash": {"type": "string", "description": "sha256: of paper.md when extracted. Invalidates this cache if paper.md changes."},
+    "extraction_scope": {
+      "type": "array",
+      "items": {"type": "string"},
+      "uniqueItems": true,
+      "description": "Benchmark keys considered at extract time. The paper counts as reviewed for every key here, including ones that produce no row."
+    },
+    "batch_size": {"type": "integer", "minimum": 1},
+    "batch_tool_calls_total": {"type": "integer", "minimum": 0},
+    "benchmarks": {
+      "type": "array",
+      "description": "One entry per benchmark this paper scores on. Empty array is valid.",
+      "items": {"$ref": "#/$defs/BenchmarkEntry"}
+    },
+    "benchmarks_absent": {
+      "type": "object",
+      "description": "Map {benchmark_key → one-line reason} for benchmarks the paper mentions but does not score (cited-only, unreadable, out-of-scope). Forces exhaustive per-benchmark review at extract time; no downstream consumer.",
+      "additionalProperties": {"type": "string"}
+    }
+  },
+  "$defs": {
+    "BenchmarkEntry": {
+      "type": "object",
+      "required": ["benchmark", "models"],
+      "additionalProperties": false,
+      "properties": {
+        "benchmark": {"type": "string", "description": "Benchmark key from leaderboard/benchmarks/{key}.md frontmatter."},
+        "models": {"type": "array", "items": {"$ref": "#/$defs/ModelRow"}}
+      }
+    },
+    "ModelRow": {
+      "type": "object",
+      "description": "One row in a results table.",
+      "required": ["name_in_paper", "weight_type", "is_score_original", "model_paper", "cited_paper", "scores", "protocol"],
+      "additionalProperties": false,
+      "properties": {
+        "name_in_paper": {
+          "type": "string",
+          "description": "Method label from the paper's results table, verbatim. When the label is generic (Ours, Baseline, (b)), resolve to the method's canonical name from the paper's title/abstract/method section and emit that. Immutable after this stage."
+        },
+        "label_quote": {"type": ["string", "null"], "description": "Exact label characters from the paper. Evidence only."},
+        "params": {"type": ["string", "null"], "description": "e.g. '7B', '1.5B'. null when not stated."},
+        "params_quote": {"type": ["string", "null"]},
+        "weight_type": {
+          "type": "string",
+          "enum": ["shared", "finetuned", "unknown"],
+          "description": "shared = same checkpoint across benchmarks. finetuned = trained on this benchmark's data."
+        },
+        "weight_type_quote": {"type": ["string", "null"]},
+        "is_score_original": {
+          "type": "string",
+          "enum": ["original", "cited_baseline", "reproduction", "unknown"],
+          "description": "original: this paper ran the method AND introduces it. cited_baseline: number quoted from another source (populate cited_paper). reproduction: this paper re-ran a method it does not introduce. unknown: cannot tell."
+        },
+        "model_paper": {
+          "type": ["string", "null"],
+          "format": "uri",
+          "description": "URL of the paper that introduces the method. Resolve from the paper's references. Any URL (arxiv, ACL, DOI, tech report). null only when the method has no public paper."
+        },
+        "cited_paper": {
+          "type": ["string", "null"],
+          "format": "uri",
+          "description": "URL of the source this score is quoted from. Populate only when is_score_original='cited_baseline'. Any URL (arxiv, github, blog, tech report). null otherwise."
+        },
+        "scores": {"$ref": "#/$defs/Scores"},
+        "protocol": {"$ref": "#/$defs/Protocol"}
+      }
+    },
+    "Scores": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Shape of required keys is prescribed by leaderboard/benchmarks/{bm}.md's Scoring section.",
+      "properties": {
+        "overall_score": {"type": ["number", "null"], "description": "Paper's reported aggregate. null when absent or not locatable."},
+        "overall_score_quote": {"type": ["string", "null"]},
+        "suite_scores": {
+          "type": "object",
+          "description": "Sub-scores over benchmark-defined suites (e.g. LIBERO's 4 suites). Keys match the benchmark's declared suites.",
+          "additionalProperties": {
+            "type": "object",
+            "required": ["value", "quote"],
+            "additionalProperties": false,
+            "properties": {
+              "value": {"type": "number"},
+              "quote": {"type": "string", "description": "Exact characters from the paper."}
+            }
+          }
+        },
+        "task_scores": {
+          "type": "object",
+          "description": "Per-task scores (e.g. RoboCasa atomic tasks, MIKASA T1–T10). Same shape as suite_scores.",
+          "additionalProperties": {
+            "type": "object",
+            "required": ["value", "quote"],
+            "additionalProperties": false,
+            "properties": {"value": {"type": "number"}, "quote": {"type": "string"}}
+          }
+        },
+        "reported_table": {"type": ["string", "null"], "description": "e.g. 'Table 1', 'Fig. 4'."}
+      }
+    },
+    "Protocol": {
+      "type": "object",
+      "required": ["matches_standard", "rationale"],
+      "additionalProperties": false,
+      "properties": {
+        "matches_standard": {
+          "type": "string",
+          "enum": ["yes", "no", "partial", "unknown"],
+          "description": "Whether the row's evaluation matches the benchmark's Standard in {bm}.md. If the rationale describes any Checks violation, use 'no' (not 'yes')."
+        },
+        "rationale": {
+          "type": "string",
+          "description": "Why matches_standard has that value. Every factual claim (task count, demo count, split) must appear in evidence_quote."
+        },
+        "evidence_quote": {
+          "type": ["string", "null"],
+          "description": "Verbatim paper text backing the rationale. A rationale claim with no matching quote downgrades matches_standard one step toward 'unknown'."
+        }
+      }
+    }
+  }
+}

--- a/leaderboard/data/leaderboard.schema.json
+++ b/leaderboard/data/leaderboard.schema.json
@@ -1,42 +1,74 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "VLA Leaderboard Entries",
+  "description": "data/leaderboard.json. Written by refine.py, sync_external.py, and manual edits. Rendered by leaderboard/site/app.js. validate.py enforces this schema plus benchmark-aware rules (score range, aggregation, official-leaderboard policy, citation coverage).",
   "type": "object",
   "required": ["last_updated", "results"],
+  "additionalProperties": false,
   "properties": {
-    "last_updated": { "type": "string", "format": "date" },
+    "last_updated": {"type": "string", "format": "date", "description": "ISO date of the most recent data change. Bump when results changes."},
     "results": {
       "type": "array",
+      "description": "One entry per (model × benchmark × reported_paper). Sorted by (benchmark, model).",
       "items": {
         "type": "object",
         "required": ["model", "display_name", "benchmark", "weight_type", "curated_by", "date_added"],
         "additionalProperties": false,
         "properties": {
-          "model": { "type": "string" },
-          "display_name": { "type": "string" },
-          "name_in_paper": { "type": ["string", "null"], "description": "Exact model label from the source paper's results table." },
-          "benchmark": { "type": "string" },
-          "overall_score": { "type": ["number", "null"] },
+          "model": {
+            "type": "string",
+            "description": "BibTeX-style key. First-party: {method_bib} (e.g. 'kim24openvla'). Third-party: {method_bib}__{measuring_paper_bib}. The measuring paper is the one that ran or first reported the number."
+          },
+          "display_name": {
+            "type": "string",
+            "description": "Site-rendered method name. First-party: 'OpenVLA'. Third-party: 'OpenVLA (from X-VLA)', where the parenthesized paper matches the measuring paper."
+          },
+          "name_in_paper": {
+            "type": ["string", "null"],
+            "description": "Method label verbatim from the source paper's results table. null for manual or API-synced entries with no paper label."
+          },
+          "benchmark": {"type": "string", "description": "Key in benchmarks.json."},
+          "overall_score": {
+            "type": ["number", "null"],
+            "description": "Aggregate that controls ranking. Set only when the entry uses the benchmark's standard protocol (all Checks pass). Otherwise null, with the paper's raw aggregate stored in task_scores.reported_avg."
+          },
           "suite_scores": {
             "type": "object",
-            "additionalProperties": { "type": "number" }
+            "description": "Sub-scores over declared suites. Keys match benchmarks.json when overall_score is non-null.",
+            "additionalProperties": {"type": "number"}
           },
           "task_scores": {
             "type": "object",
-            "additionalProperties": { "type": "number" }
+            "description": "Per-task scores. Key 'reported_avg' is reserved for a paper-reported aggregate that could not be ranked.",
+            "additionalProperties": {"type": "number"}
           },
-          "reported_paper": { "type": ["string", "null"], "format": "uri" },
-          "reported_table": { "type": ["string", "null"] },
+          "reported_paper": {
+            "type": ["string", "null"],
+            "format": "uri",
+            "description": "URL of the paper that measured this number. null for API-synced entries."
+          },
+          "reported_table": {"type": ["string", "null"]},
           "curated_by": {
             "type": "string",
-            "description": "Canonical forms: '<family> <version>' for AI extractions (e.g. 'opus 4.6', 'sonnet 4.6'), '@handle' for human curators, '<source>-api' for API-synced entries, or 'human' as a legacy fallback.",
+            "description": "AI: '<family> <version>' (e.g. 'opus 4.6'). Human: '@handle'. API sync: '<source>-api'. Legacy: 'human'.",
             "pattern": "^((opus|sonnet|haiku) \\d+\\.\\d+|@[\\w-]+|[a-z][a-z0-9_-]*-api|human)$"
           },
-          "notes": { "type": "string" },
-          "date_added": { "type": "string", "format": "date" },
-          "params": { "type": ["string", "null"] },
-          "model_paper": { "type": ["string", "null"], "format": "uri" },
-          "weight_type": { "type": "string", "enum": ["shared", "finetuned"] }
+          "notes": {
+            "type": "string",
+            "description": "Caveats (non-standard subset, training budget, architecture class, non-arxiv cite source)."
+          },
+          "date_added": {"type": "string", "format": "date"},
+          "params": {"type": ["string", "null"], "description": "e.g. '7B', '~50M'."},
+          "model_paper": {
+            "type": ["string", "null"],
+            "format": "uri",
+            "description": "URL of the paper that introduces the method. Distinct from reported_paper."
+          },
+          "weight_type": {
+            "type": "string",
+            "enum": ["shared", "finetuned"],
+            "description": "shared = same checkpoint across benchmarks. finetuned = trained on this benchmark's data."
+          }
         }
       }
     }

--- a/leaderboard/scripts/extract.py
+++ b/leaderboard/scripts/extract.py
@@ -290,36 +290,11 @@ def _extraction_schema() -> dict:
     return json.loads(EXTRACTION_SCHEMA_PATH.read_text())
 
 
-def _batched_schema() -> dict:
-    """Wrap the per-paper extraction schema in a ``papers`` array.
-
-    The LLM emits only the content fields (arxiv_id, benchmarks,
-    benchmarks_absent); the wrapper script fills in extracted_at,
-    paper_hash, extraction_scope, etc. after the call.
-    """
-    single = _extraction_schema()
-    llm_item = {
-        "type": "object",
-        "required": ["arxiv_id", "benchmarks"],
-        "additionalProperties": False,
-        "properties": {
-            "arxiv_id": single["properties"]["arxiv_id"],
-            "benchmarks": single["properties"]["benchmarks"],
-            "benchmarks_absent": single["properties"]["benchmarks_absent"],
-        },
-    }
-    return {
-        "type": "object",
-        "required": ["papers"],
-        "properties": {
-            "papers": {
-                "type": "array",
-                "description": "One entry per input paper; arxiv_id matches the path supplied.",
-                "items": llm_item,
-            }
-        },
-        "$defs": single["$defs"],
-    }
+# The claude CLI's `--json-schema` mode does not reliably populate
+# `structured_output` for schemas larger than a few fields (the LLM
+# falls back to emitting a JSON code block in assistant text, which the
+# CLI does not convert). Instead of relying on that path, we instruct
+# the LLM to Write a partial file per paper and post-process.
 
 
 def _build_system_prompt(all_rules: str) -> str:
@@ -376,6 +351,15 @@ bibliography. Non-arxiv sources (official github, tech reports, blogs)
 are valid URLs too. Leave null when the paper quotes a number without
 naming a source.
 
+## Normalize scale
+
+Emit numeric values in the benchmark's declared `metric.range` (see
+each benchmark's frontmatter below). Most benchmarks are 0–100 (% success
+rate); CALVIN is 0–5 (avg completed subtasks); RoboArena is Elo. If a
+paper reports on a 0–1 scale but the benchmark range is 0–100, multiply
+by 100 before emitting. Evidence quotes remain verbatim paper text — do
+not rewrite the quote to show the converted number.
+
 ## Exclude ablation variants
 
 Skip rows whose only differentiator is quantization (INT4, AWQ, GPTQ),
@@ -404,19 +388,21 @@ variance dimensions — differences along these still allow 'yes'.
 """
 
 
+EXTRACTIONS_RAW_DIR = ROOT / ".cache" / "extractions_raw"
+
+
 def _call_claude_cli(
     system_prompt: str,
     user_prompt: str,
-    json_schema: dict,
-    paper_dir: Path,
+    extra_add_dirs: list[Path],
     model: str = DEFAULT_MODEL,
     timeout: int = DEFAULT_TIMEOUT,
     log_path: Path | None = None,
-) -> tuple[dict, int]:
-    """Call claude CLI in tool mode over paper_dir.
+) -> int:
+    """Invoke the claude CLI. Returns n_tool_calls observed in the stream.
 
-    Returns ``(structured_output, n_tool_calls)``. Writes raw stream-json
-    stdout to ``log_path``. Raises LLMError on any failure.
+    Writes raw stream-json stdout to ``log_path``. Raises LLMError on
+    non-zero exit or no final result event.
     """
     cmd = [
         "claude",
@@ -425,17 +411,21 @@ def _call_claude_cli(
         model,
         "--system-prompt",
         system_prompt,
-        "--json-schema",
-        json.dumps(json_schema),
         "--output-format",
         "stream-json",
         "--verbose",
-        "--add-dir",
-        str(paper_dir),
         "--permission-mode",
         "bypassPermissions",
         "--no-session-persistence",
+        # Restrict to Claude Code native tools (Read/Write/Edit/Bash/Grep/Glob/
+        # WebFetch/WebSearch). Custom MCP servers (Perplexity, arxiv-mcp, etc.)
+        # and user skills may delegate to outside knowledge sources and bypass
+        # the paper-grounded discipline the extract stage depends on.
+        "--strict-mcp-config",
+        "--disable-slash-commands",
     ]
+    for d in extra_add_dirs:
+        cmd += ["--add-dir", str(d.resolve())]
     try:
         result = subprocess.run(cmd, input=user_prompt, capture_output=True, text=True, timeout=timeout)
     except FileNotFoundError as e:
@@ -445,8 +435,8 @@ def _call_claude_cli(
     if result.returncode != 0:
         raise LLMError(f"exit {result.returncode}: {result.stderr[:500]}")
 
-    structured: dict | None = None
     n_tool_calls = 0
+    seen_result = False
     for line in result.stdout.splitlines():
         line = line.strip()
         if not line:
@@ -462,33 +452,32 @@ def _call_claude_cli(
                 if block.get("type") == "tool_use":
                     n_tool_calls += 1
         if evt.get("type") == "result":
-            structured = evt.get("structured_output")
+            seen_result = True
 
     if log_path is not None:
         log_path.parent.mkdir(parents=True, exist_ok=True)
         log_path.write_text(result.stdout, encoding="utf-8")
 
-    if not isinstance(structured, dict):
-        raise LLMError("no structured_output in stream")
-    return structured, n_tool_calls
+    if not seen_result:
+        raise LLMError("no result event in stream")
+    return n_tool_calls
 
 
 def _call_claude_cli_with_retry(
     system_prompt: str,
     user_prompt: str,
-    json_schema: dict,
-    paper_dir: Path,
+    extra_add_dirs: list[Path],
     model: str,
     timeout: int,
     log_path: Path | None,
     retries: int = 1,
-) -> tuple[dict, int]:
-    """Retry LLM call once on transient failure. Raises LLMError if all attempts fail."""
+) -> int:
+    """Retry once on transient failure."""
     last_err: LLMError | None = None
     for attempt in range(retries + 1):
         try:
             return _call_claude_cli(
-                system_prompt, user_prompt, json_schema, paper_dir, model=model, timeout=timeout, log_path=log_path
+                system_prompt, user_prompt, extra_add_dirs, model=model, timeout=timeout, log_path=log_path
             )
         except LLMError as e:
             last_err = e
@@ -499,14 +488,19 @@ def _call_claude_cli_with_retry(
 
 
 # ---------------------------------------------------------------------------
-# Batched extraction
+# Batched extraction (file-based: LLM writes per-paper partials)
 # ---------------------------------------------------------------------------
 
 
-def _assemble_record(aid: str, p: dict, model: str, batch_size: int, n_tool_calls: int) -> dict:
-    """Build the final per-paper extraction record from LLM output + metadata.
+def _partial_path(arxiv_id: str) -> Path:
+    return EXTRACTIONS_RAW_DIR / f"{arxiv_id}.partial.json"
 
-    Matches extraction.schema.json.
+
+def _assemble_record(aid: str, partial: dict, model: str, batch_size: int, n_tool_calls: int) -> dict:
+    """Build the full per-paper extraction record from the LLM's partial.
+
+    Matches extraction.schema.json. The partial carries arxiv_id,
+    benchmarks, and benchmarks_absent; the script fills the rest.
     """
     return {
         "arxiv_id": aid,
@@ -516,8 +510,8 @@ def _assemble_record(aid: str, p: dict, model: str, batch_size: int, n_tool_call
         "batch_tool_calls_total": n_tool_calls,
         "paper_hash": _paper_hash(aid),
         "extraction_scope": sorted(_current_benchmark_keys()),
-        "benchmarks": p.get("benchmarks", []),
-        "benchmarks_absent": p.get("benchmarks_absent") or {},
+        "benchmarks": partial.get("benchmarks", []),
+        "benchmarks_absent": partial.get("benchmarks_absent") or {},
     }
 
 
@@ -527,27 +521,46 @@ def _run_one_batch(
     model: str,
     timeout: int,
 ) -> dict[str, dict | None]:
-    """Run a single claude CLI call across ``todo`` papers. Per-paper results or None on LLM failure."""
-    paper_lines = [f"- arxiv_id={aid}  path={CACHE_DIR / aid / 'paper.md'}" for aid in todo]
+    """Run a single claude CLI call across ``todo`` papers.
+
+    The LLM reads each paper and writes per-paper extraction JSON to
+    ``{EXTRACTIONS_RAW_DIR}/{arxiv_id}.partial.json``. The script then
+    reads each partial, fills in metadata, and saves the final record
+    to ``.cache/extractions/{arxiv_id}.json``.
+    """
+    EXTRACTIONS_RAW_DIR.mkdir(parents=True, exist_ok=True)
+    # Clear any stale partials for this batch's ids so "file exists" =
+    # "this call produced it".
+    for aid in todo:
+        _partial_path(aid).unlink(missing_ok=True)
+
+    paper_lines = [
+        f"- arxiv_id={aid}  paper={CACHE_DIR / aid / 'paper.md'}  output={_partial_path(aid)}" for aid in todo
+    ]
     system_prompt = _build_system_prompt(all_rules)
     user_prompt = (
-        "Extract benchmark results from EACH paper listed below.\n\n"
-        "Return ONE entry per paper in the `papers` array, keyed by arxiv_id.\n"
-        "Every arxiv_id below must appear in your output, even if its benchmarks "
-        "array is empty.\n\n"
-        "Use available tools to navigate each paper.md independently. "
-        "Every quote you emit for a paper must come from that paper's file.\n\n"
+        "Extract benchmark results from each paper listed below.\n\n"
+        "For every paper, write a JSON file to the `output=` path shown, "
+        "containing EXACTLY these fields:\n"
+        "  - arxiv_id (string, matches the input)\n"
+        "  - benchmarks (array, per extraction.schema.json's $defs/BenchmarkEntry)\n"
+        "  - benchmarks_absent (object, or omit if none)\n\n"
+        "Do not include extracted_at, paper_hash, extraction_scope, "
+        "model_used, or batch_* — the script fills those.\n\n"
+        "Every arxiv_id below must produce a file, even if benchmarks is "
+        "[]. Every quote you write must come from that paper's `paper=` "
+        "file.\n\n"
+        f"Field semantics: {EXTRACTION_SCHEMA_PATH}\n\n"
         "Papers:\n" + "\n".join(paper_lines)
     )
     batch_tag = "_".join(todo[:2]) + (f"+{len(todo) - 2}" if len(todo) > 2 else "")
     log_path = EXTRACTION_LOGS_DIR / f"batch_{batch_tag}.log"
 
     try:
-        llm_output, n_tool_calls = _call_claude_cli_with_retry(
+        n_tool_calls = _call_claude_cli_with_retry(
             system_prompt,
             user_prompt,
-            _batched_schema(),
-            CACHE_DIR.resolve(),
+            extra_add_dirs=[CACHE_DIR, EXTRACTIONS_RAW_DIR],
             model=model,
             timeout=timeout,
             log_path=log_path,
@@ -557,16 +570,22 @@ def _run_one_batch(
         print(f"    LLM error for batch ({len(todo)} papers): {e}")
         return {aid: None for aid in todo}
 
-    by_id: dict[str, dict] = {p.get("arxiv_id"): p for p in llm_output.get("papers", []) if p.get("arxiv_id")}
     results: dict[str, dict | None] = {}
     for aid in todo:
-        p = by_id.get(aid)
-        if p is None:
-            print(f"    WARN {aid} missing from batch output")
+        partial_path = _partial_path(aid)
+        if not partial_path.exists():
+            print(f"    {aid}: no partial file written")
             results[aid] = None
             continue
-        record = _assemble_record(aid, p, model, len(todo), n_tool_calls)
+        try:
+            partial = json.loads(partial_path.read_text())
+        except json.JSONDecodeError as e:
+            print(f"    {aid}: invalid JSON in partial: {e}")
+            results[aid] = None
+            continue
+        record = _assemble_record(aid, partial, model, len(todo), n_tool_calls)
         _save_cached_extraction(aid, record)
+        partial_path.unlink()
         results[aid] = record
     return results
 

--- a/leaderboard/scripts/extract.py
+++ b/leaderboard/scripts/extract.py
@@ -353,12 +353,16 @@ naming a source.
 
 ## Normalize scale
 
-Emit numeric values in the benchmark's declared `metric.range` (see
-each benchmark's frontmatter below). Most benchmarks are 0–100 (% success
-rate); CALVIN is 0–5 (avg completed subtasks); RoboArena is Elo. If a
-paper reports on a 0–1 scale but the benchmark range is 0–100, multiply
-by 100 before emitting. Evidence quotes remain verbatim paper text — do
-not rewrite the quote to show the converted number.
+Emit numeric values in the benchmark's declared `metric.range`. If the
+paper reports on a different scale (commonly 0–1 for a 0–100 benchmark),
+convert before emitting. Quotes stay verbatim from the paper.
+
+## Preserve non-standard tasks
+
+A benchmark's declared task list identifies the standard protocol, not
+the set of allowed keys. Tasks outside that list (non-standard protocols)
+stay in `task_scores` under the paper's verbatim names; the row's
+`protocol.matches_standard` becomes 'no' but the data is preserved.
 
 ## Exclude ablation variants
 
@@ -417,10 +421,8 @@ def _call_claude_cli(
         "--permission-mode",
         "bypassPermissions",
         "--no-session-persistence",
-        # Restrict to Claude Code native tools (Read/Write/Edit/Bash/Grep/Glob/
-        # WebFetch/WebSearch). Custom MCP servers (Perplexity, arxiv-mcp, etc.)
-        # and user skills may delegate to outside knowledge sources and bypass
-        # the paper-grounded discipline the extract stage depends on.
+        # Restrict to Claude Code native tools; block MCP servers and
+        # user skills that might delegate to outside knowledge sources.
         "--strict-mcp-config",
         "--disable-slash-commands",
     ]

--- a/leaderboard/scripts/extract.py
+++ b/leaderboard/scripts/extract.py
@@ -10,6 +10,10 @@ Two subcommands::
     uv run extract.py run 2505.05800 [--workers 4] # extract from papers
 
 Pipeline: scan → run → refine.py → validate.py → sync_external.py
+
+Output shape is defined by leaderboard/data/extraction.schema.json. This
+script loads that schema at runtime — field semantics live there, not
+duplicated in the prompt.
 """
 
 from __future__ import annotations
@@ -43,11 +47,13 @@ EXTRACTION_LOGS_DIR = ROOT / ".cache" / "extraction_logs"
 EXTRACTIONS_JSON = DATA_DIR / "extractions.json"
 BENCHMARKS_DIR = ROOT / "benchmarks"
 BENCHMARKS_JSON_PATH = DATA_DIR / "benchmarks.json"
+EXTRACTION_SCHEMA_PATH = DATA_DIR / "extraction.schema.json"
 SCAN_CACHE_PATH = ROOT / ".cache" / "scan_results.json"
 FETCH_FAILURES_PATH = CACHE_DIR / "fetch_failures.json"
 
 DEFAULT_MODEL = "claude-opus-4-6[1m]"
 DEFAULT_TIMEOUT = 2400
+DEFAULT_BATCH_SIZE = 30
 _ARXIV_RE = re.compile(r"arxiv\.org/abs/(\d+\.\d+)")
 
 # Lock for thread-safe fetch failure writes
@@ -278,245 +284,121 @@ class LLMError(RuntimeError):
     pass
 
 
-EXTRACTION_SCHEMA: dict = {
-    "type": "object",
-    "required": ["benchmarks", "confidence"],
-    "properties": {
-        "benchmarks": {
-            "type": "array",
-            "description": "One entry per benchmark found in this paper. Empty array if the paper does not evaluate any known benchmark.",
-            "items": {
-                "type": "object",
-                "required": ["benchmark", "models"],
-                "properties": {
-                    "benchmark": {
-                        "type": "string",
-                        "description": "Benchmark key exactly as listed in the rules (e.g. 'libero', 'calvin', 'simpler_env')",
-                    },
-                    "models": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "required": ["label", "scores"],
-                            "properties": {
-                                "label": {
-                                    "type": "string",
-                                    "description": (
-                                        "Canonical method name. Usually the paper's table label, but "
-                                        "when the label is generic ('Ours', 'Baseline', 'Ablation', etc.) "
-                                        "resolve to the method's real name from the paper's title / "
-                                        "abstract / method section."
-                                    ),
-                                },
-                                "label_quote": {"type": ["string", "null"]},
-                                "params": {"type": ["string", "null"]},
-                                "params_quote": {"type": ["string", "null"]},
-                                "weight_type": {"type": "string", "enum": ["shared", "finetuned", "unknown"]},
-                                "weight_type_quote": {"type": ["string", "null"]},
-                                "is_score_original": {
-                                    "type": "string",
-                                    "enum": ["original", "cited_baseline", "reproduction", "unknown"],
-                                },
-                                "attribution_quote": {"type": ["string", "null"]},
-                                "scores": {
-                                    "type": "object",
-                                    "properties": {
-                                        "overall_score": {"type": ["number", "null"]},
-                                        "overall_score_quote": {"type": ["string", "null"]},
-                                        "suite_scores": {
-                                            "type": "object",
-                                            "additionalProperties": {
-                                                "type": "object",
-                                                "required": ["value", "quote"],
-                                                "properties": {
-                                                    "value": {"type": "number"},
-                                                    "quote": {"type": "string"},
-                                                },
-                                            },
-                                        },
-                                        "task_scores": {
-                                            "type": "object",
-                                            "additionalProperties": {
-                                                "type": "object",
-                                                "required": ["value", "quote"],
-                                                "properties": {
-                                                    "value": {"type": "number"},
-                                                    "quote": {"type": "string"},
-                                                },
-                                            },
-                                        },
-                                        "reported_table": {"type": ["string", "null"]},
-                                    },
-                                },
-                                "protocol": {
-                                    "type": "object",
-                                    "required": ["matches_standard", "rationale"],
-                                    "properties": {
-                                        "matches_standard": {
-                                            "type": "string",
-                                            "enum": ["yes", "no", "partial", "unknown"],
-                                        },
-                                        "rationale": {"type": "string"},
-                                        "evidence_quote": {"type": ["string", "null"]},
-                                    },
-                                },
-                            },
-                        },
-                    },
-                    "risky_patterns": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "required": ["id", "answer"],
-                            "properties": {
-                                "id": {"type": "string"},
-                                "answer": {"type": "string", "enum": ["yes", "no", "unknown"]},
-                                "quote": {"type": ["string", "null"]},
-                            },
-                        },
-                    },
-                },
-            },
+@functools.lru_cache(maxsize=1)
+def _extraction_schema() -> dict:
+    """Load the authoritative per-paper extraction schema."""
+    return json.loads(EXTRACTION_SCHEMA_PATH.read_text())
+
+
+def _batched_schema() -> dict:
+    """Wrap the per-paper extraction schema in a ``papers`` array.
+
+    The LLM emits only the content fields (arxiv_id, benchmarks,
+    benchmarks_absent); the wrapper script fills in extracted_at,
+    paper_hash, extraction_scope, etc. after the call.
+    """
+    single = _extraction_schema()
+    llm_item = {
+        "type": "object",
+        "required": ["arxiv_id", "benchmarks"],
+        "additionalProperties": False,
+        "properties": {
+            "arxiv_id": single["properties"]["arxiv_id"],
+            "benchmarks": single["properties"]["benchmarks"],
+            "benchmarks_absent": single["properties"]["benchmarks_absent"],
         },
-        "confidence": {"type": "string", "enum": ["high", "medium", "low"]},
-        "benchmarks_absent": {
-            "type": "object",
-            "description": (
-                "Map {benchmark_key: reason} for benchmarks the paper mentions but do not appear in "
-                "`benchmarks[]` (cited-only, non-standard, unreadable, etc.). Omit benchmarks the paper "
-                "never mentions."
-            ),
-            "additionalProperties": {"type": "string"},
+    }
+    return {
+        "type": "object",
+        "required": ["papers"],
+        "properties": {
+            "papers": {
+                "type": "array",
+                "description": "One entry per input paper; arxiv_id matches the path supplied.",
+                "items": llm_item,
+            }
         },
-    },
-}
+        "$defs": single["$defs"],
+    }
 
 
 def _build_system_prompt(all_rules: str) -> str:
     return f"""You are the EXTRACT stage of a two-stage VLA leaderboard pipeline.
 
-Your goal is recall. Surface every row that could belong on the leaderboard,
-with the evidence (verbatim quotes, protocol notes, attribution) a downstream
-PRECISION stage needs to make the final cut. When uncertain, extract.
+Your objective at this stage is recall, not precision. Surface every
+row that could belong on the leaderboard. A downstream PRECISION stage
+applies eligibility filters, dedup, canonical-name cleanup, and notes
+composition — do not pre-filter for those concerns. When uncertain,
+extract; it is better to surface a row that later gets dropped than to
+silently lose a real measurement.
 
-The precision stage handles protocol gating, score arithmetic, dedup across
-papers, canonical naming cleanup, and notes — do not pre-filter for those
-concerns.
+Baseline-comparison and related-work tables in a paper often hold the
+only record of a given model on a benchmark (the original paper may
+never reach extraction). Extract every row in every comparison table.
 
-Baseline-comparison and related-work score tables often hold the only record
-of a given model on this benchmark (the original paper may never reach
-extraction). Extract every row in every comparison table.
+Field semantics and output structure are defined by the JSON schema you
+write against. The rules below cover decisions that depend on paper
+context (the schema alone cannot specify them).
 
-## Inclusion criteria
+## Scope per benchmark
 
-A row is eligible when ALL three hold:
+For every benchmark listed in the rules below:
 
-1. **Public name (resolve from paper context when the table label is
-   generic).** Each row maps to a specific, canonical method name a reader
-   could Google — "OpenVLA", "RT-2", "π₀", "Diffusion Policy", "3D Diffuser
-   Actor", "CogACT".
+1. Grep the paper for the benchmark's key name, display name, and the
+   suite/task names in its Standard.
+2. Paper scores it → add to `benchmarks[]`.
+3. Paper mentions it without an extractable score → add to
+   `benchmarks_absent` with a one-line reason.
+4. Paper doesn't mention it → omit from both.
 
-   When the table label is generic ("Ours", "Our Method", "Proposed",
-   "Baseline", "(Ours)"), find the method's real name in the paper's title /
-   abstract / method section and emit THAT as `label` — you have Read access
-   to the paper for exactly this. Downstream stages cannot redo this lookup.
-
-   Skip only when the paper offers no canonical name, or the label is an
-   unnamed suffix ("Ablation", "(b)", "variant X") with no recoverable
-   identity.
-
-2. **Primary configuration, not an ablation variant.** Skip rows whose only
-   differentiator is:
-   - quantization scheme (INT4, INT8, FP8, AWQ, PTQ, QAT, GPTQ, GGUF, ...)
-   - parameter-efficient tuning (LoRA, QLoRA, adapter, prefix-tuning, ...)
-   - training-stage variant ("w/o pretrain", "stage 1", "50% data", ...)
-   - horizon / action-chunk hyperparameters ("k=1", "chunk=8", ...)
-   - suffix tweaks like "+feature X"
-   Unless that variant is the paper's main contribution.
-
-3. **Numeric score.** The row reports a concrete number on a listed
-   benchmark — either the paper's own run or a cited baseline. Skip rows
-   with only qualitative notes.
-
-## Per-row fields
-
-For each eligible model:
-
-- `label`: canonical method name (resolved per criterion 1).
-- `weight_type`: `shared` (same checkpoint across benchmarks) or `finetuned`
-  (trained specifically on this benchmark's data).
-- `is_score_original`:
-  - `original` — paper ran this model itself
-  - `cited_baseline` — number quoted from another paper, not re-run
-  - `reproduction` — paper explicitly marks it as their reproduction
-  - `unknown` — genuinely cannot tell
-- `scores`: the benchmark's numeric results. See the benchmark rules
-  below for the exact JSON shape; the general structure is:
-  - `overall_score`: the benchmark's canonical aggregate.
-  - `suite_scores`: sub-scores over groupings the benchmark itself
-    defines — e.g. LIBERO's 5 suites (`libero_spatial`/`libero_object`/
-    `libero_goal`/`libero_10`/`libero_90`), CALVIN's
-    `chain_1`..`chain_5`, SimplerEnv's `google_robot_vm`/`..._va`/
-    `widowx_vm`.
-  - `task_scores`: individual per-task success rates — e.g. RoboCasa
-    `PnPCounterToMicrowave`, ManiSkill2 `PickCube`.
-
-  Emit every tabulated per-suite / per-task number as its own entry.
-  Do not collapse a detailed results table to `overall_score` alone.
-
-  Every numeric score carries a verbatim `quote`. Values you cannot
-  locate in the paper are `null`.
-- `protocol.matches_standard`: `yes` / `no` / `partial` / `unknown`.
-  Failing a benchmark's `Checks` → `no`. Differences along `Methodology
-  axes` → `yes`.
-
-Use the exact benchmark key as listed in the rules (e.g. `libero`, `calvin`).
-
-## Coverage
-
-Your goal at this stage is coverage. A downstream stage filters and
-deduplicates — your job is to surface every benchmark-row the paper touches.
-
-For every benchmark key in your scope, before calling StructuredOutput:
-
-1. Grep the paper for the benchmark's key name, display name, and its
-   standard suite / task names listed in the rules below.
-2. If the paper reports any numeric score for it → add an entry to
-   `benchmarks[]`.
-3. If the paper mentions it without an extractable score (cited-only,
-   non-standard unreadable, etc.) → add an entry to `benchmarks_absent`
-   keyed by benchmark id with a one-line reason.
-4. If the paper does not mention the benchmark → omit it from both.
-
-A paper that evaluates on multiple benchmarks produces entries for every
-one of them, not just the one framed as the paper's main contribution.
-
-Return `benchmarks: []` only for pure survey / theory papers with no
+Return `benchmarks: []` only for pure theory/survey papers with no
 evaluation table.
 
-## Review before StructuredOutput
+## Resolving generic labels
 
-Before emitting the final output, check each row:
+When a results-table label is generic ("Ours", "Our Method", "Proposed",
+"Baseline", "(b)", "variant X"), look up the method's real name in the
+paper's title, abstract, or method section and emit that canonical name
+as `name_in_paper`. Downstream stages cannot redo this lookup.
 
-- Every numeric value has an `*_quote` containing that value's exact
-  characters from the paper. If you cannot locate the text, set the
-  value to `null`.
+## Resolving model_paper
+
+For every row, set `model_paper` to the URL of the paper that introduces
+the method. Find it in the paper's reference list. Any URL is valid —
+arxiv, ACL Anthology, DOI, tech report. null only when the method has
+no public paper.
+
+## Resolving cited_paper
+
+When `is_score_original='cited_baseline'`, set `cited_paper` to the URL
+the score is attributed to. Resolve arxiv references via the paper's
+bibliography. Non-arxiv sources (official github, tech reports, blogs)
+are valid URLs too. Leave null when the paper quotes a number without
+naming a source.
+
+## Exclude ablation variants
+
+Skip rows whose only differentiator is quantization (INT4, AWQ, GPTQ),
+parameter-efficient tuning (LoRA, adapter), training-stage variant
+("w/o pretrain", "50% data"), or hyperparameter sweep ("k=1",
+"chunk=8") — unless that variant is the paper's main contribution.
+
+## Self-check before emitting
+
+- Every numeric value has a matching *_quote from the paper. If not
+  locatable, set the value to null.
 - Every claim in `protocol.rationale` (task count, demo count, split,
-  embodiment, etc.) has matching text in `evidence_quote`. A claim
-  without a supporting quote → downgrade `matches_standard` one step
-  toward `"unknown"`.
-- `matches_standard` is consistent with `protocol.rationale`. If the
-  rationale describes any benchmark `Checks` violation (subset of the
-  standard task set, alternative embodiment, non-standard split, etc.),
-  `matches_standard` cannot be `"yes"`.
+  embodiment) has a matching evidence_quote. Unsupported claims →
+  downgrade matches_standard one step toward 'unknown'.
+- If the rationale describes any Checks violation, matches_standard is
+  'no' — not 'yes'.
 
 ## Benchmark rules
 
-Each block below opens with `**Standard**: ...` (the canonical protocol).
-`Scoring` prescribes the JSON shape. `Checks` lists yes/no questions;
-failing any → `protocol.matches_standard = "no"`. `Methodology axes` are
-variance dimensions — differences along these still allow
-`matches_standard = "yes"`.
+Each block below opens with **Standard**: (the canonical protocol).
+Scoring prescribes the JSON shape for scores. Checks lists yes/no
+questions; failing any → matches_standard='no'. Methodology axes are
+variance dimensions — differences along these still allow 'yes'.
 
 {all_rules}
 """
@@ -533,10 +415,8 @@ def _call_claude_cli(
 ) -> tuple[dict, int]:
     """Call claude CLI in tool mode over paper_dir.
 
-    The paper file is NOT inlined into the prompt. The model navigates it
-    via tools restricted to ``paper_dir``. Returns
-    ``(structured_output, n_tool_calls)``. Writes raw stream-json stdout
-    to ``log_path``.
+    Returns ``(structured_output, n_tool_calls)``. Writes raw stream-json
+    stdout to ``log_path``. Raises LLMError on any failure.
     """
     cmd = [
         "claude",
@@ -593,34 +473,102 @@ def _call_claude_cli(
     return structured, n_tool_calls
 
 
+def _call_claude_cli_with_retry(
+    system_prompt: str,
+    user_prompt: str,
+    json_schema: dict,
+    paper_dir: Path,
+    model: str,
+    timeout: int,
+    log_path: Path | None,
+    retries: int = 1,
+) -> tuple[dict, int]:
+    """Retry LLM call once on transient failure. Raises LLMError if all attempts fail."""
+    last_err: LLMError | None = None
+    for attempt in range(retries + 1):
+        try:
+            return _call_claude_cli(
+                system_prompt, user_prompt, json_schema, paper_dir, model=model, timeout=timeout, log_path=log_path
+            )
+        except LLMError as e:
+            last_err = e
+            if attempt < retries:
+                time.sleep(10)
+    assert last_err is not None
+    raise last_err
+
+
 # ---------------------------------------------------------------------------
 # Batched extraction
 # ---------------------------------------------------------------------------
 
 
-def _batched_schema() -> dict:
-    """Wrap the single-paper EXTRACTION_SCHEMA in a ``papers`` array."""
-    single = EXTRACTION_SCHEMA
+def _assemble_record(aid: str, p: dict, model: str, batch_size: int, n_tool_calls: int) -> dict:
+    """Build the final per-paper extraction record from LLM output + metadata.
+
+    Matches extraction.schema.json.
+    """
     return {
-        "type": "object",
-        "required": ["papers"],
-        "properties": {
-            "papers": {
-                "type": "array",
-                "description": "One entry per input paper. Match arxiv_id to the path supplied.",
-                "items": {
-                    "type": "object",
-                    "required": ["arxiv_id", "benchmarks", "confidence"],
-                    "properties": {
-                        "arxiv_id": {"type": "string"},
-                        "benchmarks": single["properties"]["benchmarks"],
-                        "confidence": single["properties"]["confidence"],
-                        "benchmarks_absent": single["properties"]["benchmarks_absent"],
-                    },
-                },
-            }
-        },
+        "arxiv_id": aid,
+        "extracted_at": _now_iso(),
+        "model_used": model,
+        "batch_size": batch_size,
+        "batch_tool_calls_total": n_tool_calls,
+        "paper_hash": _paper_hash(aid),
+        "extraction_scope": sorted(_current_benchmark_keys()),
+        "benchmarks": p.get("benchmarks", []),
+        "benchmarks_absent": p.get("benchmarks_absent") or {},
     }
+
+
+def _run_one_batch(
+    todo: list[str],
+    all_rules: str,
+    model: str,
+    timeout: int,
+) -> dict[str, dict | None]:
+    """Run a single claude CLI call across ``todo`` papers. Per-paper results or None on LLM failure."""
+    paper_lines = [f"- arxiv_id={aid}  path={CACHE_DIR / aid / 'paper.md'}" for aid in todo]
+    system_prompt = _build_system_prompt(all_rules)
+    user_prompt = (
+        "Extract benchmark results from EACH paper listed below.\n\n"
+        "Return ONE entry per paper in the `papers` array, keyed by arxiv_id.\n"
+        "Every arxiv_id below must appear in your output, even if its benchmarks "
+        "array is empty.\n\n"
+        "Use available tools to navigate each paper.md independently. "
+        "Every quote you emit for a paper must come from that paper's file.\n\n"
+        "Papers:\n" + "\n".join(paper_lines)
+    )
+    batch_tag = "_".join(todo[:2]) + (f"+{len(todo) - 2}" if len(todo) > 2 else "")
+    log_path = EXTRACTION_LOGS_DIR / f"batch_{batch_tag}.log"
+
+    try:
+        llm_output, n_tool_calls = _call_claude_cli_with_retry(
+            system_prompt,
+            user_prompt,
+            _batched_schema(),
+            CACHE_DIR.resolve(),
+            model=model,
+            timeout=timeout,
+            log_path=log_path,
+            retries=1,
+        )
+    except LLMError as e:
+        print(f"    LLM error for batch ({len(todo)} papers): {e}")
+        return {aid: None for aid in todo}
+
+    by_id: dict[str, dict] = {p.get("arxiv_id"): p for p in llm_output.get("papers", []) if p.get("arxiv_id")}
+    results: dict[str, dict | None] = {}
+    for aid in todo:
+        p = by_id.get(aid)
+        if p is None:
+            print(f"    WARN {aid} missing from batch output")
+            results[aid] = None
+            continue
+        record = _assemble_record(aid, p, model, len(todo), n_tool_calls)
+        _save_cached_extraction(aid, record)
+        results[aid] = record
+    return results
 
 
 def extract_batch(
@@ -631,13 +579,10 @@ def extract_batch(
     timeout: int = DEFAULT_TIMEOUT,
     resume: bool = True,
 ) -> dict[str, dict | None]:
-    """Extract benchmark results from N papers in a SINGLE claude CLI call.
+    """Extract benchmark results from N papers in batched claude CLI calls.
 
-    The model has tool access over ``CACHE_DIR`` and navigates each
-    paper.md independently. Paper contents are NEVER inlined. Returns a
-    dict ``{arxiv_id -> extraction | None}``. None means fetch failed or
-    the model omitted the paper. Successfully-extracted rows (including
-    empty `benchmarks`) are saved to the per-paper cache.
+    On batch-level failure, falls back to per-paper calls so one stuck
+    paper cannot poison the whole batch.
     """
     results: dict[str, dict | None] = {}
 
@@ -659,68 +604,17 @@ def extract_batch(
     if not todo:
         return results
 
-    paper_lines = []
-    for aid in todo:
-        paper_lines.append(f"- arxiv_id={aid}  path={CACHE_DIR / aid / 'paper.md'}")
+    batch_results = _run_one_batch(todo, all_rules, model, timeout)
+    results.update(batch_results)
 
-    system_prompt = _build_system_prompt(all_rules)
-    user_prompt = (
-        "Extract benchmark results from EACH paper listed below.\n\n"
-        "Return ONE entry per paper in the `papers` array, keyed by arxiv_id.\n"
-        "Every arxiv_id below must appear in your output, even if its benchmarks "
-        "array is empty.\n\n"
-        "Use available tools to navigate each paper.md independently. "
-        "Every quote you emit for a paper must come from that paper's file.\n\n"
-        "Papers:\n" + "\n".join(paper_lines)
-    )
-
-    batch_tag = "_".join(todo[:2]) + (f"+{len(todo) - 2}" if len(todo) > 2 else "")
-    log_path = EXTRACTION_LOGS_DIR / f"batch_{batch_tag}.log"
-
-    try:
-        llm_output, n_tool_calls = _call_claude_cli(
-            system_prompt,
-            user_prompt,
-            _batched_schema(),
-            CACHE_DIR.resolve(),
-            model=model,
-            timeout=timeout,
-            log_path=log_path,
-        )
-    except LLMError as e:
-        print(f"    LLM error for batch ({len(todo)} papers): {e}")
-        for aid in todo:
-            results[aid] = None
-        return results
-
-    scope = sorted(_current_benchmark_keys())
-    by_id: dict[str, dict] = {}
-    for p in llm_output.get("papers", []):
-        aid = p.get("arxiv_id")
-        if aid:
-            by_id[aid] = p
-
-    now = _now_iso()
-    for aid in todo:
-        p = by_id.get(aid)
-        if p is None:
-            print(f"    WARN {aid} missing from batch output")
-            results[aid] = None
-            continue
-        record = {
-            "arxiv_id": aid,
-            "extracted_at": now,
-            "model_used": model,
-            "batch_size": len(todo),
-            "batch_tool_calls_total": n_tool_calls,
-            "paper_hash": _paper_hash(aid),
-            "extraction_scope": scope,
-            "benchmarks": p.get("benchmarks", []),
-            "benchmarks_absent": p.get("benchmarks_absent") or {},
-            "confidence": p.get("confidence"),
-        }
-        _save_cached_extraction(aid, record)
-        results[aid] = record
+    # Fallback: if >=50% of the batch failed, retry remaining ones one-by-one.
+    # Protects against a single stuck paper poisoning a whole batch.
+    failed_ids = [aid for aid, r in batch_results.items() if r is None]
+    if len(todo) > 1 and len(failed_ids) >= len(todo) // 2:
+        print(f"    batch degraded ({len(failed_ids)}/{len(todo)} failed) — retrying per-paper")
+        for aid in failed_ids:
+            single = _run_one_batch([aid], all_rules, model, timeout)
+            results.update(single)
 
     return results
 
@@ -733,9 +627,9 @@ def extract_batch(
 def _fetch_s2_citations(arxiv_id: str, limit: int = 1000) -> tuple[list[dict], int]:
     """Return (arxiv-citing papers, total citation count).
 
-    The total count includes non-arxiv citations (conference/journal papers
-    without arxiv preprints) — those cannot be processed by our pipeline but
-    are shown as the coverage denominator to reflect real-world citation scale.
+    Total includes non-arxiv citations (conference/journal papers without
+    arxiv preprints) — those cannot be processed but are shown as the
+    denominator to reflect real-world citation scale.
     """
     headers = {"Accept": "application/json"}
     api_key = os.environ.get("SEMANTIC_SCHOLAR_API_KEY")
@@ -783,16 +677,29 @@ def _fetch_s2_citations(arxiv_id: str, limit: int = 1000) -> tuple[list[dict], i
 app = typer.Typer(help="Extract benchmark scores from arxiv papers via LLM.", add_completion=False)
 
 
+def _load_scan_cache() -> dict:
+    if not SCAN_CACHE_PATH.exists():
+        return {"scanned_at": None, "benchmarks": {}}
+    return json.loads(SCAN_CACHE_PATH.read_text())
+
+
 @app.command()
 def scan(
     benchmark: Annotated[Optional[str], typer.Option(help="Only scan one benchmark.")] = None,
 ) -> None:
-    """Discover citing papers for each benchmark via Semantic Scholar."""
+    """Discover citing papers for each benchmark via Semantic Scholar.
+
+    Results merge into the existing scan_results.json so a single-benchmark
+    rescan does not wipe other benchmarks' entries.
+    """
     if not BENCHMARKS_JSON_PATH.exists():
         print(f"{BENCHMARKS_JSON_PATH} not found.")
         raise typer.Exit(1)
     benchmarks = json.loads(BENCHMARKS_JSON_PATH.read_text())
-    scan_results: dict[str, dict] = {}
+
+    cache = _load_scan_cache()
+    scan_results: dict[str, dict] = dict(cache.get("benchmarks", {}))
+
     total_new = 0
     EXTRACTIONS_DIR.mkdir(parents=True, exist_ok=True)
     extracted_stems = {f.stem for f in EXTRACTIONS_DIR.glob("*.json")}
@@ -831,12 +738,10 @@ def scan(
         json.dumps({"scanned_at": _now_iso(), "benchmarks": scan_results}, indent=2, ensure_ascii=False) + "\n"
     )
 
-    print(f"\n{total_new} new papers across {len(scan_results)} benchmarks")
+    scope = f"benchmark '{benchmark}'" if benchmark else f"{len(scan_results)} benchmarks"
+    print(f"\n{total_new} new papers across {scope}")
     print(f"Wrote {SCAN_CACHE_PATH}")
     print("Run `update_coverage.py` to refresh coverage.json.")
-
-
-DEFAULT_BATCH_SIZE = 30
 
 
 @app.command()
@@ -960,7 +865,7 @@ def pack() -> None:
             bms.sort(key=lambda b: b.get("benchmark", ""))
             for bm in bms:
                 if models := bm.get("models"):
-                    models.sort(key=lambda m: m.get("label", ""))
+                    models.sort(key=lambda m: m.get("name_in_paper", ""))
     EXTRACTIONS_JSON.write_text(json.dumps(entries, indent=2, ensure_ascii=False, sort_keys=False) + "\n")
     print(f"Packed {len(entries)} extractions → {EXTRACTIONS_JSON}")
 

--- a/leaderboard/scripts/refine.py
+++ b/leaderboard/scripts/refine.py
@@ -447,10 +447,8 @@ def _refine_one_benchmark(
         "--permission-mode",
         "bypassPermissions",
         "--no-session-persistence",
-        # Restrict to Claude Code native tools only. Without this the
-        # refine stage has been observed pulling in external knowledge
-        # via Perplexity (or other MCP servers), which undermines the
-        # paper-grounded attribution discipline the pipeline depends on.
+        # Restrict to Claude Code native tools; block MCP servers and
+        # user skills that might delegate to outside knowledge sources.
         "--strict-mcp-config",
         "--disable-slash-commands",
         "--add-dir",

--- a/leaderboard/scripts/refine.py
+++ b/leaderboard/scripts/refine.py
@@ -6,19 +6,18 @@
 
 Two-stage pipeline:
 
-1. `build_candidates()` — deterministic Python step. Applies the protocol
-   gate (`yes` → compute `overall_score` from components; `no`/`partial`/
-   `unknown` → keep row with `overall_score = null`) and emits candidate
-   entries in a pre-schema shape.
+1. ``build_candidates()`` — deterministic Python step. Applies the
+   protocol gate, computes overall_score per the benchmark's aggregation
+   rule, classifies each row (first_party vs third_party) per the
+   decision table in candidates.schema.json, and resolves collapse
+   candidates by cross-checking the original paper's extraction.
 
-2. LLM agent (opus) — receives the candidate entries via a temp file and
-   only handles FUZZY decisions: eligibility (drop "Ours"/ablation/quant
-   labels), dedup across papers, cross-benchmark identity consistency,
-   and substantive note composition.
+2. LLM agent (opus) — per-benchmark fuzzy decisions: eligibility (drop
+   ablation / generic-label rows), dedup across papers, cross-benchmark
+   identity consistency, notes composition, and model-key assignment.
 
-Why this split: protocol gating and arithmetic are deterministic rules —
-they do not need LLM judgment and the LLM was getting them wrong. The
-LLM now only tackles problems that require fuzzy reasoning.
+Why per-benchmark: one LLM call for the entire leaderboard blows
+context and is hard to debug. Each benchmark is a bounded workload.
 
 Usage::
 
@@ -30,6 +29,7 @@ from __future__ import annotations
 
 import functools
 import json
+import re
 import subprocess
 from datetime import date
 from pathlib import Path
@@ -43,13 +43,35 @@ EXTRACTIONS_DIR = ROOT / ".cache" / "extractions"
 BENCHMARKS_DIR = ROOT / "benchmarks"
 BENCHMARKS_JSON_PATH = DATA_DIR / "benchmarks.json"
 LEADERBOARD_PATH = DATA_DIR / "leaderboard.json"
-SCHEMA_PATH = DATA_DIR / "leaderboard.schema.json"
+LEADERBOARD_SCHEMA_PATH = DATA_DIR / "leaderboard.schema.json"
+CANDIDATES_SCHEMA_PATH = DATA_DIR / "candidates.schema.json"
 CANDIDATES_PATH = ROOT / ".cache" / "refine_candidates.json"
 REFINE_LOGS_DIR = ROOT / ".cache" / "refine_logs"
 
-# Aggregation rules live in each benchmark's md frontmatter and are
-# compiled into benchmarks.json. This function reads them from there —
-# never hardcode a rule here; edit the benchmark's .md frontmatter instead.
+_ARXIV_RE = re.compile(r"arxiv\.org/abs/(\d+\.\d+)")
+
+
+def _arxiv_id_of(url: str | None) -> str | None:
+    if not url:
+        return None
+    m = _ARXIV_RE.search(url)
+    return m.group(1) if m else None
+
+
+def _citing_url(arxiv_id: str) -> str:
+    return f"https://arxiv.org/abs/{arxiv_id}"
+
+
+def _norm_name(name: str) -> str:
+    """Normalize a method name for cross-paper matching.
+
+    Case-insensitive, strips trailing parentheticals ('(ours)'), common
+    whitespace/punct variations.
+    """
+    s = name.strip().lower()
+    s = re.sub(r"\s*\([^)]*\)\s*$", "", s)
+    s = re.sub(r"[^\w]+", "", s)
+    return s
 
 
 @functools.cache
@@ -65,11 +87,10 @@ def _aggregation_rules() -> dict[str, dict | str]:
 
 
 def _compute_overall(benchmark: str, suite: dict, task: dict) -> float | None:
-    """Compute overall_score from component scores per aggregation rule.
+    """Compute overall_score from component scores per the aggregation rule.
 
-    Returns None for: missing rule, `"forbidden"` rule, or partial component
-    data. `isinstance(rule, dict)` handles all three non-computing cases in
-    one branch (None / str / dict union from `_aggregation_rules`).
+    Returns None for missing rule, ``"forbidden"`` rule, or partial
+    component data.
     """
     rule = _aggregation_rules().get(benchmark)
     if not isinstance(rule, dict):
@@ -93,45 +114,110 @@ def _to_plain_scores(container: dict | None) -> dict:
     return out
 
 
+def _load_all_extractions() -> dict[str, dict]:
+    """Load every .cache/extractions/*.json into memory keyed by arxiv_id."""
+    out: dict[str, dict] = {}
+    for p in sorted(EXTRACTIONS_DIR.glob("*.json")):
+        ext = json.loads(p.read_text())
+        aid = ext.get("arxiv_id")
+        if aid:
+            out[aid] = ext
+    return out
+
+
+def _build_row_index(extractions: dict[str, dict]) -> set[tuple[str, str, str]]:
+    """Index of (arxiv_id, benchmark, normalized name) for collapse cross-check."""
+    idx: set[tuple[str, str, str]] = set()
+    for aid, ext in extractions.items():
+        for bm in ext.get("benchmarks", []):
+            for m in bm.get("models", []):
+                idx.add((aid, bm["benchmark"], _norm_name(m.get("name_in_paper", ""))))
+    return idx
+
+
+def _classify_row(
+    citing_url: str,
+    is_score_original: str,
+    model_paper: str | None,
+    cited_paper: str | None,
+    benchmark: str,
+    name_in_paper: str,
+    row_index: set[tuple[str, str, str]],
+) -> tuple[str, str, str | None]:
+    """Resolve a row's attribution case. Returns (row_type, reported_paper, effective_cited_paper).
+
+    row_type is 'first_party', 'third_party', or 'drop' (canonical row
+    exists in the original paper's extraction — this row is redundant).
+    """
+    # Case 1: this paper introduces the method and ran it
+    if is_score_original == "original" and citing_url == model_paper:
+        return "first_party", citing_url, cited_paper
+
+    model_arxiv = _arxiv_id_of(model_paper)
+    cited_arxiv = _arxiv_id_of(cited_paper)
+
+    # Case 2: cited baseline pointing at the method's own paper
+    if (
+        is_score_original == "cited_baseline"
+        and model_arxiv
+        and cited_arxiv
+        and cited_arxiv == model_arxiv
+    ):
+        # Cross-check: does the original paper's extraction contain this row?
+        if (model_arxiv, benchmark, _norm_name(name_in_paper)) in row_index:
+            return "drop", "", None
+        # Cite unverified — demote to third_party and null out the cite
+        # so downstream treats it as citing-paper measured.
+        return "third_party", citing_url, None
+
+    # Case 3a/3b: third-party via arxiv cite
+    if is_score_original == "cited_baseline" and cited_arxiv:
+        return "third_party", cited_paper, cited_paper
+
+    # Case 3c / reproduction: citing paper measured it
+    return "third_party", citing_url, cited_paper
+
+
 def build_candidates(benchmark_filter: str | None = None) -> tuple[list[dict], dict]:
-    """Read extractions and emit candidate entries.
+    """Read extractions and emit candidate entries matching candidates.schema.json.
 
     Applied here (deterministic):
-    - Protocol gate: `yes` computes `overall_score` from components;
-      everything else (`no`/`partial`/`unknown`) keeps `overall_score = null`
-      but the row is retained so non-standard subsets still surface on the
-      leaderboard as unranked entries (see leaderboard/CONTRIBUTING.md).
-    - Arithmetic: mean of required component keys per the benchmark's
-      `aggregation` rule in benchmarks.json.
-    - Forbidden-overall enforcement for benchmarks with aggregation `"forbidden"`.
-    - Schema field population (reported_paper, reported_table, etc).
+    - Protocol gate: match='yes' → compute overall_score from components
+      (or use raw when no rule); everything else → overall_score=null,
+      paper's raw aggregate preserved in task_scores.reported_avg.
+    - Attribution decision table per candidates.schema.json row_type.
+    - Collapse cross-check: cited_baseline rows whose cited_paper IS
+      the method's own paper are dropped when the original paper's
+      extraction already has the canonical row, and demoted to
+      third_party otherwise.
 
-    NOT applied here (left to the LLM step):
+    NOT applied here (for the refine LLM):
     - Eligibility filter (junk labels, ablation variants)
     - Dedup across papers
     - Cross-benchmark identity consistency
-    - Substantive note composition
+    - Notes composition
 
-    Returns (candidates, stats) where stats tracks how each paper and row
-    was handled for pipeline audit.
+    Returns (candidates, stats).
     """
+    extractions = _load_all_extractions()
+    row_index = _build_row_index(extractions)
+
     candidates: list[dict] = []
     stats = {
         "extractions_total": 0,
-        "papers_empty": 0,  # extraction file had benchmarks:[] — citing paper, no scores
+        "papers_empty": 0,
         "papers_with_scores": 0,
         "rows_total": 0,
-        "rows_match_no_kept_null": 0,  # protocol=no rows kept with overall_score=null
+        "rows_dropped_collapse": 0,
+        "rows_match_no_kept_null": 0,
         "rows_drop_empty_after_conversion": 0,
-        "rows_kept": 0,
+        "rows_first_party": 0,
+        "rows_third_party": 0,
     }
-    for ext_file in sorted(EXTRACTIONS_DIR.glob("*.json")):
-        ext = json.loads(ext_file.read_text())
-        arxiv_id = ext.get("arxiv_id")
-        if not arxiv_id:
-            continue
+
+    for aid, ext in extractions.items():
         stats["extractions_total"] += 1
-        reported_paper = f"https://arxiv.org/abs/{arxiv_id}"
+        citing_url = _citing_url(aid)
         ext_benchmarks = ext.get("benchmarks") or []
         if not ext_benchmarks:
             stats["papers_empty"] += 1
@@ -143,60 +229,70 @@ def build_candidates(benchmark_filter: str | None = None) -> tuple[list[dict], d
                 continue
             for m in bm.get("models", []):
                 stats["rows_total"] += 1
+                name = m.get("name_in_paper", "")
                 protocol = m.get("protocol") or {}
                 match = protocol.get("matches_standard", "unknown")
                 scores_raw = m.get("scores") or {}
                 suite_scores = _to_plain_scores(scores_raw.get("suite_scores"))
                 task_scores = _to_plain_scores(scores_raw.get("task_scores"))
+                raw_overall = scores_raw.get("overall_score")
+
+                # Classify row first so we can short-circuit drops.
+                row_type, reported_paper, effective_cited = _classify_row(
+                    citing_url=citing_url,
+                    is_score_original=m.get("is_score_original", "unknown"),
+                    model_paper=m.get("model_paper"),
+                    cited_paper=m.get("cited_paper"),
+                    benchmark=benchmark,
+                    name_in_paper=name,
+                    row_index=row_index,
+                )
+                if row_type == "drop":
+                    stats["rows_dropped_collapse"] += 1
+                    continue
 
                 # Arithmetic / protocol gate.
-                #
-                # Only `matches_standard == "yes"` rows get an aggregated
-                # `overall_score`. Everything else (including the hard "no"
-                # case) keeps `overall_score = null` but stays in the
-                # candidate pool so non-standard subsets still appear on
-                # the leaderboard as non-ranked entries — see
-                # leaderboard/CONTRIBUTING.md "non-standard entries must
-                # set overall_score to null and store the original
-                # aggregate in task_scores.reported_avg".
                 if match == "yes":
                     overall = _compute_overall(benchmark, suite_scores, task_scores)
-                    # Fallback: if the benchmark has no aggregation rule at
-                    # all, trust the LLM-extracted overall. Forbidden rules
-                    # and partial-data cases keep overall=None.
+                    # Fallback: if the benchmark has no aggregation rule,
+                    # trust the paper's raw overall.
                     if overall is None and _aggregation_rules().get(benchmark) is None:
-                        raw_overall = scores_raw.get("overall_score")
                         if isinstance(raw_overall, (int, float)):
                             overall = raw_overall
                 else:
                     overall = None
                     if match == "no":
                         stats["rows_match_no_kept_null"] += 1
-                    # Non-standard-protocol preservation: per
-                    # leaderboard/CONTRIBUTING.md, an entry with a
-                    # reported aggregate but no component breakdown keeps
-                    # the paper's number in `task_scores.reported_avg`
-                    # (overall_score stays null so it does not rank).
-                    # Without this recovery the row would be dropped by
-                    # the empty-score check below.
-                    raw_overall = scores_raw.get("overall_score")
-                    if isinstance(raw_overall, (int, float)) and not task_scores and not suite_scores:
-                        task_scores = {"reported_avg": raw_overall}
 
-                # Skip entries with no score at all (schema requires >=1).
+                # reported_avg recovery. Any case where we did not end up
+                # with a ranked overall_score but the paper did report
+                # one → preserve that number in task_scores.reported_avg
+                # so the row survives the empty-score gate with
+                # overall_score=null. Applies to match='no'/'partial'/
+                # 'unknown' as well as match='yes' with partial-component
+                # data that couldn't satisfy the aggregation rule.
+                if (
+                    overall is None
+                    and isinstance(raw_overall, (int, float))
+                    and "reported_avg" not in task_scores
+                    and "reported_avg" not in suite_scores
+                ):
+                    task_scores = {**task_scores, "reported_avg": raw_overall}
+
                 if overall is None and not suite_scores and not task_scores:
                     stats["rows_drop_empty_after_conversion"] += 1
                     continue
 
-                stats["rows_kept"] += 1
+                weight_type = m.get("weight_type")
+                if weight_type not in ("shared", "finetuned"):
+                    weight_type = "shared"
+
                 candidates.append(
                     {
-                        "name_in_paper": m.get("label", ""),
-                        "params": m.get("params"),
                         "benchmark": benchmark,
-                        "weight_type": m.get("weight_type")
-                        if m.get("weight_type") in ("shared", "finetuned")
-                        else "shared",
+                        "name_in_paper": name,
+                        "params": m.get("params"),
+                        "weight_type": weight_type,
                         "overall_score": overall,
                         "suite_scores": suite_scores,
                         "task_scores": task_scores,
@@ -205,21 +301,30 @@ def build_candidates(benchmark_filter: str | None = None) -> tuple[list[dict], d
                         "protocol_match": match,
                         "protocol_rationale": protocol.get("rationale", ""),
                         "is_score_original": m.get("is_score_original", "unknown"),
+                        "model_paper": m.get("model_paper"),
+                        "cited_paper": effective_cited,
+                        "row_type": row_type,
                     }
                 )
+                if row_type == "first_party":
+                    stats["rows_first_party"] += 1
+                else:
+                    stats["rows_third_party"] += 1
+
     return candidates, stats
 
 
 def _print_stats(stats: dict) -> None:
-    """Print a one-page audit of what build_candidates() did."""
     print(
         f"Extractions scanned: {stats['extractions_total']}\n"
         f"  papers with scores:              {stats['papers_with_scores']}\n"
         f"  papers empty (cited, no scores): {stats['papers_empty']}\n"
         f"Model rows processed: {stats['rows_total']}\n"
-        f"  match=no kept with null overall: {stats['rows_match_no_kept_null']}\n"
-        f"  dropped (no score after conv):   {stats['rows_drop_empty_after_conversion']}\n"
-        f"  kept as candidates:              {stats['rows_kept']}"
+        f"  collapse → dropped (canonical row in original): {stats['rows_dropped_collapse']}\n"
+        f"  match=no kept with null overall:                {stats['rows_match_no_kept_null']}\n"
+        f"  dropped (no score after conv):                  {stats['rows_drop_empty_after_conversion']}\n"
+        f"  kept first_party:                               {stats['rows_first_party']}\n"
+        f"  kept third_party:                               {stats['rows_third_party']}"
     )
 
 
@@ -228,153 +333,107 @@ def _print_stats(stats: dict) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _build_system_prompt() -> str:
+def _benchmark_rules(benchmark: str) -> str:
+    """Return the md body for one benchmark (frontmatter stripped)."""
+    path = BENCHMARKS_DIR / f"{benchmark}.md"
+    if not path.exists():
+        return ""
+    text = path.read_text(encoding="utf-8")
+    if text.startswith("---"):
+        end = text.find("---", 3)
+        if end != -1:
+            text = text[end + 3 :].strip()
+    return text
+
+
+def _build_system_prompt(benchmark: str, rules: str) -> str:
     return f"""You are the PRECISION stage of a two-stage VLA leaderboard pipeline.
 
-An EXTRACT stage (with Read access to each paper) produced the candidates at
-`{CANDIDATES_PATH}`. A deterministic Python step has already applied the
-protocol gate: rows with `protocol_match == "yes"` have `overall_score`
-computed from component scores; all other rows keep `overall_score = null`
-but are retained.
+Your objective at this stage is precision, not recall. An upstream
+EXTRACT stage optimized for recall and surfaced every candidate that
+could belong on the leaderboard; you keep only the canonical ones.
+Apply filters aggressively — when in doubt, drop. A small leaderboard
+of canonical entries beats a large one with ablation junk.
 
-You do NOT have paper access at this stage. All paper-derived context is
-already in the candidate fields — rely on them.
+Candidate rows are at `{CANDIDATES_PATH}`. Field semantics and per-row
+invariants are defined in `{CANDIDATES_SCHEMA_PATH}` — read it, and
+follow the `row_type` dispatch in the description of that field
+exactly.
 
-## Candidate fields
+You do not have paper access at this stage. Rely on the candidate
+fields. `overall_score` and `model_paper` are authoritative — pass
+them through unchanged.
 
-Each candidate is one (paper × benchmark × model) row with:
+## Your job (in order)
 
-- `name_in_paper`: the canonical method name the extract stage resolved
-  from the paper. Treat as already cleaned — do not re-derive.
-- `params`, `benchmark`, `weight_type`
-- `overall_score`: computed by the python step. Never recompute or change.
-- `suite_scores`, `task_scores`: component scores, plain numbers
-- `reported_paper`, `reported_table`
-- `protocol_match`: `"yes"` / `"no"` / `"partial"` / `"unknown"`
-- `protocol_rationale`: the extract stage's reasoning — use as the basis
-  for `notes`
-- `is_score_original`: `"original"` / `"cited_baseline"` / `"reproduction"`
-  / `"unknown"`
+1. **Drop ineligible rows.** Any candidate whose `name_in_paper` is
+   still a generic label ("Ours", "Baseline", "(b)", "variant X",
+   "Ablation") is unattributable — drop. Also drop variants whose only
+   differentiator is quantization (INT4, AWQ), PEFT (LoRA), training
+   stage ("w/o pretrain"), or hyperparameter sweep. When in doubt
+   about whether a row is a genuine method vs an ablation, drop.
 
-## Your job
+2. **Dedup within (model, benchmark, reported_paper).** Keep the row
+   with the richest scores. Distinct reported_paper values always
+   remain distinct entries.
 
-Apply filters aggressively; when in doubt, drop. A small leaderboard of
-canonical entries beats a large one with ablation junk.
+3. **Assign `model`, `display_name`, `reported_paper`** per the
+   row_type rules in the schema. Keep these consistent across a
+   method's first-party entries.
 
-### 1. Drop failed-resolution rows
+4. **Compose `notes`** from `protocol_rationale` (trim long ones).
+   Append origin context when useful — non-standard subset details,
+   training budget, architecture class. When `cited_paper` is a
+   non-arxiv URL, mention it in notes. Never leave notes blank or
+   boilerplate.
 
-Drop any row whose `name_in_paper` is still a generic label — "Ours",
-"Our Method", "Our Model", "Proposed", "This Work", "Baseline", "(Ours)",
-"Ablation", "(b)", "(c)", "variant X", or similar. The extract stage was
-supposed to resolve these to the method's real name. Since you cannot
-read the paper, a generic label means the row is not attributable.
+## Benchmark scope: {benchmark}
 
-### 2. Drop ablation / variant rows
-
-Drop rows whose only differentiator is:
-- quantization (INT4, INT8, AWQ, PTQ, QAT, GPTQ, ...)
-- parameter-efficient tuning (LoRA, QLoRA, adapter, ...)
-- training-stage snapshots ("stage 1", "50% data", "w/o pretrain")
-- horizon / chunk / hyperparameter sweeps ("k=1", "chunk=8")
-- "+feature X" / "w/o Y" style tags
-
-Unless the variant IS the paper's main contribution.
-
-### 3. Dedup
-
-Distinct `reported_paper`s produce distinct entries — never collapse a
-third-party measurement into a first-party canonical row. Within a single
-`(model, benchmark, reported_paper)` triple, collapse duplicates and keep
-the row with the most score detail.
-
-### 4. Cross-benchmark identity
-
-A model's first-party entries across benchmarks carry the same
-`display_name`, `params`, and `model_paper`. Pick the most canonical
-values. Third-party entries inherit the underlying method's canonical
-values.
-
-### 5. Assign `model` and `display_name`
-
-`model` is a BibTeX-style key encoding provenance:
-
-- First-party (`reported_paper == model_paper`):
-  - `model: kim24openvla`, `display_name: "OpenVLA"`
-- Third-party measurement:
-  - `model: kim24openvla__black24xvla`, `display_name: "OpenVLA (from X-VLA)"`
-
-`display_name` for third-party entries makes the measuring paper obvious
-to a reader scanning the leaderboard.
-
-### 6. Compose `notes`
-
-Base on `protocol_rationale` (trim if long), append origin info. Write
-something specific:
-
-- OK: "ABC→D split with 1000 evaluation chains; avg_len metric; reproduction"
-- OK: "18/18 PerAct tasks, single camera view; cited from RVT paper Table 2"
-- Bad: "partial protocol match"
-- Bad: ""
-
-## Benchmark rules
-
-Each block in `leaderboard/benchmarks/*.md` opens with `**Standard**: ...`
-(the canonical protocol). You already have resolved scores, so consult
-these only for dedup / identity / notes context.
+{rules}
 
 ## Output
 
-Write `{LEADERBOARD_PATH}`:
+Write a JSON array of leaderboard entries to the output path specified
+in the user message. Each entry matches `{LEADERBOARD_SCHEMA_PATH}`:
 
-```
-{{
-  "last_updated": "{date.today().isoformat()}",
-  "results": [<entry>, ...]
-}}
-```
-
-Each entry matches `{SCHEMA_PATH}` with fields: `model`, `display_name`,
-`name_in_paper`, `params`, `model_paper`, `benchmark`, `weight_type`,
-`overall_score`, `suite_scores`, `task_scores`, `reported_paper`,
-`reported_table`, `curated_by`, `date_added`, `notes`.
-
-- Copy `name_in_paper` verbatim from the candidate. Never blank it out,
-  never synthesize from `display_name`.
-- `curated_by` uses the form `"<family> <version>"` — e.g. `"opus 4.6"`,
-  `"sonnet 4.6"`. The schema rejects `"claude-sonnet-4-6"` and similar.
+- Copy `name_in_paper` verbatim from the candidate.
+- `curated_by = "opus 4.6"` (or the model you are).
 - `date_added = "{date.today().isoformat()}"`.
-- `results` sorted by `(benchmark, model)`. UTF-8, trailing newline.
-
-Never touch `overall_score` — the python step computed it.
+- Do not emit a top-level wrapper — write the array directly.
 
 Report what you dropped and why when you finish.
 """
 
 
-def refine(
-    model: str = "opus",
-    benchmark: str | None = None,
-    output: Path = LEADERBOARD_PATH,
-    timeout: int = 7200,
-) -> None:
-    # Stage 1: build candidates (deterministic)
-    print("Stage 1: building candidates from extractions...")
-    candidates, stats = build_candidates(benchmark_filter=benchmark)
+def _refine_one_benchmark(
+    benchmark: str,
+    candidates: list[dict],
+    output_path: Path,
+    model: str,
+    timeout: int,
+) -> list[dict]:
+    """Run the LLM refine step for a single benchmark's candidates.
+
+    Writes candidates to a temp file the LLM reads, invokes claude CLI,
+    returns the list of leaderboard entries (empty on failure).
+    """
+    bm_candidates = [c for c in candidates if c["benchmark"] == benchmark]
+    if not bm_candidates:
+        return []
+
+    scratch_in = REFINE_LOGS_DIR / f"candidates_{benchmark}.json"
+    scratch_out = REFINE_LOGS_DIR / f"out_{benchmark}.json"
+    REFINE_LOGS_DIR.mkdir(parents=True, exist_ok=True)
     CANDIDATES_PATH.parent.mkdir(parents=True, exist_ok=True)
-    CANDIDATES_PATH.write_text(json.dumps(candidates, indent=2, ensure_ascii=False) + "\n")
-    _print_stats(stats)
-    print(f"Wrote {CANDIDATES_PATH}")
+    CANDIDATES_PATH.write_text(json.dumps(bm_candidates, indent=2, ensure_ascii=False) + "\n")
+    scratch_in.write_text(json.dumps(bm_candidates, indent=2, ensure_ascii=False) + "\n")
 
-    if not candidates:
-        print("No candidates to refine. Exiting.")
-        return
-
-    # Stage 2: launch LLM agent for fuzzy decisions
-    system_prompt = _build_system_prompt()
-    scope = f"benchmark {benchmark}" if benchmark else "all benchmarks"
+    rules = _benchmark_rules(benchmark)
+    system_prompt = _build_system_prompt(benchmark, rules)
     user_msg = (
-        f"Refine {len(candidates)} candidates for {scope}. "
-        f"Candidates are at {CANDIDATES_PATH}. Write the final leaderboard to {output}."
+        f"Refine {len(bm_candidates)} candidates for benchmark '{benchmark}'. "
+        f"Read them from {CANDIDATES_PATH}. Write a JSON array of "
+        f"leaderboard entries to {scratch_out}."
     )
 
     cmd = [
@@ -390,26 +449,85 @@ def refine(
         "--permission-mode",
         "bypassPermissions",
         "--no-session-persistence",
+        "--add-dir",
+        str(REFINE_LOGS_DIR.resolve()),
+        "--add-dir",
+        str(CANDIDATES_PATH.parent.resolve()),
         user_msg,
     ]
 
-    log_path = REFINE_LOGS_DIR / f"refine_{date.today().isoformat()}.log"
-    print(f"Stage 2: launching claude ({model}) for fuzzy decisions on {scope}...")
+    log_path = REFINE_LOGS_DIR / f"refine_{benchmark}_{date.today().isoformat()}.log"
+    print(f"  [{benchmark}] {len(bm_candidates)} candidates → LLM ({model})...")
     result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
-
-    log_path.parent.mkdir(parents=True, exist_ok=True)
     log_path.write_text(result.stdout, encoding="utf-8")
-
     if result.returncode != 0:
-        print(f"claude exited with code {result.returncode}")
-        raise SystemExit(result.returncode)
+        print(f"  [{benchmark}] claude exit {result.returncode}: {result.stderr[:300]}")
+        return []
 
-    if output.exists():
-        data = json.loads(output.read_text())
-        n = len(data.get("results", []))
-        print(f"Done: {output} ({n} entries)")
-    else:
-        print(f"Warning: {output} was not created")
+    if not scratch_out.exists():
+        print(f"  [{benchmark}] no output file written")
+        return []
+    try:
+        entries = json.loads(scratch_out.read_text())
+    except json.JSONDecodeError as e:
+        print(f"  [{benchmark}] invalid JSON output: {e}")
+        return []
+    if not isinstance(entries, list):
+        print(f"  [{benchmark}] output is not an array (got {type(entries).__name__})")
+        return []
+    print(f"  [{benchmark}] LLM produced {len(entries)} entries")
+    return entries
+
+
+def _merge_leaderboard(
+    new_entries: list[dict],
+    benchmarks_touched: list[str],
+    output_path: Path,
+) -> None:
+    """Merge per-benchmark results into leaderboard.json.
+
+    Entries for benchmarks_touched are replaced; entries for other
+    benchmarks are preserved from the existing file. Results are sorted
+    by (benchmark, model).
+    """
+    existing: list[dict] = []
+    if output_path.exists():
+        data = json.loads(output_path.read_text())
+        existing = data.get("results", [])
+    kept = [e for e in existing if e.get("benchmark") not in benchmarks_touched]
+    merged = kept + new_entries
+    merged.sort(key=lambda r: (r.get("benchmark", ""), r.get("model", "")))
+    out = {"last_updated": date.today().isoformat(), "results": merged}
+    output_path.write_text(json.dumps(out, indent=2, ensure_ascii=False) + "\n")
+
+
+def refine(
+    model: str = "opus",
+    benchmark: str | None = None,
+    output: Path = LEADERBOARD_PATH,
+    timeout: int = 7200,
+) -> None:
+    print("Stage 1: building candidates from extractions...")
+    candidates, stats = build_candidates(benchmark_filter=benchmark)
+    CANDIDATES_PATH.parent.mkdir(parents=True, exist_ok=True)
+    CANDIDATES_PATH.write_text(json.dumps(candidates, indent=2, ensure_ascii=False) + "\n")
+    _print_stats(stats)
+    print(f"Wrote {CANDIDATES_PATH}")
+
+    if not candidates:
+        print("No candidates to refine. Exiting.")
+        return
+
+    # Group by benchmark and run LLM per-benchmark.
+    benchmarks = sorted({c["benchmark"] for c in candidates})
+    print(f"\nStage 2: refining {len(benchmarks)} benchmark(s) with {model}...")
+    all_entries: list[dict] = []
+    for bm in benchmarks:
+        entries = _refine_one_benchmark(bm, candidates, output, model=model, timeout=timeout)
+        all_entries.extend(entries)
+
+    _merge_leaderboard(all_entries, benchmarks, output)
+    print(f"\nDone: {output} now has {len(all_entries)} new entries across {len(benchmarks)} benchmark(s)")
 
 
 # ---------------------------------------------------------------------------
@@ -424,9 +542,9 @@ def main(
     output: Annotated[Path, typer.Option("-o", help="Output path.")] = LEADERBOARD_PATH,
     benchmark: Annotated[Optional[str], typer.Option(help="Only refine this benchmark.")] = None,
     model: Annotated[str, typer.Option(help="Claude model for the fuzzy stage.")] = "opus",
-    timeout: Annotated[int, typer.Option(help="LLM timeout in seconds.")] = 7200,
+    timeout: Annotated[int, typer.Option(help="Per-benchmark LLM timeout in seconds.")] = 7200,
 ) -> None:
-    """Refine extractions into leaderboard.json (python pre-step + LLM fuzzy stage)."""
+    """Refine extractions into leaderboard.json (python pre-step + per-benchmark LLM stage)."""
     refine(model=model, benchmark=benchmark, output=output, timeout=timeout)
 
 

--- a/leaderboard/scripts/refine.py
+++ b/leaderboard/scripts/refine.py
@@ -157,12 +157,7 @@ def _classify_row(
     cited_arxiv = _arxiv_id_of(cited_paper)
 
     # Case 2: cited baseline pointing at the method's own paper
-    if (
-        is_score_original == "cited_baseline"
-        and model_arxiv
-        and cited_arxiv
-        and cited_arxiv == model_arxiv
-    ):
+    if is_score_original == "cited_baseline" and model_arxiv and cited_arxiv and cited_arxiv == model_arxiv:
         # Cross-check: does the original paper's extraction contain this row?
         if (model_arxiv, benchmark, _norm_name(name_in_paper)) in row_index:
             return "drop", "", None
@@ -170,8 +165,9 @@ def _classify_row(
         # so downstream treats it as citing-paper measured.
         return "third_party", citing_url, None
 
-    # Case 3a/3b: third-party via arxiv cite
-    if is_score_original == "cited_baseline" and cited_arxiv:
+    # Case 3a/3b: third-party via arxiv cite. cited_arxiv being truthy
+    # means cited_paper parsed as an arxiv URL, so it is a str here.
+    if is_score_original == "cited_baseline" and cited_arxiv and cited_paper is not None:
         return "third_party", cited_paper, cited_paper
 
     # Case 3c / reproduction: citing paper measured it
@@ -411,15 +407,17 @@ def _refine_one_benchmark(
     output_path: Path,
     model: str,
     timeout: int,
-) -> list[dict]:
+) -> list[dict] | None:
     """Run the LLM refine step for a single benchmark's candidates.
 
-    Writes candidates to a temp file the LLM reads, invokes claude CLI,
-    returns the list of leaderboard entries (empty on failure).
+    Returns the list of leaderboard entries on success (possibly empty
+    if the LLM intentionally kept nothing). Returns None on LLM failure,
+    so the caller can distinguish "LLM said drop everything" from "LLM
+    crashed" and avoid wiping existing entries in the latter case.
     """
     bm_candidates = [c for c in candidates if c["benchmark"] == benchmark]
     if not bm_candidates:
-        return []
+        return None
 
     scratch_in = REFINE_LOGS_DIR / f"candidates_{benchmark}.json"
     scratch_out = REFINE_LOGS_DIR / f"out_{benchmark}.json"
@@ -449,32 +447,37 @@ def _refine_one_benchmark(
         "--permission-mode",
         "bypassPermissions",
         "--no-session-persistence",
+        # Restrict to Claude Code native tools only. Without this the
+        # refine stage has been observed pulling in external knowledge
+        # via Perplexity (or other MCP servers), which undermines the
+        # paper-grounded attribution discipline the pipeline depends on.
+        "--strict-mcp-config",
+        "--disable-slash-commands",
         "--add-dir",
         str(REFINE_LOGS_DIR.resolve()),
         "--add-dir",
         str(CANDIDATES_PATH.parent.resolve()),
-        user_msg,
     ]
 
     log_path = REFINE_LOGS_DIR / f"refine_{benchmark}_{date.today().isoformat()}.log"
     print(f"  [{benchmark}] {len(bm_candidates)} candidates → LLM ({model})...")
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    result = subprocess.run(cmd, input=user_msg, capture_output=True, text=True, timeout=timeout)
     log_path.write_text(result.stdout, encoding="utf-8")
     if result.returncode != 0:
         print(f"  [{benchmark}] claude exit {result.returncode}: {result.stderr[:300]}")
-        return []
+        return None
 
     if not scratch_out.exists():
         print(f"  [{benchmark}] no output file written")
-        return []
+        return None
     try:
         entries = json.loads(scratch_out.read_text())
     except json.JSONDecodeError as e:
         print(f"  [{benchmark}] invalid JSON output: {e}")
-        return []
+        return None
     if not isinstance(entries, list):
         print(f"  [{benchmark}] output is not an array (got {type(entries).__name__})")
-        return []
+        return None
     print(f"  [{benchmark}] LLM produced {len(entries)} entries")
     return entries
 
@@ -518,16 +521,27 @@ def refine(
         print("No candidates to refine. Exiting.")
         return
 
-    # Group by benchmark and run LLM per-benchmark.
+    # Group by benchmark and run LLM per-benchmark. Only benchmarks
+    # whose LLM stage ran to completion are passed to the merge step;
+    # on LLM failure, the existing leaderboard entries for that
+    # benchmark are preserved rather than wiped to nothing.
     benchmarks = sorted({c["benchmark"] for c in candidates})
     print(f"\nStage 2: refining {len(benchmarks)} benchmark(s) with {model}...")
     all_entries: list[dict] = []
+    touched: list[str] = []
     for bm in benchmarks:
         entries = _refine_one_benchmark(bm, candidates, output, model=model, timeout=timeout)
+        if entries is None:
+            print(f"  [{bm}] LLM step did not produce output — preserving existing entries")
+            continue
+        touched.append(bm)
         all_entries.extend(entries)
 
-    _merge_leaderboard(all_entries, benchmarks, output)
-    print(f"\nDone: {output} now has {len(all_entries)} new entries across {len(benchmarks)} benchmark(s)")
+    _merge_leaderboard(all_entries, touched, output)
+    print(
+        f"\nDone: {output} refreshed {len(touched)} benchmark(s) "
+        f"({len(all_entries)} new entries); {len(benchmarks) - len(touched)} preserved"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/leaderboard/scripts/validate.py
+++ b/leaderboard/scripts/validate.py
@@ -180,6 +180,38 @@ def validate_citations(data: dict) -> list[str]:
     return errors
 
 
+def validate_scale_sanity(data: dict) -> list[str]:
+    """Catch probable scale leaks (e.g. paper 0-1 values copied verbatim to a 0-100 %-benchmark).
+
+    Flag when a row has ≥2 non-zero numeric scores across task_scores and
+    suite_scores, and ALL of them are ≤ 1.0, on a benchmark whose declared
+    metric.range upper bound is ≥ 10. A single sub-1.0 task score is valid
+    (hard task failure); multiple together almost always means the paper's
+    0-1 scale was not converted to %.
+    """
+    errors = []
+    for i, r in enumerate(data["results"]):
+        bm = data["benchmarks"].get(r["benchmark"], {})
+        rule_range = bm.get("metric", {}).get("range", [0, 100])
+        if rule_range[1] < 10:
+            # Benchmark itself runs on a small scale (e.g. CALVIN 0-5) — cannot use this heuristic
+            continue
+        values = []
+        for score_dict in (r.get("task_scores") or {}, r.get("suite_scores") or {}):
+            for k, v in score_dict.items():
+                if k == "reported_avg":
+                    continue
+                if isinstance(v, (int, float)) and v > 0:
+                    values.append(v)
+        if len(values) >= 2 and all(v <= 1.0 for v in values):
+            errors.append(
+                f"results[{i}] ({r['model']}/{r['benchmark']}): probable scale leak — "
+                f"all {len(values)} non-zero scores are ≤ 1.0 on a benchmark with range {rule_range}. "
+                f"The paper likely reports values on a 0-1 scale; multiply by 100 before emitting."
+            )
+    return errors
+
+
 def validate_aggregation_rules(data: dict) -> list[str]:
     """Check each entry's overall_score against the benchmark's aggregation rule.
 
@@ -266,6 +298,7 @@ def main() -> int:
     # registry never leaks back into leaderboard.json.
     data["benchmarks"] = benchmarks
     errors += validate_score_ranges(data)
+    errors += validate_scale_sanity(data)
     errors += validate_aggregation_rules(data)
     errors += validate_official_leaderboard_policy(data)
     errors += validate_papers_reviewed(data)

--- a/leaderboard/tests/test_refine.py
+++ b/leaderboard/tests/test_refine.py
@@ -1,0 +1,549 @@
+"""Deterministic-logic tests for leaderboard/scripts/refine.py.
+
+Covers the parts that do NOT need an LLM: URL parsing, aggregation-rule
+math, the row_type decision table, collapse cross-check, reported_avg
+recovery, and leaderboard merging.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# The scripts are UV-run-style (# /// script) with typer as an inline dep
+# rather than a project dependency, so typer is not installed in the
+# pytest venv. Stub it out so the module-level imports succeed — we do
+# not exercise the CLI surface from these tests.
+sys.modules.setdefault("typer", MagicMock())
+
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+import refine  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# URL helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        ("https://arxiv.org/abs/2410.12345", "2410.12345"),
+        ("http://arxiv.org/abs/2410.12345", "2410.12345"),
+        ("https://arxiv.org/abs/2410.12345v2", "2410.12345"),
+        ("https://arxiv.org/abs/2410.1234", "2410.1234"),
+        ("https://github.com/foo/bar", None),
+        ("https://proceedings.mlr.press/v1/paper.pdf", None),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_arxiv_id_of(url, expected):
+    assert refine._arxiv_id_of(url) == expected
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("OpenVLA", "openvla"),
+        ("PMP (Ours)", "pmp"),
+        ("  PointMapPolicy  ", "pointmappolicy"),
+        ("3D Diffuser Actor", "3ddiffuseractor"),
+        ("X-VLA", "xvla"),
+    ],
+)
+def test_norm_name(name, expected):
+    assert refine._norm_name(name) == expected
+
+
+# ---------------------------------------------------------------------------
+# Aggregation rule arithmetic
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_rules(monkeypatch):
+    """Stub _aggregation_rules so tests do not depend on benchmarks.json state."""
+    rules = {
+        "libero": {
+            "container": "suite_scores",
+            "keys": ["libero_spatial", "libero_object", "libero_goal", "libero_10"],
+        },
+        "mikasa": {
+            "container": "task_scores",
+            "keys": [
+                "ShellGameTouch",
+                "InterceptMedium",
+                "RememberColor3",
+                "RememberColor5",
+                "RememberColor9",
+            ],
+        },
+        "simpler_env": "forbidden",
+        # calvin: absent → no rule
+    }
+    monkeypatch.setattr(refine, "_aggregation_rules", lambda: rules)
+    yield
+
+
+def test_compute_overall_libero_complete(mock_rules):
+    suite = {"libero_spatial": 80, "libero_object": 85, "libero_goal": 90, "libero_10": 75}
+    assert refine._compute_overall("libero", suite, {}) == 82.5
+
+
+def test_compute_overall_libero_partial_returns_none(mock_rules):
+    suite = {"libero_spatial": 80, "libero_object": 85, "libero_goal": 90}
+    assert refine._compute_overall("libero", suite, {}) is None
+
+
+def test_compute_overall_simpler_env_forbidden(mock_rules):
+    suite = {"google_robot_vm": 50, "google_robot_va": 45, "widowx_vm": 30}
+    assert refine._compute_overall("simpler_env", suite, {}) is None
+
+
+def test_compute_overall_calvin_no_rule(mock_rules):
+    assert refine._compute_overall("calvin", {"1_task": 90}, {}) is None
+
+
+def test_compute_overall_mikasa_task_container(mock_rules):
+    task = {
+        "ShellGameTouch": 50,
+        "InterceptMedium": 60,
+        "RememberColor3": 70,
+        "RememberColor5": 65,
+        "RememberColor9": 55,
+    }
+    assert refine._compute_overall("mikasa", {}, task) == 60.0
+
+
+# ---------------------------------------------------------------------------
+# Row classification decision table
+# ---------------------------------------------------------------------------
+
+
+def _classify(**kwargs):
+    defaults = {
+        "citing_url": "https://arxiv.org/abs/2501.11111",
+        "is_score_original": "original",
+        "model_paper": None,
+        "cited_paper": None,
+        "benchmark": "libero",
+        "name_in_paper": "TestMethod",
+        "row_index": set(),
+    }
+    defaults.update(kwargs)
+    return refine._classify_row(**defaults)
+
+
+def test_classify_first_party_citing_equals_model_paper():
+    row_type, reported, cited = _classify(
+        citing_url="https://arxiv.org/abs/2406.09246",
+        is_score_original="original",
+        model_paper="https://arxiv.org/abs/2406.09246",
+        cited_paper=None,
+    )
+    assert row_type == "first_party"
+    assert reported == "https://arxiv.org/abs/2406.09246"
+    assert cited is None
+
+
+def test_classify_original_but_citing_neq_model_paper_is_third_party():
+    # is_score_original='original' but citing paper is not the model's paper
+    # → paper ran the method; credit the citing paper as measurer.
+    row_type, reported, _ = _classify(
+        citing_url="https://arxiv.org/abs/2501.11111",
+        is_score_original="original",
+        model_paper="https://arxiv.org/abs/2406.09246",
+        cited_paper=None,
+    )
+    assert row_type == "third_party"
+    assert reported == "https://arxiv.org/abs/2501.11111"
+
+
+def test_classify_collapse_hit_drops_row():
+    # cited_paper's arxiv == model_paper's arxiv; original paper's extraction
+    # contains the matching row → this row is redundant and drops.
+    row_index = {("2406.09246", "libero", "openvla")}
+    row_type, _, _ = _classify(
+        is_score_original="cited_baseline",
+        model_paper="https://arxiv.org/abs/2406.09246",
+        cited_paper="https://arxiv.org/abs/2406.09246",
+        name_in_paper="OpenVLA",
+        row_index=row_index,
+    )
+    assert row_type == "drop"
+
+
+def test_classify_collapse_miss_demotes_and_nulls_cited():
+    # cited arxiv == model arxiv but original paper's extraction lacks the row
+    # → cite unverified. Demote to third_party crediting citing paper;
+    # null out cited_paper so downstream does not carry the unverified link.
+    row_type, reported, cited = _classify(
+        citing_url="https://arxiv.org/abs/2501.11111",
+        is_score_original="cited_baseline",
+        model_paper="https://arxiv.org/abs/2406.09246",
+        cited_paper="https://arxiv.org/abs/2406.09246",
+        name_in_paper="OpenVLA",
+        row_index=set(),
+    )
+    assert row_type == "third_party"
+    assert reported == "https://arxiv.org/abs/2501.11111"
+    assert cited is None
+
+
+def test_classify_third_party_via_different_arxiv_cite():
+    row_type, reported, cited = _classify(
+        citing_url="https://arxiv.org/abs/2501.11111",
+        is_score_original="cited_baseline",
+        model_paper="https://arxiv.org/abs/2406.09246",
+        cited_paper="https://arxiv.org/abs/2410.00000",
+        name_in_paper="OpenVLA",
+    )
+    assert row_type == "third_party"
+    assert reported == "https://arxiv.org/abs/2410.00000"
+    assert cited == "https://arxiv.org/abs/2410.00000"
+
+
+def test_classify_pi0_github_case_stays_citing_attributed():
+    # π₀ scenario: citing paper attributes a LIBERO score to π₀'s official
+    # github (non-arxiv). π₀'s own paper has no such LIBERO score — we MUST
+    # NOT collapse to π₀ paper. Row stays third_party crediting citing.
+    row_type, reported, cited = _classify(
+        citing_url="https://arxiv.org/abs/2501.11111",
+        is_score_original="cited_baseline",
+        model_paper="https://arxiv.org/abs/2410.24164",
+        cited_paper="https://github.com/physical-intelligence/openpi",
+        name_in_paper="pi_0",
+    )
+    assert row_type == "third_party"
+    assert reported == "https://arxiv.org/abs/2501.11111"
+    assert cited == "https://github.com/physical-intelligence/openpi"
+
+
+def test_classify_reproduction_is_third_party():
+    row_type, reported, _ = _classify(
+        citing_url="https://arxiv.org/abs/2501.11111",
+        is_score_original="reproduction",
+        model_paper="https://arxiv.org/abs/2406.09246",
+        cited_paper=None,
+        name_in_paper="OpenVLA",
+    )
+    assert row_type == "third_party"
+    assert reported == "https://arxiv.org/abs/2501.11111"
+
+
+def test_classify_unknown_with_no_cite_is_third_party():
+    row_type, reported, _ = _classify(
+        is_score_original="unknown",
+        model_paper="https://arxiv.org/abs/2406.09246",
+        cited_paper=None,
+    )
+    assert row_type == "third_party"
+
+
+# ---------------------------------------------------------------------------
+# Merge helper
+# ---------------------------------------------------------------------------
+
+
+def test_merge_leaderboard_replaces_only_touched_benchmarks(tmp_path):
+    existing = {
+        "last_updated": "2026-01-01",
+        "results": [
+            {"model": "a", "benchmark": "libero"},
+            {"model": "b", "benchmark": "calvin"},
+            {"model": "c", "benchmark": "libero"},
+        ],
+    }
+    output = tmp_path / "leaderboard.json"
+    output.write_text(json.dumps(existing))
+    new_entries = [{"model": "x", "benchmark": "libero"}]
+    refine._merge_leaderboard(new_entries, ["libero"], output)
+
+    result = json.loads(output.read_text())
+    libero_models = sorted(r["model"] for r in result["results"] if r["benchmark"] == "libero")
+    calvin_models = sorted(r["model"] for r in result["results"] if r["benchmark"] == "calvin")
+    assert libero_models == ["x"]
+    assert calvin_models == ["b"]
+    # Sorted by (benchmark, model)
+    bms = [(r["benchmark"], r["model"]) for r in result["results"]]
+    assert bms == sorted(bms)
+
+
+def test_merge_leaderboard_on_missing_existing_file(tmp_path):
+    output = tmp_path / "leaderboard.json"
+    refine._merge_leaderboard(
+        [{"model": "m", "benchmark": "libero"}],
+        ["libero"],
+        output,
+    )
+    data = json.loads(output.read_text())
+    assert len(data["results"]) == 1
+    assert data["last_updated"]  # today
+
+
+# ---------------------------------------------------------------------------
+# build_candidates end-to-end with synthetic extractions
+# ---------------------------------------------------------------------------
+
+
+def _make_row(
+    name: str,
+    *,
+    is_score_original: str = "original",
+    model_paper: str | None = None,
+    cited_paper: str | None = None,
+    match: str = "yes",
+    overall: float | None = None,
+    suite: dict | None = None,
+    task: dict | None = None,
+) -> dict:
+    return {
+        "name_in_paper": name,
+        "weight_type": "shared",
+        "is_score_original": is_score_original,
+        "model_paper": model_paper,
+        "cited_paper": cited_paper,
+        "scores": {
+            "overall_score": overall,
+            "suite_scores": {k: {"value": v, "quote": ""} for k, v in (suite or {}).items()},
+            "task_scores": {k: {"value": v, "quote": ""} for k, v in (task or {}).items()},
+        },
+        "protocol": {"matches_standard": match, "rationale": "fixture"},
+    }
+
+
+def _make_extraction(arxiv_id: str, benchmark: str, rows: list[dict]) -> dict:
+    return {
+        "arxiv_id": arxiv_id,
+        "extracted_at": "2026-04-17T00:00:00Z",
+        "paper_hash": f"sha256:{arxiv_id}",
+        "extraction_scope": [benchmark],
+        "benchmarks": [{"benchmark": benchmark, "models": rows}],
+    }
+
+
+def _write_extractions(tmp_path: Path, monkeypatch, extractions: list[dict]) -> None:
+    ext_dir = tmp_path / "extractions"
+    ext_dir.mkdir()
+    for ext in extractions:
+        (ext_dir / f"{ext['arxiv_id']}.json").write_text(json.dumps(ext))
+    monkeypatch.setattr(refine, "EXTRACTIONS_DIR", ext_dir)
+
+
+def test_build_candidates_yes_complete_suite_computes_overall(tmp_path, monkeypatch, mock_rules):
+    ext = _make_extraction(
+        "2500.00001",
+        "libero",
+        [
+            _make_row(
+                "TestMethod",
+                model_paper="https://arxiv.org/abs/2500.00001",
+                overall=85.7,
+                suite={"libero_spatial": 80, "libero_object": 85, "libero_goal": 90, "libero_10": 75},
+            )
+        ],
+    )
+    _write_extractions(tmp_path, monkeypatch, [ext])
+
+    candidates, stats = refine.build_candidates()
+    assert len(candidates) == 1
+    c = candidates[0]
+    assert c["overall_score"] == 82.5  # computed mean, not the paper's 85.7
+    assert c["row_type"] == "first_party"
+
+
+def test_build_candidates_yes_partial_preserves_raw_in_reported_avg(tmp_path, monkeypatch, mock_rules):
+    # Regression for defect B: match=yes + aggregation rule + partial
+    # components + raw overall → overall_score=None, raw lands in
+    # task_scores.reported_avg.
+    ext = _make_extraction(
+        "2500.00001",
+        "libero",
+        [
+            _make_row(
+                "TestMethod",
+                model_paper="https://arxiv.org/abs/2500.00001",
+                overall=85.7,
+                suite={"libero_spatial": 80, "libero_object": 85, "libero_goal": 90},
+            )
+        ],
+    )
+    _write_extractions(tmp_path, monkeypatch, [ext])
+
+    candidates, _ = refine.build_candidates()
+    assert len(candidates) == 1
+    c = candidates[0]
+    assert c["overall_score"] is None
+    assert c["task_scores"].get("reported_avg") == 85.7
+    assert "libero_spatial" in c["suite_scores"]
+
+
+def test_build_candidates_match_no_with_overall_preserves_reported_avg(tmp_path, monkeypatch, mock_rules):
+    ext = _make_extraction(
+        "2500.00001",
+        "libero",
+        [
+            _make_row(
+                "TestMethod",
+                model_paper="https://arxiv.org/abs/2500.00001",
+                match="no",
+                overall=47.2,
+            )
+        ],
+    )
+    _write_extractions(tmp_path, monkeypatch, [ext])
+
+    candidates, stats = refine.build_candidates()
+    assert len(candidates) == 1
+    assert candidates[0]["overall_score"] is None
+    assert candidates[0]["task_scores"].get("reported_avg") == 47.2
+    assert stats["rows_match_no_kept_null"] == 1
+
+
+def test_build_candidates_collapse_drops_when_original_contains_row(tmp_path, monkeypatch, mock_rules):
+    # Original paper + citing paper. Citing is cited_baseline quoting the
+    # original. Original has the same (benchmark, name) row → citing drops.
+    original = _make_extraction(
+        "2406.09246",
+        "libero",
+        [
+            _make_row(
+                "OpenVLA",
+                model_paper="https://arxiv.org/abs/2406.09246",
+                overall=84.0,
+                suite={"libero_spatial": 80, "libero_object": 85, "libero_goal": 90, "libero_10": 81},
+            )
+        ],
+    )
+    citing = _make_extraction(
+        "2501.11111",
+        "libero",
+        [
+            _make_row(
+                "OpenVLA",
+                is_score_original="cited_baseline",
+                model_paper="https://arxiv.org/abs/2406.09246",
+                cited_paper="https://arxiv.org/abs/2406.09246",
+                overall=84.0,
+                suite={"libero_spatial": 80, "libero_object": 85, "libero_goal": 90, "libero_10": 81},
+            )
+        ],
+    )
+    _write_extractions(tmp_path, monkeypatch, [original, citing])
+
+    candidates, stats = refine.build_candidates()
+    assert len(candidates) == 1
+    assert candidates[0]["row_type"] == "first_party"
+    assert stats["rows_dropped_collapse"] == 1
+
+
+def test_build_candidates_collapse_miss_demotes_to_third_party_with_null_cite(tmp_path, monkeypatch, mock_rules):
+    # Citing cites the original, but the original's extraction exists WITHOUT
+    # this row (citing is making a broken attribution). Demote to third_party,
+    # reported_paper=citing, cited_paper=None.
+    original = _make_extraction("2406.09246", "libero", [])  # no rows
+    citing = _make_extraction(
+        "2501.11111",
+        "libero",
+        [
+            _make_row(
+                "OpenVLA",
+                is_score_original="cited_baseline",
+                model_paper="https://arxiv.org/abs/2406.09246",
+                cited_paper="https://arxiv.org/abs/2406.09246",
+                overall=84.0,
+                suite={"libero_spatial": 80, "libero_object": 85, "libero_goal": 90, "libero_10": 81},
+            )
+        ],
+    )
+    _write_extractions(tmp_path, monkeypatch, [original, citing])
+
+    candidates, _ = refine.build_candidates()
+    assert len(candidates) == 1
+    c = candidates[0]
+    assert c["row_type"] == "third_party"
+    assert c["reported_paper"] == "https://arxiv.org/abs/2501.11111"
+    assert c["cited_paper"] is None
+
+
+def test_build_candidates_pi0_github_cite_not_collapsed(tmp_path, monkeypatch, mock_rules):
+    # Citing paper cites π₀/libero from github. Must stay third_party
+    # credited to citing — the number must NOT be filed under π₀'s paper.
+    citing = _make_extraction(
+        "2501.11111",
+        "libero",
+        [
+            _make_row(
+                "pi_0",
+                is_score_original="cited_baseline",
+                model_paper="https://arxiv.org/abs/2410.24164",
+                cited_paper="https://github.com/physical-intelligence/openpi",
+                overall=85.7,
+                suite={"libero_spatial": 80, "libero_object": 85, "libero_goal": 90, "libero_10": 88},
+            )
+        ],
+    )
+    _write_extractions(tmp_path, monkeypatch, [citing])
+
+    candidates, _ = refine.build_candidates()
+    assert len(candidates) == 1
+    c = candidates[0]
+    assert c["row_type"] == "third_party"
+    assert c["reported_paper"] == "https://arxiv.org/abs/2501.11111"
+    assert c["cited_paper"] == "https://github.com/physical-intelligence/openpi"
+
+
+def test_build_candidates_benchmark_filter(tmp_path, monkeypatch, mock_rules):
+    libero_full = {
+        "libero_spatial": 80,
+        "libero_object": 85,
+        "libero_goal": 90,
+        "libero_10": 81,
+    }
+    mikasa_full = {
+        "ShellGameTouch": 50,
+        "InterceptMedium": 60,
+        "RememberColor3": 70,
+        "RememberColor5": 65,
+        "RememberColor9": 55,
+    }
+    ext = {
+        "arxiv_id": "2500.00001",
+        "extracted_at": "2026-04-17T00:00:00Z",
+        "paper_hash": "sha256:x",
+        "extraction_scope": ["libero", "mikasa"],
+        "benchmarks": [
+            {
+                "benchmark": "libero",
+                "models": [
+                    _make_row(
+                        "Libero1",
+                        model_paper="https://arxiv.org/abs/2500.00001",
+                        suite=libero_full,
+                    )
+                ],
+            },
+            {
+                "benchmark": "mikasa",
+                "models": [
+                    _make_row(
+                        "Mikasa1",
+                        model_paper="https://arxiv.org/abs/2500.00001",
+                        task=mikasa_full,
+                    )
+                ],
+            },
+        ],
+    }
+    _write_extractions(tmp_path, monkeypatch, [ext])
+
+    mikasa_only, _ = refine.build_candidates(benchmark_filter="mikasa")
+    assert all(c["benchmark"] == "mikasa" for c in mikasa_only)
+    assert len(mikasa_only) == 1


### PR DESCRIPTION
## Summary

Pipeline-only refactor. `leaderboard.json` is not touched — regenerating the live data with the new pipeline is a separate follow-up PR.

- **Three JSON schemas as the single source of truth** for field semantics, replacing inline dicts in `extract.py` and prose duplication in `CONTRIBUTING.md`:
  - `extraction.schema.json` — one paper's extraction (per-file + packed-array)
  - `candidates.schema.json` — `build_candidates()` output / refine input
  - `leaderboard.schema.json` — enhanced descriptions, `additionalProperties: false`

- **Two-stage pipeline, cleanly separated roles**:
  - `extract.py` optimizes for **recall**. Emits per-row `model_paper` / `cited_paper` URLs so refine can attribute without paper access. File-based LLM output (the CLI's `--json-schema` mode does not reliably populate `structured_output` for schemas with `$defs`).
  - `refine.py` optimizes for **precision**. Deterministic `build_candidates` applies the Case 1/2/3 decision table per `candidates.schema.json`'s `row_type`, including a collapse cross-check against the original paper's extraction. Refine LLM runs **per-benchmark**, and merges only successful benchmarks — an LLM crash preserves existing entries instead of wiping them.

- **Claude Code native tools only** for both extract and refine CLI calls (`--strict-mcp-config --disable-slash-commands`). Discovered during the mikasa pilot that the refine LLM was delegating `model_paper` resolution to MCP servers, bypassing the paper-grounded discipline the pipeline depends on.

- **Scale normalization** (prompt + schema description) — the extract LLM was copying paper values verbatim, leaving e.g. `0.65` on a 0–100 benchmark. `validate_scale_sanity()` flags rows where ≥2 non-zero numeric scores are all ≤ 1.0 on a 0–100 benchmark.

- **CONTRIBUTING.md: 256 → 75 lines.** Result Fields / Score Provenance / Benchmark-Specific Caveats sections removed — everything that duplicated schema or `benchmarks/*.md` prose now defers there.

- **35 unit tests** covering the deterministic refine logic — `_arxiv_id_of`, `_compute_overall`, `_classify_row` (six decision branches including the π₀/github safety case), `build_candidates` end-to-end fixtures, `_merge_leaderboard`. No LLM calls.

## Pilot verification (not committed)

Ran end-to-end on MIKASA-Robo's 14 citing papers through three iterations of the fix cycle. Final run produced 6 sensible entries, all task scores in 0–100, TakeItBack preserved across the non-standard 4-task subset, `reported_avg` matches existing hand-curated values (BC-MLP=21, CQL-MLP=15.75). Zero MCP tool calls, zero skill invocations across extract + refine logs.

## Out of scope

- **Regenerating `leaderboard.json` end-to-end** — follow-up PR.
- **Removing `benchmarks.json.papers_reviewed`** in favor of `extraction_scope` — documented as a follow-up; out of scope here because it touches `update_coverage.py` + data.

## Test plan

- [x] `make check` (ruff + format + ty) clean
- [x] `uv run pytest leaderboard/tests/` — 35/35 pass
- [x] `uv run leaderboard/scripts/validate.py` — 670 results, 18 benchmarks OK
- [x] `refine.py candidates` deterministic pre-step runs
- [x] mikasa pilot: scan → extract → refine → structurally valid output, no MCP calls
- [ ] CI Leaderboard Validate green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)