### PR TITLE
ci: lfs checkout for pages / update-data workflows

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,6 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # leaderboard/data/{leaderboard,extractions,scan_results}.json
+          # live in LFS. scan.py reads leaderboard.json and the site
+          # serves it verbatim, so the blob must be smudged here.
+          lfs: true
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -18,6 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # sync_external/scan/validate read leaderboard.json
+          # (LFS-tracked) — smudge the blob so they don't hit a pointer.
+          lfs: true
 
       - uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
After #45, `leaderboard.json` lives in LFS. The Deploy Leaderboard workflow checked out without `lfs: true` → got a pointer file → scan.py's `json.loads` blew up on the pointer text.

Same latent hazard in `update-data.yml` (sync_external / scan / validate all read leaderboard.json).

Adds `lfs: true` to both checkouts. `leaderboard-validate.yml` already had it.

Failed run: https://github.com/allenai/vla-evaluation-harness/actions/runs/24774678639
