### PR TITLE
feat: per-episode video recorder + RoboMME enhancements (subgoal, H100 lavapipe fallback)

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -28,11 +28,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # ── Vulkan ICD for NVIDIA GPU ────────────────────────────────────────
+# Skip writes when the ICD file is already present — on hosts whose Docker
+# default-runtime is `nvidia`, nvidia-container-runtime bind-mounts these
+# JSONs read-only into every container (including the build container), so
+# an unconditional write would fail with "Read-only file system".
 RUN mkdir -p /usr/share/vulkan/icd.d /usr/share/glvnd/egl_vendor.d \
-    && printf '{"file_format_version":"1.0.0","ICD":{"library_path":"libGLX_nvidia.so.0","api_version":"1.2.155"}}\n' \
-        > /usr/share/vulkan/icd.d/nvidia_icd.json \
-    && printf '{"file_format_version":"1.0.0","ICD":{"library_path":"libEGL_nvidia.so.0"}}\n' \
-        > /usr/share/glvnd/egl_vendor.d/10_nvidia.json
+    && { [ -s /usr/share/vulkan/icd.d/nvidia_icd.json ] \
+         || printf '{"file_format_version":"1.0.0","ICD":{"library_path":"libGLX_nvidia.so.0","api_version":"1.2.155"}}\n' \
+            > /usr/share/vulkan/icd.d/nvidia_icd.json; } \
+    && { [ -s /usr/share/glvnd/egl_vendor.d/10_nvidia.json ] \
+         || printf '{"file_format_version":"1.0.0","ICD":{"library_path":"libEGL_nvidia.so.0"}}\n' \
+            > /usr/share/glvnd/egl_vendor.d/10_nvidia.json; }
 
 # ── Miniforge (lightweight conda, conda-forge defaults) ──────────────
 RUN wget -qO /tmp/miniforge.sh \

--- a/src/vla_eval/benchmarks/recording.py
+++ b/src/vla_eval/benchmarks/recording.py
@@ -1,144 +1,302 @@
 """Per-episode video recording helper, shared across benchmarks.
 
 Most benchmarks have a "save the agent's view of each episode as an mp4"
-need (debugging failures, demo browsing, public showcase, qualitative
+need (failure-case debugging, demo browsing, public showcase, qualitative
 analysis).  This module is a single home for that pattern so each
 benchmark doesn't reinvent it.
 
-Typical use from a benchmark:
+## Design
+
+* **Streaming**: frames are encoded to disk as they arrive
+  (``imageio.get_writer`` + ``append_data``) rather than buffered in RAM.
+  Memory is O(1) regardless of episode length; a 1300-step 256×256×3
+  episode that previously held ~250 MB now holds one frame at a time.
+  A side benefit is that a partially-written mp4 is left on disk if the
+  process is killed mid-episode — playable up to the last completed
+  frame, useful for debugging crashes.
+* **Atomic finalize**: frames stream into a tempfile in the same output
+  directory; ``save()`` resolves the final filename (which usually
+  depends on success/failure status) and ``os.replace``-s the tempfile
+  into place.  Concurrent jobs sharing a directory don't collide.
+* **Logging-style filename templating**: the filename is a ``str.format``
+  template (or callable) over a context dict that the caller passes at
+  ``start()`` time, plus a ``status`` key injected at ``save()`` time.
+  Default template ``"{task_name}_ep{episode_idx}_{status}.mp4"``;
+  benchmarks with richer identifiers can use any context they like, e.g.
+  ``"{suite}/{task}/{episode_idx:04d}_seed{seed}_{status}.mp4"``.
+* **Best-effort**: every encode-side failure logs a warning with the
+  context for debuggability and clears state — a corrupted video should
+  never bring down an otherwise good eval episode.
+
+## Caller pattern
 
     from vla_eval.benchmarks.recording import EpisodeVideoRecorder
-    from vla_eval.types import Task
 
-    class MyBenchmark(StepBenchmark):
-        def __init__(self, ..., save_episode_video: bool = False,
-                     video_dir: str | None = None) -> None:
-            ...
-            self._recorder = EpisodeVideoRecorder(
-                output_dir=video_dir or "/workspace/results/videos",
-                fps=20,
-            ) if save_episode_video else None
+    recorder = EpisodeVideoRecorder(
+        output_dir="/workspace/results/videos",
+        # filename can stay default, or e.g.
+        # filename="{suite}/{task}_ep{episode_idx}_{status}.mp4",
+        fps=20,
+    )
 
-        def reset(self, task: Task) -> Any:
-            ...
-            if self._recorder is not None:
-                self._recorder.start(task)
-                # Capture the initial frame so the video covers the whole episode.
-                self._recorder.record(initial_frame)
+    # In benchmark.reset(task):
+    recorder.start({"task_name": task["env_id"], "episode_idx": task["episode_idx"]})
+    recorder.record(initial_frame)
 
-        def step(self, action) -> StepResult:
-            ...
-            if self._recorder is not None:
-                # If the underlying buffer is reused (ManiSkill does), copy first.
-                self._recorder.record(np.array(frame, copy=True))
+    # In benchmark.step(action):
+    recorder.record(frame)  # caller may mutate `frame` after this returns
+                            # (imageio's writer copies into its own buffer)
 
-        def get_step_result(self, step_result) -> EpisodeResult:
-            success = ...
-            if self._recorder is not None:
-                self._recorder.save(success=success)
-            return {"success": success}
+    # In benchmark.get_step_result(step_result):
+    recorder.save(status="success" if success else "fail")
 
-        def cleanup(self) -> None:
-            ...
-            if self._recorder is not None:
-                self._recorder.discard()  # drop any in-flight frames
+    # In benchmark.cleanup():
+    recorder.discard()  # drops any in-flight writer + tempfile
 
-The recorder is best-effort: encode failures log a warning and clear the
-buffer rather than aborting the episode.  Frame buffering is in-memory
-(``imageio.mimsave``); a typical 1300-step episode at 256×256×3 uint8 is
-~250 MB.  If you need lower memory or non-blocking saves, switch to
-``imageio.get_writer`` streaming and async ``cleanup()`` join — both are
-straightforward upgrades that don't change the public API here.
+## Multi-camera
+
+The recorder is single-stream by design.  Benchmarks with multiple views
+(e.g. front + wrist) instantiate one recorder per view with different
+``filename`` templates (e.g. ``"{view}_ep{episode_idx}_{status}.mp4"``,
+substituting the view name into the context at ``start()``).  This keeps
+each recorder simple and lets callers mix-and-match resolutions, fps,
+and codecs per view.
 """
 
 from __future__ import annotations
 
 import logging
 import os
-from typing import TYPE_CHECKING
+import tempfile
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any, Union
 
 import numpy as np
 
-if TYPE_CHECKING:
-    from vla_eval.types import Task
-
 logger = logging.getLogger(__name__)
+
+# Either a `str.format`-style template or a callable that takes the resolved
+# context (caller's start() context + injected ``status``) and returns a
+# filename relative to ``output_dir``.
+FilenameSpec = Union[str, Callable[[Mapping[str, Any]], str]]
 
 
 class EpisodeVideoRecorder:
-    """Buffers per-step frames and writes one mp4 per episode.
+    """Streaming per-episode video recorder.
 
-    Filename pattern: ``{task_name}_ep{episode_idx}_{success|fail}.mp4``.
-    ``task["episode_idx"]`` is required at ``start()`` time — without it
-    multi-episode runs of the same task collide on a single ``_ep0_`` filename
-    and silently overwrite.
+    Lifecycle: ``start()`` → ``record()`` × N → ``save()`` (or
+    ``discard()``).  ``start()`` may be called again to begin a new
+    episode; if a previous episode never reached ``save()``/``discard()``
+    (e.g. orchestrator crash) the in-flight writer is closed and its
+    tempfile cleaned up first.
+
+    Inactive (no episode in progress) is a valid state: ``record()`` /
+    ``save()`` / ``discard()`` are no-ops in that case so callers don't
+    need defensive ``if recorder.active`` checks.
     """
 
-    def __init__(self, output_dir: str, fps: int = 20) -> None:
-        self.output_dir = output_dir
+    def __init__(
+        self,
+        output_dir: str | os.PathLike[str],
+        filename: FilenameSpec = "{task_name}_ep{episode_idx}_{status}.mp4",
+        fps: int = 20,
+        required_context: Sequence[str] = ("episode_idx",),
+        writer_kwargs: Mapping[str, Any] | None = None,
+    ) -> None:
+        """
+        Args:
+            output_dir: Directory the final mp4 lands in.  Created if missing.
+                Filename templates may include subdirectories (e.g.
+                ``"{suite}/{task}_..."``); intermediate dirs are also created.
+            filename: ``str.format`` template or callable producing the
+                filename relative to ``output_dir``.  Resolved at ``save()``
+                time over ``{**start_context, "status": status}``.
+            fps: Output framerate.
+            required_context: Keys that must be present in the dict passed to
+                ``start()``.  ``ValueError`` is raised at ``start()`` if any
+                are missing.  Default ``("episode_idx",)`` because without an
+                episode index, multi-episode runs of the same task collide
+                on a single ``_ep0_`` filename.
+            writer_kwargs: Extra kwargs forwarded to ``imageio.get_writer``
+                (e.g. ``{"codec": "libx264", "quality": 8}``).
+        """
+        self.output_dir = Path(output_dir)
+        self._filename_spec = filename
         self.fps = fps
-        self._frames: list[np.ndarray] = []
-        self._task: Task | None = None
+        self._required_context = tuple(required_context)
+        self._writer_kwargs = dict(writer_kwargs or {})
 
-    def start(self, task: Task) -> None:
-        """Begin recording for ``task``. Drops any frames left from a prior
-        episode (e.g. orchestrator skipped ``get_step_result`` after a
-        crash) so we don't accumulate."""
-        if "episode_idx" not in task:
-            raise ValueError(
-                "EpisodeVideoRecorder.start(task) requires task['episode_idx'] "
-                "(otherwise per-episode mp4s collide on the same filename)"
+        # Lifecycle state — None whenever no episode is in progress.
+        self._writer: Any = None
+        self._tempfile: Path | None = None
+        self._context: dict[str, Any] | None = None
+        self._frames_written = 0
+
+    @property
+    def active(self) -> bool:
+        return self._writer is not None
+
+    def start(self, context: Mapping[str, Any]) -> None:
+        """Begin a new episode.
+
+        Validates required context keys, opens a streaming writer to a
+        tempfile in ``output_dir``.  If a previous episode is still in
+        flight (no ``save``/``discard`` called) it is discarded first.
+        On writer-open failure the recorder stays inactive and subsequent
+        ``record()``/``save()`` are no-ops; the failure is logged.
+        """
+        missing = [k for k in self._required_context if k not in context]
+        if missing:
+            raise ValueError(f"EpisodeVideoRecorder.start: missing required context keys: {missing}")
+
+        if self.active:
+            self.discard()
+
+        self._context = dict(context)
+        try:
+            self.output_dir.mkdir(parents=True, exist_ok=True)
+            # Tempfile in the same directory so os.replace() at save time is
+            # atomic on the same filesystem.
+            # Tempfile keeps a real `.mp4` suffix so imageio's format
+            # auto-detection works; the `.recorder-` prefix marks it as ours.
+            fd, temp_path = tempfile.mkstemp(
+                prefix=".recorder-",
+                suffix=".mp4",
+                dir=str(self.output_dir),
             )
-        self._frames = []
-        self._task = task
+            os.close(fd)
+            self._tempfile = Path(temp_path)
+
+            import imageio
+
+            self._writer = imageio.get_writer(str(self._tempfile), fps=self.fps, **self._writer_kwargs)
+        except Exception as e:
+            logger.warning(
+                "Failed to open video writer for context=%r: %s",
+                self._context,
+                e,
+            )
+            self._cleanup_tempfile()
+            self._writer = None
+            self._context = None
 
     def record(self, frame: np.ndarray) -> None:
-        """Append a frame.
+        """Append a frame to the in-flight episode.
 
-        The caller is responsible for copying if the underlying buffer is
-        reused across steps (ManiSkill / SAPIEN reuse one image buffer per
-        camera; without ``np.array(frame, copy=True)`` every recorded
-        frame ends up identical to the last one).
+        ``imageio``'s writers copy the frame data synchronously, so the
+        caller is free to mutate the underlying buffer once this returns
+        — no defensive ``np.array(frame, copy=True)`` required.
+
+        No-op if no episode is in progress.  Per-frame encode failures
+        log a warning but don't disable the writer (could be transient).
         """
-        if self._task is None:
-            # start() not called — silently ignore so a benchmark that
-            # toggles recording mid-run doesn't crash.
+        if not self.active:
             return
-        self._frames.append(frame)
+        try:
+            self._writer.append_data(frame)
+            self._frames_written += 1
+        except Exception as e:
+            logger.warning(
+                "Failed to write frame to video for context=%r: %s",
+                self._context,
+                e,
+            )
 
-    def save(self, success: bool) -> str | None:
-        """Encode the buffered frames to mp4 and reset.
+    def save(self, status: str = "success") -> Path | None:
+        """Finalize the in-flight episode.
 
-        Returns the file path on success, ``None`` if there was nothing to
-        save or the encode failed.  Encode failures log a warning rather
-        than raise — a corrupted video should never fail an otherwise good
-        eval episode.
+        Closes the streaming writer, resolves the final filename from
+        ``{**context, "status": status}``, and atomically moves the
+        tempfile into place.  Returns the final ``Path`` on success,
+        ``None`` if the recorder was inactive or any finalize step
+        failed.  After this call the recorder is inactive again.
         """
-        if self._task is None or not self._frames:
-            self._frames = []
-            self._task = None
+        if not self.active:
+            return None
+
+        # Local copy + clear state up front so failure paths can't leak it.
+        writer, tempfile_path, context = self._writer, self._tempfile, self._context
+        frames_written = self._frames_written
+        self._writer = None
+        self._tempfile = None
+        self._context = None
+        self._frames_written = 0
+
+        try:
+            writer.close()
+        except Exception as e:
+            logger.warning(
+                "Failed to close video writer for context=%r: %s",
+                context,
+                e,
+            )
+            _safe_unlink(tempfile_path)
             return None
 
         try:
-            import imageio
-
-            os.makedirs(self.output_dir, exist_ok=True)
-            task_name = self._task.get("name", self._task.get("env_id", "unknown"))
-            status = "success" if success else "fail"
-            fname = f"{task_name}_ep{self._task['episode_idx']}_{status}.mp4"
-            path = os.path.join(self.output_dir, fname)
-            imageio.mimsave(path, self._frames, fps=self.fps)
-            logger.info("Saved episode video: %s (%d frames)", path, len(self._frames))
-            return path
+            full_context = {**(context or {}), "status": status}
+            relative_name = self._resolve_filename(full_context)
         except Exception as e:
-            logger.warning("Failed to save episode video: %s", e)
+            logger.warning(
+                "Failed to resolve filename for context=%r status=%r: %s",
+                context,
+                status,
+                e,
+            )
+            _safe_unlink(tempfile_path)
             return None
-        finally:
-            self._frames = []
-            self._task = None
+
+        final_path = self.output_dir / relative_name
+        try:
+            final_path.parent.mkdir(parents=True, exist_ok=True)
+            os.replace(str(tempfile_path), str(final_path))
+        except Exception as e:
+            logger.warning(
+                "Failed to finalize video at %s for context=%r: %s",
+                final_path,
+                context,
+                e,
+            )
+            _safe_unlink(tempfile_path)
+            return None
+
+        logger.info("Saved episode video: %s (%d frames)", final_path, frames_written)
+        return final_path
 
     def discard(self) -> None:
-        """Drop the buffer without saving. Call from ``cleanup()`` paths to
-        avoid leaking frames if the orchestrator never calls ``save()``."""
-        self._frames = []
-        self._task = None
+        """Abandon the in-flight episode without producing an mp4.
+
+        Closes the writer (best-effort) and removes the tempfile.  Safe
+        to call when no episode is in progress (no-op).
+        """
+        writer = self._writer
+        tempfile_path = self._tempfile
+        self._writer = None
+        self._tempfile = None
+        self._context = None
+        self._frames_written = 0
+        if writer is not None:
+            try:
+                writer.close()
+            except Exception:
+                pass
+        _safe_unlink(tempfile_path)
+
+    def _resolve_filename(self, context: Mapping[str, Any]) -> str:
+        if callable(self._filename_spec):
+            return self._filename_spec(context)
+        return self._filename_spec.format(**context)
+
+    def _cleanup_tempfile(self) -> None:
+        _safe_unlink(self._tempfile)
+        self._tempfile = None
+
+
+def _safe_unlink(path: Path | None) -> None:
+    if path is None:
+        return
+    try:
+        path.unlink(missing_ok=True)
+    except Exception:
+        pass

--- a/src/vla_eval/benchmarks/recording.py
+++ b/src/vla_eval/benchmarks/recording.py
@@ -1,0 +1,144 @@
+"""Per-episode video recording helper, shared across benchmarks.
+
+Most benchmarks have a "save the agent's view of each episode as an mp4"
+need (debugging failures, demo browsing, public showcase, qualitative
+analysis).  This module is a single home for that pattern so each
+benchmark doesn't reinvent it.
+
+Typical use from a benchmark:
+
+    from vla_eval.benchmarks.recording import EpisodeVideoRecorder
+    from vla_eval.types import Task
+
+    class MyBenchmark(StepBenchmark):
+        def __init__(self, ..., save_episode_video: bool = False,
+                     video_dir: str | None = None) -> None:
+            ...
+            self._recorder = EpisodeVideoRecorder(
+                output_dir=video_dir or "/workspace/results/videos",
+                fps=20,
+            ) if save_episode_video else None
+
+        def reset(self, task: Task) -> Any:
+            ...
+            if self._recorder is not None:
+                self._recorder.start(task)
+                # Capture the initial frame so the video covers the whole episode.
+                self._recorder.record(initial_frame)
+
+        def step(self, action) -> StepResult:
+            ...
+            if self._recorder is not None:
+                # If the underlying buffer is reused (ManiSkill does), copy first.
+                self._recorder.record(np.array(frame, copy=True))
+
+        def get_step_result(self, step_result) -> EpisodeResult:
+            success = ...
+            if self._recorder is not None:
+                self._recorder.save(success=success)
+            return {"success": success}
+
+        def cleanup(self) -> None:
+            ...
+            if self._recorder is not None:
+                self._recorder.discard()  # drop any in-flight frames
+
+The recorder is best-effort: encode failures log a warning and clear the
+buffer rather than aborting the episode.  Frame buffering is in-memory
+(``imageio.mimsave``); a typical 1300-step episode at 256×256×3 uint8 is
+~250 MB.  If you need lower memory or non-blocking saves, switch to
+``imageio.get_writer`` streaming and async ``cleanup()`` join — both are
+straightforward upgrades that don't change the public API here.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from vla_eval.types import Task
+
+logger = logging.getLogger(__name__)
+
+
+class EpisodeVideoRecorder:
+    """Buffers per-step frames and writes one mp4 per episode.
+
+    Filename pattern: ``{task_name}_ep{episode_idx}_{success|fail}.mp4``.
+    ``task["episode_idx"]`` is required at ``start()`` time — without it
+    multi-episode runs of the same task collide on a single ``_ep0_`` filename
+    and silently overwrite.
+    """
+
+    def __init__(self, output_dir: str, fps: int = 20) -> None:
+        self.output_dir = output_dir
+        self.fps = fps
+        self._frames: list[np.ndarray] = []
+        self._task: Task | None = None
+
+    def start(self, task: Task) -> None:
+        """Begin recording for ``task``. Drops any frames left from a prior
+        episode (e.g. orchestrator skipped ``get_step_result`` after a
+        crash) so we don't accumulate."""
+        if "episode_idx" not in task:
+            raise ValueError(
+                "EpisodeVideoRecorder.start(task) requires task['episode_idx'] "
+                "(otherwise per-episode mp4s collide on the same filename)"
+            )
+        self._frames = []
+        self._task = task
+
+    def record(self, frame: np.ndarray) -> None:
+        """Append a frame.
+
+        The caller is responsible for copying if the underlying buffer is
+        reused across steps (ManiSkill / SAPIEN reuse one image buffer per
+        camera; without ``np.array(frame, copy=True)`` every recorded
+        frame ends up identical to the last one).
+        """
+        if self._task is None:
+            # start() not called — silently ignore so a benchmark that
+            # toggles recording mid-run doesn't crash.
+            return
+        self._frames.append(frame)
+
+    def save(self, success: bool) -> str | None:
+        """Encode the buffered frames to mp4 and reset.
+
+        Returns the file path on success, ``None`` if there was nothing to
+        save or the encode failed.  Encode failures log a warning rather
+        than raise — a corrupted video should never fail an otherwise good
+        eval episode.
+        """
+        if self._task is None or not self._frames:
+            self._frames = []
+            self._task = None
+            return None
+
+        try:
+            import imageio
+
+            os.makedirs(self.output_dir, exist_ok=True)
+            task_name = self._task.get("name", self._task.get("env_id", "unknown"))
+            status = "success" if success else "fail"
+            fname = f"{task_name}_ep{self._task['episode_idx']}_{status}.mp4"
+            path = os.path.join(self.output_dir, fname)
+            imageio.mimsave(path, self._frames, fps=self.fps)
+            logger.info("Saved episode video: %s (%d frames)", path, len(self._frames))
+            return path
+        except Exception as e:
+            logger.warning("Failed to save episode video: %s", e)
+            return None
+        finally:
+            self._frames = []
+            self._task = None
+
+    def discard(self) -> None:
+        """Drop the buffer without saving. Call from ``cleanup()`` paths to
+        avoid leaking frames if the orchestrator never calls ``save()``."""
+        self._frames = []
+        self._task = None

--- a/src/vla_eval/benchmarks/robomme/benchmark.py
+++ b/src/vla_eval/benchmarks/robomme/benchmark.py
@@ -386,10 +386,11 @@ class RoboMMEBenchmark(StepBenchmark):
             self._current_subgoal = self._extract_subgoal(info_flat)
 
         if self._recorder is not None:
-            self._recorder.start(task)
+            task_name = task.get("name") or task.get("env_id", "unknown")
+            self._recorder.start({"task_name": task_name, "episode_idx": episode_idx})
             front_list = obs_batch.get("front_rgb_list", [])
             if front_list:
-                self._recorder.record(np.array(front_list[-1], copy=True))
+                self._recorder.record(front_list[-1])
 
         return obs_batch
 
@@ -411,9 +412,7 @@ class RoboMMEBenchmark(StepBenchmark):
         if self._recorder is not None and obs:
             front_list = obs.get("front_rgb_list", [])
             if front_list:
-                # Copy explicitly: ManiSkill may reuse the same buffer across steps,
-                # which would make every saved frame identical to the last one.
-                self._recorder.record(np.array(front_list[-1], copy=True))
+                self._recorder.record(front_list[-1])
 
         # Cast potential torch scalars
         terminated = bool(terminated)
@@ -485,7 +484,7 @@ class RoboMMEBenchmark(StepBenchmark):
     def get_step_result(self, step_result: StepResult) -> EpisodeResult:
         success = step_result.info.get("status") == "success"
         if self._recorder is not None:
-            self._recorder.save(success=success)
+            self._recorder.save(status="success" if success else "fail")
         return {"success": success}
 
     def get_metadata(self) -> dict[str, Any]:

--- a/src/vla_eval/benchmarks/robomme/benchmark.py
+++ b/src/vla_eval/benchmarks/robomme/benchmark.py
@@ -7,13 +7,98 @@ is sent to the model server as ``video_history`` on the first observation.
 
 from __future__ import annotations
 
-from typing import Any
+import logging
+import os
+import re
+import subprocess
+import sys
+from typing import Any, Literal
 
 import numpy as np
 
 from vla_eval.benchmarks.base import StepBenchmark, StepResult
+from vla_eval.benchmarks.recording import EpisodeVideoRecorder
 from vla_eval.specs import IMAGE_RGB, LANGUAGE, RAW, DimSpec
 from vla_eval.types import Action, EpisodeResult, Observation, Task
+
+logger = logging.getLogger(__name__)
+
+# A grounded subgoal that hasn't had its `<obj_center>`-style placeholders
+# substituted with image coords still has bracketed identifiers (alpha/_).
+# Filled coords look like `<70, 84>` — the first char inside `<` is a digit.
+_UNFILLED_PLACEHOLDER_RE = re.compile(r"<[A-Za-z_]")
+
+# Probe script for ROBOMME_USE_LAVAPIPE=auto. Runs in a child process so a hang
+# in SAPIEN's Vulkan instance creation can be timed out without poisoning the
+# parent process (SAPIEN's VkInstance is created at import time and cannot be
+# reset in-process). subprocess.run's timeout is the watchdog.
+_NATIVE_PROBE = """
+import sapien
+import sapien.render
+import sapien.physx as physx
+rs = sapien.render.RenderSystem('cuda:0')
+scene = sapien.Scene([physx.PhysxCpuSystem(), rs])
+cam = scene.add_camera(name='t', width=64, height=64, fovy=1.0, near=0.01, far=10.0)
+cam.set_pose(sapien.Pose([0, 0, 1]))
+scene.step()
+scene.update_render()
+cam.take_picture()
+cam.get_picture('Color')
+"""
+
+
+def native_render_path_works(timeout_s: int = 15) -> bool:
+    """Probe whether SAPIEN's native NVIDIA Vulkan path works on this host.
+
+    Spawns a child Python that does ``RenderSystem('cuda:0')`` → scene → camera
+    → ``take_picture`` → ``get_picture('Color')``. The hang on affected hosts
+    shows up at ``get_picture`` (Vulkan fence wait that never signals) —
+    ``subprocess.run`` times out and SIGKILLs the child while we abort it.
+
+    Returns True if the child completes successfully within the timeout, False
+    if it hangs, crashes, or any unexpected error occurs. Conservative: any
+    non-zero exit means "fall back to lavapipe".
+
+    Public so launchers can health-check a host before scheduling work on it.
+    """
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", _NATIVE_PROBE],
+            timeout=timeout_s,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return result.returncode == 0
+    except subprocess.TimeoutExpired:
+        return False
+    except Exception as e:
+        logger.warning("Native render-path probe error: %s", e)
+        return False
+
+
+def _resolve_lavapipe_icd() -> str | None:
+    """Find the lavapipe ICD path. Returns None if not available.
+
+    Honors ``ROBOMME_LAVAPIPE_ICD`` if explicitly set — falling back silently
+    when an explicit user setting points to a missing file would be surprising,
+    so that case logs an error and returns None instead. The implicit default
+    paths (``/opt/lavapipe/lvp_icd.json`` then the Mesa-shipped
+    ``/usr/share/vulkan/icd.d/lvp_icd.x86_64.json``) are tried in order.
+    """
+    user_icd = os.environ.get("ROBOMME_LAVAPIPE_ICD")
+    if user_icd:
+        if os.path.isfile(user_icd):
+            return user_icd
+        logger.error(
+            "ROBOMME_LAVAPIPE_ICD=%s does not exist; refusing to silently fall back to a different ICD path",
+            user_icd,
+        )
+        return None
+    for candidate in ("/opt/lavapipe/lvp_icd.json", "/usr/share/vulkan/icd.d/lvp_icd.x86_64.json"):
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
 
 _DEFAULT_TASK_LIST = [
     "PickXtimes",
@@ -61,7 +146,24 @@ class RoboMMEBenchmark(StepBenchmark):
         send_wrist_image: Include wrist camera in observations.
         send_state: Include proprioceptive state in observations.
         send_video_history: Send conditioning video on the first observation.
+        send_subgoal: Attach the per-step subgoal text to ``obs["subgoal"]``.
+        subgoal_mode: ``"grounded"`` sends ``info['grounded_subgoal_online']``
+            (subgoal with image-coord placeholders filled, e.g. ``"pick up the
+            green cube at <77, 170>"``); ``"simple"`` sends
+            ``info['simple_subgoal_online']`` (no coords).  Both come from
+            ``DemonstrationWrapper`` in the upstream robomme env.  ``"grounded"``
+            falls back to simple if grounded is empty.
+        save_episode_video: Encode an mp4 of the agentview frames per episode
+            and write it to ``video_dir`` on episode end.  Requires
+            ``task["episode_idx"]`` to be set on each ``reset(task)`` call so
+            per-episode files don't collide.
+        video_dir: Output directory for per-episode videos.  Ignored unless
+            ``save_episode_video=True``.  Defaults to
+            ``/workspace/results/videos`` so the file lands inside the bench
+            container's standard results bind-mount.
     """
+
+    _rendering_configured: bool = False
 
     def __init__(
         self,
@@ -72,8 +174,14 @@ class RoboMMEBenchmark(StepBenchmark):
         send_wrist_image: bool = True,
         send_state: bool = True,
         send_video_history: bool = True,
+        send_subgoal: bool = False,
+        subgoal_mode: Literal["grounded", "simple"] = "grounded",
+        save_episode_video: bool = False,
+        video_dir: str | None = None,
     ) -> None:
         super().__init__()
+        if subgoal_mode not in ("grounded", "simple"):
+            raise ValueError(f"subgoal_mode must be 'grounded' or 'simple', got {subgoal_mode!r}")
         self.tasks = tasks or list(_DEFAULT_TASK_LIST)
         self.action_space = action_space
         self.dataset = dataset
@@ -81,24 +189,169 @@ class RoboMMEBenchmark(StepBenchmark):
         self.send_wrist_image = send_wrist_image
         self.send_state = send_state
         self.send_video_history = send_video_history
+        self.send_subgoal = send_subgoal
+        self.subgoal_mode = subgoal_mode
+
+        self._recorder: EpisodeVideoRecorder | None = (
+            EpisodeVideoRecorder(output_dir=video_dir or "/workspace/results/videos", fps=20)
+            if save_episode_video
+            else None
+        )
 
         self._env: Any = None
         self._task_description: str = ""
         self._video_frames: list[np.ndarray] = []
         self._wrist_video_frames: list[np.ndarray] = []
-
-    # ------------------------------------------------------------------
-    # Helpers
-    # ------------------------------------------------------------------
-
-    # ------------------------------------------------------------------
-    # Benchmark ABC
-    # ------------------------------------------------------------------
+        self._current_subgoal: str = ""
 
     def get_tasks(self) -> list[Task]:
         return [{"name": t, "env_id": t} for t in self.tasks]
 
+    @staticmethod
+    def _setup_rendering() -> None:
+        """Optionally switch SAPIEN to lavapipe software Vulkan.
+
+        On a small subset of hosts, SAPIEN's ``RenderSystem("cuda:0")`` path
+        hangs at the first ``take_picture`` — observed as 100%% GPU util with
+        no progress past ``_setup_scene``. Symptom matches SAPIEN #290
+        (closed as host-specific). Empirically, the kernel module flavor is
+        not the discriminator: across our DGX-H100 fleet, both the closed
+        ``NVIDIA`` and the open ``Dual MIT/GPL`` modules reproduce the hang
+        on some nodes and not others, with byte-identical packages. The
+        difference appears to be hardware/firmware-level.
+
+        ``ROBOMME_USE_LAVAPIPE`` (env var) controls the workaround:
+            - unset / ``0`` / ``false`` (default): native NVIDIA path,
+              ~30–80 fps at 256×256. Will hang on affected hosts.
+            - ``1`` / ``true`` / ``yes``: always engage lavapipe.
+            - ``auto``: probe the native path in a child process (with
+              a watchdog timeout). If it returns successfully, leave SAPIEN
+              alone. If it hangs, engage lavapipe in this process.
+              ``auto`` adds ~5–10 s of startup probe time on healthy hosts
+              but lets a single launcher work across the whole fleet.
+
+        Decision is cached per-process via ``_rendering_configured``;
+        changing ``ROBOMME_USE_LAVAPIPE`` after the first ``reset()`` has no
+        effect (Vulkan ICD is loaded at the first ``import sapien.render``
+        and cannot be re-bound in-process).
+
+        Lavapipe path (when engaged) is ~5–10× slower than the native path
+        (~4–12 fps vs ~33–80 fps). When engaged we also set
+        ``LP_NUM_THREADS=4`` and ``OMP_NUM_THREADS=1`` (empirical sweet spot
+        for Mesa lavapipe with 256×256 frames; recovers ~30%% over the
+        unset default). Three-piece patch:
+
+        1. ``VK_ICD_FILENAMES`` → lavapipe (so Vulkan dispatch goes to
+           the Mesa software renderer, bypassing the broken interop path).
+        2. Wrap ``sapien.render.RenderSystem`` to drop the ``device``
+           positional arg — lavapipe has no CUDA backend, so calling
+           ``RenderSystem("cuda:0")`` raises "Failed to find a supported
+           physical device".
+        3. Patch ``mani_skill ... parse_sim_and_render_backend`` so the
+           render backend resolves to ``sapien_cpu``, matching the device
+           that lavapipe actually uses.
+        """
+        if RoboMMEBenchmark._rendering_configured:
+            return
+
+        mode = os.environ.get("ROBOMME_USE_LAVAPIPE", "").strip().lower()
+        if mode == "auto":
+            if native_render_path_works():
+                logger.info("SAPIEN auto-detect: native NVIDIA Vulkan path works, skipping lavapipe")
+                RoboMMEBenchmark._rendering_configured = True
+                return
+            logger.warning(
+                "SAPIEN auto-detect: native render path hung within watchdog timeout; engaging lavapipe fallback"
+            )
+        elif mode not in ("1", "true", "yes", "on"):
+            RoboMMEBenchmark._rendering_configured = True
+            return
+
+        # Engagement requested (mode in {"1","true","yes","on","auto"+hang}).
+        # If the patch can't take effect, the next take_picture would silently
+        # hang — fail loudly so the launcher knows to either fix the host or
+        # set ROBOMME_USE_LAVAPIPE before any sapien import.
+        if not RoboMMEBenchmark._engage_lavapipe():
+            raise RuntimeError(
+                f"Lavapipe rendering requested (ROBOMME_USE_LAVAPIPE={mode!r}) but could not "
+                "be engaged. Check earlier log lines for the specific reason "
+                "(sapien.render already imported, ICD missing, etc.); continuing on the "
+                "native NVIDIA path would hang on affected hosts."
+            )
+        RoboMMEBenchmark._rendering_configured = True
+
+    @staticmethod
+    def _engage_lavapipe() -> bool:
+        """Apply the three-piece lavapipe patch + perf-tuning env vars.
+
+        Must be called BEFORE ``import sapien.render`` in this process for
+        ``VK_ICD_FILENAMES`` and ``LP_NUM_THREADS`` to take effect (Vulkan
+        ICD is loaded at first ``import sapien.render``).
+
+        Returns True on success, False if the patch could not be applied
+        (sapien.render already imported, lavapipe ICD missing, etc.). The
+        caller is responsible for treating False as fatal — silently
+        continuing on the native path would hang on affected hosts.
+        """
+        if "sapien.render" in sys.modules:
+            logger.error(
+                "Cannot engage lavapipe: sapien.render is already imported. "
+                "VK_ICD_FILENAMES / LP_NUM_THREADS only take effect on first "
+                "Vulkan init. Set ROBOMME_USE_LAVAPIPE before any sapien import."
+            )
+            return False
+
+        lavapipe_icd = _resolve_lavapipe_icd()
+        if lavapipe_icd is None:
+            logger.error("Lavapipe ICD not found; cannot engage lavapipe rendering")
+            return False
+
+        # Mesa lavapipe perf tuning. Empirical sweep on A100 with RoboMME's
+        # 256×256 frames: LP=4, OMP=1 is the sweet spot (~4.8 fps vs ~3.3 fps
+        # at LP=1 vs ~3.7 fps unset). Don't override if user already set them.
+        os.environ.setdefault("LP_NUM_THREADS", "4")
+        os.environ.setdefault("OMP_NUM_THREADS", "1")
+        os.environ.setdefault("MKL_NUM_THREADS", "1")
+
+        os.environ["VK_ICD_FILENAMES"] = lavapipe_icd
+        logger.info("SAPIEN rendering: using lavapipe software Vulkan (%s)", lavapipe_icd)
+
+        import sapien.render as sr
+
+        _OrigRenderSystem = sr.RenderSystem
+
+        def _lavapipe_render_system(*args, **kwargs):
+            return _OrigRenderSystem()
+
+        sr.RenderSystem = _lavapipe_render_system
+
+        # Patch parse_sim_and_render_backend in BOTH places: the source module
+        # (so any later imports get the patched version) AND already-imported
+        # `mani_skill.envs.sapien_env` (which captured the unpatched reference
+        # at its own import time via `from ... import parse_sim_and_render_backend`).
+        try:
+            from mani_skill.envs.utils.system import backend as _backend_mod
+
+            _orig_parse = _backend_mod.parse_sim_and_render_backend
+
+            def _patched_parse(sim_backend, render_backend):
+                result = _orig_parse(sim_backend, render_backend)
+                if result.render_backend == "sapien_cuda":
+                    result.render_backend = "sapien_cpu"
+                return result
+
+            _backend_mod.parse_sim_and_render_backend = _patched_parse
+
+            import mani_skill.envs.sapien_env  # type: ignore
+
+            mani_skill.envs.sapien_env.parse_sim_and_render_backend = _patched_parse
+        except Exception as e:
+            logger.warning("Could not patch mani_skill render backend to sapien_cpu: %s", e)
+
+        return True
+
     def reset(self, task: Task) -> Any:
+        self._setup_rendering()
         import robomme.robomme_env  # noqa: F401 — registers gym environments
         from robomme.env_record_wrapper import BenchmarkEnvBuilder
 
@@ -109,6 +362,7 @@ class RoboMMEBenchmark(StepBenchmark):
             except Exception:
                 pass
 
+        episode_idx = task.get("episode_idx", 0)
         builder = BenchmarkEnvBuilder(
             env_id=task["env_id"],
             dataset=self.dataset,
@@ -116,7 +370,7 @@ class RoboMMEBenchmark(StepBenchmark):
             gui_render=False,
             max_steps=self.max_steps,
         )
-        self._env = builder.make_env_for_episode(task.get("episode_idx", 0))
+        self._env = builder.make_env_for_episode(episode_idx)
         obs_batch, info_flat = self._env.reset()
 
         # Store conditioning video frames (demo trajectory, excluding final init frame)
@@ -127,6 +381,15 @@ class RoboMMEBenchmark(StepBenchmark):
         # Extract task description
         task_goal = info_flat["task_goal"]
         self._task_description = task_goal[0] if isinstance(task_goal, list) else str(task_goal)
+
+        if self.send_subgoal:
+            self._current_subgoal = self._extract_subgoal(info_flat)
+
+        if self._recorder is not None:
+            self._recorder.start(task)
+            front_list = obs_batch.get("front_rgb_list", [])
+            if front_list:
+                self._recorder.record(np.array(front_list[-1], copy=True))
 
         return obs_batch
 
@@ -142,6 +405,16 @@ class RoboMMEBenchmark(StepBenchmark):
         assert self._env is not None
         obs, reward, terminated, truncated, info = self._env.step(raw_action)
 
+        if self.send_subgoal:
+            self._current_subgoal = self._extract_subgoal(info)
+
+        if self._recorder is not None and obs:
+            front_list = obs.get("front_rgb_list", [])
+            if front_list:
+                # Copy explicitly: ManiSkill may reuse the same buffer across steps,
+                # which would make every saved frame identical to the last one.
+                self._recorder.record(np.array(front_list[-1], copy=True))
+
         # Cast potential torch scalars
         terminated = bool(terminated)
         truncated = bool(truncated)
@@ -149,6 +422,22 @@ class RoboMMEBenchmark(StepBenchmark):
         done = terminated or truncated or info.get("status") == "error"
 
         return StepResult(obs=obs, reward=reward, done=done, info=info)
+
+    def _extract_subgoal(self, info: dict[str, Any]) -> str:
+        """Pick the configured subgoal text from the env's info dict.
+
+        ``DemonstrationWrapper`` always populates ``simple_subgoal_online`` and
+        ``grounded_subgoal_online``; grounded may be empty OR may still hold
+        the raw placeholder template (e.g. ``"pick up the green cube at
+        <obj_center>"``) when segmentation hasn't been computed for the
+        current frame. Fall back to simple in either case so the model never
+        sees an unfilled template.
+        """
+        if self.subgoal_mode == "grounded":
+            grounded = str(info.get("grounded_subgoal_online") or "")
+            if grounded and not _UNFILLED_PLACEHOLDER_RE.search(grounded):
+                return grounded
+        return str(info.get("simple_subgoal_online") or "")
 
     def make_obs(self, raw_obs: Any, task: Task) -> Observation:
         # Handle error cases (FailAwareWrapper → None, IK failure → {})
@@ -185,13 +474,19 @@ class RoboMMEBenchmark(StepBenchmark):
             self._video_frames = []
             self._wrist_video_frames = []
 
+        if self.send_subgoal:
+            obs["subgoal"] = self._current_subgoal
+
         return obs
 
     def check_done(self, step_result: StepResult) -> bool:
         return step_result.done
 
     def get_step_result(self, step_result: StepResult) -> EpisodeResult:
-        return {"success": step_result.info.get("status") == "success"}
+        success = step_result.info.get("status") == "success"
+        if self._recorder is not None:
+            self._recorder.save(success=success)
+        return {"success": success}
 
     def get_metadata(self) -> dict[str, Any]:
         return {"max_steps": self.max_steps, "action_space": self.action_space}
@@ -208,6 +503,8 @@ class RoboMMEBenchmark(StepBenchmark):
             spec["wrist"] = IMAGE_RGB
         if self.send_state:
             spec["state"] = RAW
+        if self.send_subgoal:
+            spec["subgoal"] = LANGUAGE
         return spec
 
     def cleanup(self) -> None:
@@ -217,3 +514,7 @@ class RoboMMEBenchmark(StepBenchmark):
             except Exception:
                 pass
             self._env = None
+        self._video_frames = []
+        self._wrist_video_frames = []
+        if self._recorder is not None:
+            self._recorder.discard()

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -1,0 +1,233 @@
+"""Unit tests for ``vla_eval.benchmarks.recording.EpisodeVideoRecorder``.
+
+Exercises the full lifecycle (start → record → save / discard), filename
+templating (str + callable), required-context validation, error paths
+(writer-open failure, encode failure, missing context key at save), and
+state isolation between episodes.
+
+Frames are 4×4 RGB ``uint8`` stubs — small enough that ``imageio``'s
+ffmpeg writer copes without external codec setup, but real enough that
+the produced mp4 has a verifiable framecount.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from vla_eval.benchmarks.recording import EpisodeVideoRecorder
+
+
+def _frame() -> np.ndarray:
+    return np.zeros((4, 4, 3), dtype=np.uint8)
+
+
+def _count_frames(path: Path) -> int:
+    import imageio
+
+    with imageio.get_reader(str(path)) as r:
+        return r.count_frames()
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_save_writes_mp4_with_correct_framecount(tmp_path: Path) -> None:
+    rec = EpisodeVideoRecorder(output_dir=tmp_path, fps=10)
+    rec.start({"task_name": "PickCube", "episode_idx": 0})
+    for _ in range(5):
+        rec.record(_frame())
+    final = rec.save(status="success")
+
+    assert final is not None
+    assert final == tmp_path / "PickCube_ep0_success.mp4"
+    assert final.exists()
+    assert _count_frames(final) == 5
+
+
+def test_save_uses_status_in_filename(tmp_path: Path) -> None:
+    rec = EpisodeVideoRecorder(output_dir=tmp_path)
+    rec.start({"task_name": "T", "episode_idx": 7})
+    rec.record(_frame())
+    final = rec.save(status="fail")
+    assert final == tmp_path / "T_ep7_fail.mp4"
+    assert final.exists()
+
+
+def test_active_flag_tracks_lifecycle(tmp_path: Path) -> None:
+    rec = EpisodeVideoRecorder(output_dir=tmp_path)
+    assert rec.active is False
+    rec.start({"task_name": "T", "episode_idx": 0})
+    assert rec.active is True
+    rec.save()
+    assert rec.active is False
+
+
+def test_consecutive_episodes_each_produce_their_own_file(tmp_path: Path) -> None:
+    rec = EpisodeVideoRecorder(output_dir=tmp_path)
+    for ep in range(3):
+        rec.start({"task_name": "T", "episode_idx": ep})
+        rec.record(_frame())
+        rec.record(_frame())
+        final = rec.save(status="success")
+        assert final == tmp_path / f"T_ep{ep}_success.mp4"
+        assert final.exists()
+    assert sorted(p.name for p in tmp_path.glob("T_ep*.mp4")) == [
+        "T_ep0_success.mp4",
+        "T_ep1_success.mp4",
+        "T_ep2_success.mp4",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Filename templating
+# ---------------------------------------------------------------------------
+
+
+def test_filename_template_with_subdirectories(tmp_path: Path) -> None:
+    rec = EpisodeVideoRecorder(
+        output_dir=tmp_path,
+        filename="{suite}/{task_name}_ep{episode_idx:04d}_{status}.mp4",
+        required_context=("suite", "task_name", "episode_idx"),
+    )
+    rec.start({"suite": "Counting", "task_name": "PickX", "episode_idx": 12})
+    rec.record(_frame())
+    final = rec.save(status="success")
+    assert final == tmp_path / "Counting" / "PickX_ep0012_success.mp4"
+    assert final.exists()
+
+
+def test_filename_callable(tmp_path: Path) -> None:
+    def naming(ctx: Mapping[str, Any]) -> str:
+        return f"{ctx['run_id']}-{ctx['episode_idx']}-{ctx['status']}.mp4"
+
+    rec = EpisodeVideoRecorder(
+        output_dir=tmp_path,
+        filename=naming,
+        required_context=("run_id", "episode_idx"),
+    )
+    rec.start({"run_id": "abc", "episode_idx": 3})
+    rec.record(_frame())
+    final = rec.save(status="ok")
+    assert final == tmp_path / "abc-3-ok.mp4"
+
+
+def test_save_with_missing_template_key_is_handled(tmp_path: Path) -> None:
+    rec = EpisodeVideoRecorder(
+        output_dir=tmp_path,
+        filename="{task_name}_{seed}_{status}.mp4",
+    )
+    rec.start({"task_name": "T", "episode_idx": 0})  # `seed` missing
+    rec.record(_frame())
+    # Resolution happens at save() time; a missing key logs and returns None
+    # rather than raising.
+    final = rec.save(status="success")
+    assert final is None
+    # Tempfile must have been cleaned up.
+    assert list(tmp_path.glob(".recorder-*.mp4")) == []
+
+
+# ---------------------------------------------------------------------------
+# Validation / error paths
+# ---------------------------------------------------------------------------
+
+
+def test_start_missing_required_context_raises(tmp_path: Path) -> None:
+    rec = EpisodeVideoRecorder(output_dir=tmp_path)
+    with pytest.raises(ValueError, match="missing required context keys"):
+        rec.start({"task_name": "T"})  # episode_idx missing
+    assert rec.active is False
+
+
+def test_record_before_start_is_noop(tmp_path: Path) -> None:
+    rec = EpisodeVideoRecorder(output_dir=tmp_path)
+    rec.record(_frame())  # must not raise
+    assert rec.active is False
+
+
+def test_save_before_start_returns_none(tmp_path: Path) -> None:
+    rec = EpisodeVideoRecorder(output_dir=tmp_path)
+    assert rec.save() is None
+
+
+def test_discard_before_start_is_noop(tmp_path: Path) -> None:
+    rec = EpisodeVideoRecorder(output_dir=tmp_path)
+    rec.discard()  # must not raise
+    assert rec.active is False
+
+
+def test_writer_open_failure_leaves_recorder_inactive(tmp_path: Path) -> None:
+    rec = EpisodeVideoRecorder(output_dir=tmp_path)
+    with patch("imageio.get_writer", side_effect=RuntimeError("nope")):
+        rec.start({"task_name": "T", "episode_idx": 0})
+    assert rec.active is False
+    # No leftover tempfile.
+    assert list(tmp_path.glob(".recorder-*.mp4")) == []
+    # Subsequent record/save are no-ops.
+    rec.record(_frame())
+    assert rec.save() is None
+
+
+# ---------------------------------------------------------------------------
+# Mid-episode interruption / cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_start_again_without_save_discards_prior_episode(tmp_path: Path) -> None:
+    rec = EpisodeVideoRecorder(output_dir=tmp_path)
+    rec.start({"task_name": "T", "episode_idx": 0})
+    rec.record(_frame())
+    # Simulate orchestrator skipping save() / discard() and starting next ep:
+    rec.start({"task_name": "T", "episode_idx": 1})
+    rec.record(_frame())
+    final = rec.save(status="success")
+    assert final == tmp_path / "T_ep1_success.mp4"
+    # Only ep1 mp4 should exist; ep0's tempfile was cleaned up.
+    mp4s = sorted(p.name for p in tmp_path.glob("*.mp4"))
+    assert mp4s == ["T_ep1_success.mp4"]
+    assert list(tmp_path.glob(".recorder-*.mp4")) == []
+
+
+def test_discard_cleans_up_tempfile(tmp_path: Path) -> None:
+    rec = EpisodeVideoRecorder(output_dir=tmp_path)
+    rec.start({"task_name": "T", "episode_idx": 0})
+    rec.record(_frame())
+    rec.discard()
+    assert rec.active is False
+    assert list(tmp_path.glob(".recorder-*.mp4")) == []
+    assert list(tmp_path.glob("*.mp4")) == []
+
+
+# ---------------------------------------------------------------------------
+# Output dir created if missing
+# ---------------------------------------------------------------------------
+
+
+def test_output_dir_created_lazily(tmp_path: Path) -> None:
+    target = tmp_path / "nested" / "videos"
+    assert not target.exists()
+    rec = EpisodeVideoRecorder(output_dir=target)
+    rec.start({"task_name": "T", "episode_idx": 0})
+    rec.record(_frame())
+    final = rec.save()
+    assert final is not None
+    assert final.exists()
+    assert target.is_dir()
+
+
+def test_str_path_accepted(tmp_path: Path) -> None:
+    rec = EpisodeVideoRecorder(output_dir=str(tmp_path))
+    rec.start({"task_name": "T", "episode_idx": 0})
+    rec.record(_frame())
+    final = rec.save()
+    assert final is not None
+    assert final.exists()
+    assert os.fspath(final).startswith(str(tmp_path))


### PR DESCRIPTION
Three independent additions, plus a small Dockerfile fix.

## 1. `EpisodeVideoRecorder` — shared per-episode mp4 recorder

`vla_eval/benchmarks/recording.py` (new module). Streaming writer + logging-style filename templating, designed to be used across benchmarks (LIBERO/ManiSkill2/SimplerEnv/RoboTwin/etc.), not buried inside RoboMME. RoboMME is the first user in this PR.

```python
from vla_eval.benchmarks.recording import EpisodeVideoRecorder

recorder = EpisodeVideoRecorder(
    output_dir="/workspace/results/videos",
    # filename can stay default, or e.g.
    # filename="{suite}/{task}/{episode_idx:04d}_seed{seed}_{status}.mp4",
    fps=20,
    # writer_kwargs={"codec": "libx264", "quality": 8},  # optional codec knobs
)
recorder.start({"task_name": "PickCube", "episode_idx": 0})
for frame in episode_frames:
    recorder.record(frame)              # caller may mutate frame after this returns
recorder.save(status="success")         # → /workspace/results/videos/PickCube_ep0_success.mp4
# or recorder.discard()                 # cleanup paths
```

Design choices:

- **Streaming write** (`imageio.get_writer` + `append_data`) instead of buffering the full episode and `mimsave`-ing at the end. Memory drops from O(steps) to O(1); a 1300-step 256×256×3 episode that previously held ~250 MB now holds one frame at a time, encoding amortizes across the episode rather than blocking `save()` for several seconds, and a partial mp4 on disk after a mid-episode crash is debug-friendly.
- **Logging-style filename templating**: `str.format` template (or callable) over the context the caller passes at `start()` plus a `status` key injected at `save()`. `required_context` validates required keys early.
- **`status: str` not `success: bool`** — benchmarks may need `"timeout"`, `"error"`, `"truncated"`, `"partial"`.
- **Atomic finalize**: frames stream into a `.recorder-*.mp4` tempfile in the output dir, `save()` resolves the final filename and `os.replace`-s in place. Concurrent jobs sharing a directory don't collide; aborted episodes leave a clean tempfile that `discard()` removes.
- **`writer_kwargs`** forwarded to `imageio.get_writer` for codec/quality control without API churn.
- **Library choice**: kept `imageio`. PyAV would be ~10 lines of container/stream/packet boilerplate for the same result; OpenCV's BGR convention and per-OS codec compatibility add error vectors; nothing else is meaningfully simpler. The class is thin enough (one `get_writer` call site) that swapping backends later is a 30-line internal change.

`tests/test_recording.py`: 16 unit tests covering the lifecycle, both template forms, validation, error handling (writer-open failure, missing template key, mid-episode `start()`), and tempfile cleanup. All passing in the RoboMME container.

## 2. RoboMME GT subgoal exposure

| Param | Default | Effect |
|---|---|---|
| `send_subgoal: bool` | `False` | Attach per-step subgoal to `obs["subgoal"]`; declare `subgoal: LANGUAGE` in `get_observation_spec()`. |
| `subgoal_mode: Literal["grounded", "simple"]` | `"grounded"` | `"grounded"` uses `info['grounded_subgoal_online']` (placeholders filled with image coords, e.g. `"pick up the green cube at <77, 170>"`). Falls back to `"simple"` (`info['simple_subgoal_online']`) when grounded is empty or still holds an unfilled `<obj_center>`-style placeholder. |

`DemonstrationWrapper` always populates both keys upstream, so this just exposes existing data.

## 3. RoboMME H100 SAPIEN / Vulkan hang workaround

On a subset of DGX-H100 hosts, SAPIEN's `RenderSystem("cuda:0")` path hangs at `take_picture` — matches [SAPIEN #290](https://github.com/haosulab/SAPIEN/issues/290), closed as host-specific. Direct fleet diagnosis (`modinfo nvidia` + `take_picture` probe per node) confirms the split is not predictable from software config: kernel module flavor, apt packages, kernel cmdline, VBIOS all match across the hang/no-hang boundary. The fix bypasses NVIDIA Vulkan in favor of Mesa lavapipe.

Single env var, three modes:

| `ROBOMME_USE_LAVAPIPE` | Behavior |
|---|---|
| unset / `0` / `false` (default) | Native NVIDIA, no probe, no overhead. Will hang on affected hosts. |
| `1` / `true` / `yes` / `on` | Always engage lavapipe. |
| `auto` | Probe the native path in a child Python (`subprocess.run` SIGKILLs on timeout). Native works → leave SAPIEN alone (~3 s probe overhead, ~30–80 fps native rendering). Native hangs → engage lavapipe in this process. |

`auto` lets a single launcher cover the whole heterogeneous fleet without a per-host allowlist:

```yaml
docker:
  env:
    - "ROBOMME_USE_LAVAPIPE=auto"
```

When lavapipe engages, the benchmark also sets `LP_NUM_THREADS=4`, `OMP_NUM_THREADS=1`, `MKL_NUM_THREADS=1` (via `setdefault` — explicit launcher values always win). Empirical sweep on a 96-core A100, 16-shard concurrent RoboMME eval: `LP=4` wins at 41 s wall-clock vs 50 s at `LP=1`, slightly worse per-shard FPS at `LP=8`.

The lavapipe patch is the three-piece monkey-patch packaged as `_engage_lavapipe`:

1. `VK_ICD_FILENAMES` → lavapipe (Mesa software Vulkan).
2. Wrap `sapien.render.RenderSystem` to drop the `device` positional arg.
3. Patch `parse_sim_and_render_backend` in both the source module (`mani_skill.envs.utils.system.backend`) and the already-imported `mani_skill.envs.sapien_env`, so the resolved render backend is `sapien_cpu`.

If engagement is requested but can't take effect (sapien.render already imported, lavapipe ICD missing), `_setup_rendering` raises `RuntimeError` rather than silently continuing on the known-bad native path that would hang on the next `take_picture`.

`native_render_path_works(timeout_s=15) -> bool` is exposed publicly so launchers can health-check a host outside the benchmark lifecycle.

## 4. Dockerfile.base: idempotent NVIDIA ICD writes

On hosts whose Docker `default-runtime` is `nvidia`, nvidia-container-runtime bind-mounts the NVIDIA ICD JSONs read-only into every container including the build container; the unconditional `printf > file` then fails with `"Read-only file system"`. Switched to `[ -s file ] || printf > file` — skip when the bind-mount already provides the file. No-op on hosts with a regular runtime.

## Performance

| Host | Mode | Step FPS |
|---|---|---|
| A100 (healthy) | unset | ~92–135 |
| A100 (healthy) | `auto` (probes ~3 s, leaves SAPIEN on native) | ~53–95 |
| A100 (healthy) | `1` (forces lavapipe + LP=4) | ~5 |
| DGX-H100 hang nodes | `auto` (probe times out at ~15 s, engages lavapipe) | ~10–12 |
| DGX-H100 healthy nodes | unset | ~30–80 |

## Defaults / safety

All RoboMME additions are opt-in via constructor flags or env var; with everything unset the benchmark behaves exactly as before. The shared `EpisodeVideoRecorder` is only constructed when `save_episode_video=True`. The Dockerfile change is a no-op on regular-runtime hosts.

## Files

- `src/vla_eval/benchmarks/recording.py` (new, ~270 lines)
- `tests/test_recording.py` (new, ~250 lines, 16 tests)
- `src/vla_eval/benchmarks/robomme/benchmark.py` (~325 net new lines)
- `docker/Dockerfile.base` (~6 line change)

Lint clean (`ruff check`, `ruff format --check`). Tests pass against the RoboMME container's imageio.