### PR TITLE
refactor: extract per-episode video recorder into shared module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ license = {text = "Apache-2.0"}
 dependencies = [
     "anyio>=4.0.0",
     "filelock>=3.0",
+    "imageio[ffmpeg]",      # Streaming mp4 writer for benchmarks/recording.py
     "lazyregistry>=0.4.0",  # Python 3.8 support
     "msgpack>=1.0.0",
     "numpy>=1.24",

--- a/src/vla_eval/benchmarks/recording.py
+++ b/src/vla_eval/benchmarks/recording.py
@@ -1,43 +1,52 @@
 """Per-episode video recording helper, shared across benchmarks.
 
 Most benchmarks have a "save the agent's view of each episode as an mp4"
-need (failure-case debugging, demo browsing, public showcase, qualitative
-analysis).  This module is a single home for that pattern so each
-benchmark doesn't reinvent it.
+need (failure-case debugging, demo browsing, qualitative analysis).
+This module is one home for the pattern so each benchmark doesn't
+reinvent it.
 
-## Design
+## Design notes
 
-* **Streaming**: frames are encoded to disk as they arrive
-  (``imageio.get_writer`` + ``append_data``) rather than buffered in RAM.
-  Memory is O(1) regardless of episode length; a 1300-step 256×256×3
-  episode that previously held ~250 MB now holds one frame at a time.
-  A side benefit is that a partially-written mp4 is left on disk if the
-  process is killed mid-episode — playable up to the last completed
-  frame, useful for debugging crashes.
-* **Atomic finalize**: frames stream into a tempfile in the same output
-  directory; ``save()`` resolves the final filename (which usually
-  depends on success/failure status) and ``os.replace``-s the tempfile
-  into place.  Concurrent jobs sharing a directory don't collide.
-* **Logging-style filename templating**: the filename is a ``str.format``
-  template (or callable) over a context dict that the caller passes at
-  ``start()`` time, plus a ``status`` key injected at ``save()`` time.
-  ``filename`` and ``required_context`` are required at construction time
-  — there is no universal default because every benchmark names tasks
-  differently (``env_id``, ``task_id``, ``suite/task`` …).  Forcing the
-  caller to spell it out catches mismatched context keys at ``start()``
-  rather than as a silent dropped mp4 at ``save()``.
-* **Best-effort**: every encode-side failure logs a warning with the
-  context for debuggability and clears state — a corrupted video should
-  never bring down an otherwise good eval episode.
+* **Streaming write**: frames are encoded to disk as they arrive
+  (``imageio.get_writer`` + ``append_data``).  Memory is O(1)
+  regardless of episode length — a 1300-step 256×256×3 episode that
+  would have buffered ~250 MB now holds one frame at a time.
+* **Filename can encode success/fail status**: the final filename
+  often depends on whether the episode succeeded, which isn't known
+  until the episode ends.  ``record()`` therefore writes to a hidden
+  working file (``.recorder-<uid>.mp4`` in ``output_dir``); ``save()``
+  resolves the final filename and renames the working file into place.
+* **Required-context fail-fast**: ``filename`` declares the template,
+  and ``required_context`` declares the keys the caller will pass at
+  ``start()``.  Missing keys raise at ``start()``, before frames are
+  recorded — not as a silent ``KeyError`` -> dropped mp4 at ``save()``.
+  For ``str.format`` templates, ``required_context`` is auto-derived
+  from the field names so callers don't have to repeat themselves.
+* **Collision detection at save**: if the resolved final path already
+  exists and the recorder wasn't constructed with ``overwrite=True``,
+  ``save()`` raises ``FileExistsError`` and leaves the working file
+  on disk so the caller can recover the frames.
+
+## Filename layout
+
+Two non-obvious things that catch users out:
+
+1. **Zero-pad ``episode_idx``**: ``"ep{episode_idx:04d}"`` not
+   ``"ep{episode_idx}"`` — alphabetic sort otherwise puts ``ep10``
+   before ``ep2``.
+2. **Put the field you'd want to scan adjacent files by first.**
+   For multi-camera recording (front + wrist + ...), the views of
+   the same episode are usually what you want to compare side-by-side,
+   so ``"ep{episode_idx:04d}_{view}_{status}.mp4"`` keeps them
+   adjacent.  For multi-task single-camera, the task is more useful
+   first: ``"{task}_ep{episode_idx:04d}_{status}.mp4"``.
 
 ## Caller pattern
 
-    from vla_eval.benchmarks.recording import EpisodeVideoRecorder
-
     recorder = EpisodeVideoRecorder(
         output_dir="/workspace/results/videos",
-        filename="{env_id}_ep{episode_idx}_{status}.mp4",
-        required_context=("env_id", "episode_idx"),
+        filename="{env_id}_ep{episode_idx:04d}_{status}.mp4",
+        # required_context is auto-derived for str templates → ("env_id", "episode_idx")
         fps=20,
     )
 
@@ -46,30 +55,25 @@ benchmark doesn't reinvent it.
     recorder.record(initial_frame)
 
     # In benchmark.step(action):
-    recorder.record(frame)  # default ffmpeg path copies via .tobytes() —
-                            # see record() docstring for backend caveats
+    recorder.record(frame)
 
     # In benchmark.get_step_result(step_result):
     recorder.save(status="success" if success else "fail")
 
     # In benchmark.cleanup():
-    recorder.discard()  # drops any in-flight writer + tempfile
+    recorder.discard()  # drops any in-flight working file
 
-## Multi-camera
-
-The recorder is single-stream by design.  Benchmarks with multiple views
-(e.g. front + wrist) instantiate one recorder per view with different
-``filename`` templates (e.g. ``"{view}_ep{episode_idx}_{status}.mp4"``,
-substituting the view name into the context at ``start()``).  This keeps
-each recorder simple and lets callers mix-and-match resolutions, fps,
-and codecs per view.
+Each recorder records a single stream.  To capture multiple views
+(e.g. front + wrist), construct one recorder per view; they don't
+share state.
 """
 
 from __future__ import annotations
 
 import logging
 import os
-import tempfile
+import string
+import uuid
 from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -79,9 +83,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Either a `str.format`-style template or a callable that takes the resolved
-# context (caller's start() context + injected ``status``) and returns a
-# filename relative to ``output_dir``.
+# A `str.format`-style template, or a callable taking the resolved context
+# (caller's start() context + injected ``status``) and returning a filename
+# relative to ``output_dir``.
 FilenameSpec = str | Callable[[Mapping[str, Any]], str]
 
 
@@ -90,58 +94,83 @@ class EpisodeVideoRecorder:
 
     Lifecycle: ``start()`` → ``record()`` × N → ``save()`` (or
     ``discard()``).  ``start()`` may be called again to begin a new
-    episode; if a previous episode never reached ``save()``/``discard()``
-    (e.g. orchestrator crash) the in-flight writer is closed and its
-    tempfile cleaned up first.
+    episode; if a previous episode never reached
+    ``save()``/``discard()``, its working file is dropped first.
 
     Inactive (no episode in progress) is a valid state: ``record()`` /
-    ``save()`` / ``discard()`` are no-ops in that case so callers don't
-    need defensive ``if recorder.active`` checks.
+    ``save()`` / ``discard()`` are no-ops then, so callers don't need
+    defensive ``if recorder.active`` checks.
     """
 
     def __init__(
         self,
         output_dir: str | os.PathLike[str],
         filename: FilenameSpec,
-        required_context: Sequence[str],
+        required_context: Sequence[str] | None = None,
         fps: int = 20,
+        overwrite: bool = False,
         writer_kwargs: Mapping[str, Any] | None = None,
     ) -> None:
         """
         Args:
-            output_dir: Directory the final mp4 lands in.  Created if missing.
-                Filename templates may include subdirectories (e.g.
-                ``"{suite}/{task}_..."``); intermediate dirs are also created.
+            output_dir: Directory the final mp4 lands in.  Created on
+                first ``start()`` if missing.  Filename templates may
+                include subdirectories (``"{suite}/{task}_..."``);
+                intermediate dirs are created at ``save()`` time.
             filename: ``str.format`` template or callable producing the
-                filename relative to ``output_dir``.  Resolved at ``save()``
-                time over ``{**start_context, "status": status}``.  Required
-                because every benchmark identifies tasks differently
-                (``env_id``, ``task_id``, ``suite/task``) — there is no
-                universally safe default.
-            required_context: Keys that must be present in the dict passed to
-                ``start()``.  ``ValueError`` is raised at ``start()`` if any
-                are missing.  Required so callers explicitly declare the
-                template's expectations; failing fast at ``start()`` avoids
-                a silent ``KeyError`` -> dropped mp4 at ``save()`` time.
-                Should include every key the ``filename`` template references.
+                filename relative to ``output_dir``.  Resolved at
+                ``save()`` time over ``{**start_context, "status": status}``.
+                Required because every benchmark identifies tasks
+                differently (``env_id``, ``task_id``, ``suite/task``);
+                there is no universally safe default.
+            required_context: Keys that must be present in the dict
+                passed to ``start()``.  ``ValueError`` is raised at
+                ``start()`` if any are missing.  When ``None`` (the
+                default) and ``filename`` is a ``str.format`` template,
+                this is auto-derived from the template's field names
+                (``status`` excluded, since ``save()`` injects it) —
+                callers don't have to repeat themselves.  When the
+                ``filename`` is a callable, this must be specified
+                explicitly: there's no way to introspect a callable's
+                key dependencies.  An explicit value is allowed to be
+                a subset of the template's keys (i.e. some keys can be
+                optional — they'll fail at ``save()`` time if
+                ultimately missing).
             fps: Output framerate.
-            writer_kwargs: Extra kwargs forwarded to ``imageio.get_writer``
-                (e.g. ``{"codec": "libx264", "quality": 8}``).
+            overwrite: When False (default), ``save()`` raises
+                ``FileExistsError`` if the resolved final path is already
+                taken.  When True, an existing file is replaced.
+            writer_kwargs: Extra kwargs forwarded to
+                ``imageio.get_writer`` (e.g. ``{"codec": "libx264",
+                "quality": 8}``).
         """
         self.output_dir = Path(output_dir)
         self._filename_spec = filename
         self.fps = fps
+        if required_context is None:
+            if not isinstance(filename, str):
+                raise ValueError(
+                    "required_context must be specified when filename is a callable; "
+                    "the recorder can't introspect callables to discover key dependencies."
+                )
+            required_context = _fields_from_template(filename)
         self._required_context = tuple(required_context)
+        self._overwrite = overwrite
         self._writer_kwargs = dict(writer_kwargs or {})
+
+        # One working file per recorder instance, reused across episodes.
+        # Hidden (`.recorder-`) so it doesn't show up in casual listings,
+        # uuid-suffixed so concurrent recorders sharing output_dir don't
+        # collide.
+        self._working_path = self.output_dir / f".recorder-{uuid.uuid4().hex[:12]}.mp4"
 
         # Lifecycle state — None whenever no episode is in progress.
         self._writer: Any = None
-        self._tempfile: Path | None = None
         self._context: dict[str, Any] | None = None
         self._frames_written = 0
-        # Latched on the first record() failure so we don't log-spam every
-        # subsequent step with the same warning when the underlying writer
-        # is wedged (corrupt subprocess pipe, etc.).
+        # Latched on the first record() failure so the writer being
+        # wedged (corrupt subprocess pipe, etc.) doesn't produce one
+        # warning per step.
         self._record_failed = False
 
     @property
@@ -151,11 +180,11 @@ class EpisodeVideoRecorder:
     def start(self, context: Mapping[str, Any]) -> None:
         """Begin a new episode.
 
-        Validates required context keys, opens a streaming writer to a
-        tempfile in ``output_dir``.  If a previous episode is still in
-        flight (no ``save``/``discard`` called) it is discarded first.
-        On writer-open failure the recorder stays inactive and subsequent
-        ``record()``/``save()`` are no-ops; the failure is logged.
+        Validates required context keys, opens a streaming writer to
+        the working file.  If a previous episode is still in flight
+        (no ``save()`` / ``discard()``) it is dropped first.  On
+        writer-open failure the recorder stays inactive and subsequent
+        ``record()`` / ``save()`` are no-ops; the failure is logged.
         """
         missing = [k for k in self._required_context if k not in context]
         if missing:
@@ -165,39 +194,29 @@ class EpisodeVideoRecorder:
             self.discard()
 
         self._context = dict(context)
+        self._frames_written = 0
         self._record_failed = False
         try:
             self.output_dir.mkdir(parents=True, exist_ok=True)
-            # Tempfile keeps a real `.mp4` suffix so imageio's format
-            # auto-detection works; the `.recorder-` prefix marks it as ours.
-            fd, temp_path = tempfile.mkstemp(
-                prefix=".recorder-",
-                suffix=".mp4",
-                dir=str(self.output_dir),
-            )
-            os.close(fd)
-            self._tempfile = Path(temp_path)
-
             import imageio
 
-            self._writer = imageio.get_writer(str(self._tempfile), fps=self.fps, **self._writer_kwargs)
+            self._writer = imageio.get_writer(str(self._working_path), fps=self.fps, **self._writer_kwargs)
         except Exception as e:
             logger.warning("Failed to open video writer for context=%r: %s", self._context, e)
-            _safe_unlink(self._tempfile)
-            self._tempfile = None
             self._writer = None
             self._context = None
+            _safe_unlink(self._working_path)
 
     def record(self, frame: np.ndarray) -> None:
         """Append a frame to the in-flight episode.
 
         On the default ``.mp4`` / ffmpeg path, imageio serializes the
-        frame via ``np.ndarray.tobytes()`` before piping it to the
-        encoder subprocess — that's a synchronous copy, so the caller
-        can mutate the underlying buffer once this returns.  If you
-        configure a non-ffmpeg writer that retains references (e.g.
-        the pillow plugin appends ``Image.fromarray(arr)`` to a list
-        flushed at close), you must pass copies yourself.
+        frame via ``ndarray.tobytes()`` before piping it to the encoder
+        subprocess — that's a synchronous copy, so the caller can mutate
+        the underlying buffer once this returns.  If you configure a
+        non-ffmpeg writer that retains references (e.g. the pillow
+        plugin appends ``Image.fromarray(arr)`` to a list flushed at
+        close), pass copies yourself.
 
         No-op if no episode is in progress.  The first encode failure
         latches the recorder so subsequent ``record()`` calls become
@@ -210,7 +229,7 @@ class EpisodeVideoRecorder:
             self._frames_written += 1
         except Exception as e:
             logger.warning(
-                "record() failed for context=%r at frame %d: %s; remaining frames in this episode will be dropped",
+                "record() failed for context=%r at frame %d: %s; remaining frames will be dropped",
                 self._context,
                 self._frames_written,
                 e,
@@ -220,59 +239,69 @@ class EpisodeVideoRecorder:
     def save(self, status: str = "success") -> Path | None:
         """Finalize the in-flight episode.
 
-        Closes the streaming writer, resolves the final filename from
-        ``{**context, "status": status}``, and atomically moves the
-        tempfile into place.  Returns the final ``Path`` on success,
-        ``None`` if the recorder was inactive or any finalize step
-        failed.  After this call the recorder is inactive again.
+        Closes the writer, resolves the final filename from
+        ``{**context, "status": status}``, and moves the working file
+        into place.  Returns the final ``Path``, or ``None`` if the
+        recorder was inactive or filename resolution / writer close
+        failed.
+
+        Raises:
+            FileExistsError: if the resolved final path already exists
+                and the recorder was constructed with ``overwrite=False``
+                (the default).  The working file is left on disk so the
+                caller can recover the frames manually.
         """
         if not self.active:
             return None
 
-        writer, tempfile_path, context = self._writer, self._tempfile, self._context
+        writer, context = self._writer, self._context
         frames_written = self._frames_written
+        # Reset state up front: any return path below leaves the recorder inactive.
+        self._writer = None
+        self._context = None
+        self._frames_written = 0
+        self._record_failed = False
+
         try:
-            try:
-                writer.close()
-            except Exception as e:
-                logger.warning("Failed to close video writer for context=%r: %s", context, e)
-                _safe_unlink(tempfile_path)
-                return None
+            writer.close()
+        except Exception as e:
+            logger.warning("Failed to close video writer for context=%r: %s", context, e)
+            _safe_unlink(self._working_path)
+            return None
 
-            try:
-                relative_name = self._resolve_filename({**(context or {}), "status": status})
-            except Exception as e:
-                logger.warning("Failed to resolve filename for context=%r status=%r: %s", context, status, e)
-                _safe_unlink(tempfile_path)
-                return None
+        try:
+            relative_name = self._resolve_filename({**(context or {}), "status": status})
+        except Exception as e:
+            logger.warning("Failed to resolve filename for context=%r status=%r: %s", context, status, e)
+            _safe_unlink(self._working_path)
+            return None
 
-            final_path = self.output_dir / relative_name
-            try:
-                final_path.parent.mkdir(parents=True, exist_ok=True)
-                os.replace(str(tempfile_path), str(final_path))
-            except Exception as e:
-                logger.warning("Failed to finalize video at %s for context=%r: %s", final_path, context, e)
-                _safe_unlink(tempfile_path)
-                return None
+        final_path = self.output_dir / relative_name
+        if final_path.exists() and not self._overwrite:
+            raise FileExistsError(
+                f"{final_path} already exists. Recorded frames are at {self._working_path}. "
+                f"Pass overwrite=True to replace, or rename the working file manually."
+            )
 
-            logger.info("Saved episode video: %s (%d frames)", final_path, frames_written)
-            return final_path
-        finally:
-            self._writer = None
-            self._tempfile = None
-            self._context = None
-            self._frames_written = 0
-            self._record_failed = False
+        try:
+            final_path.parent.mkdir(parents=True, exist_ok=True)
+            os.replace(str(self._working_path), str(final_path))
+        except Exception as e:
+            logger.warning("Failed to move working file to %s for context=%r: %s", final_path, context, e)
+            _safe_unlink(self._working_path)
+            return None
+
+        logger.info("Saved episode video: %s (%d frames)", final_path, frames_written)
+        return final_path
 
     def discard(self) -> None:
         """Abandon the in-flight episode without producing an mp4.
 
-        Closes the writer (best-effort) and removes the tempfile.  Safe
-        to call when no episode is in progress (no-op).
+        Closes the writer (best-effort) and removes the working file.
+        Safe to call when no episode is in progress (no-op).
         """
-        writer, tempfile_path = self._writer, self._tempfile
+        writer = self._writer
         self._writer = None
-        self._tempfile = None
         self._context = None
         self._frames_written = 0
         self._record_failed = False
@@ -281,7 +310,7 @@ class EpisodeVideoRecorder:
                 writer.close()
             except Exception:
                 pass
-        _safe_unlink(tempfile_path)
+        _safe_unlink(self._working_path)
 
     def _resolve_filename(self, context: Mapping[str, Any]) -> str:
         spec = self._filename_spec
@@ -290,10 +319,30 @@ class EpisodeVideoRecorder:
         return spec(context)
 
 
-def _safe_unlink(path: Path | None) -> None:
-    if path is None:
-        return
+def _safe_unlink(path: Path) -> None:
     try:
         path.unlink(missing_ok=True)
     except Exception:
         pass
+
+
+def _fields_from_template(template: str) -> tuple[str, ...]:
+    """Extract top-level field names from a ``str.format`` template.
+
+    ``status`` is excluded — ``save()`` always injects it and it would
+    just cause a spurious "missing required context key" failure if
+    treated as required.  Format specs (``:04d``) and attribute /
+    indexing access are stripped: ``"{episode_idx:04d}"`` →
+    ``"episode_idx"``, ``"{task.name}"`` → ``"task"``.  Order is
+    preserved (first occurrence wins) so error messages are
+    deterministic.
+    """
+    seen: list[str] = []
+    for _, field_name, _, _ in string.Formatter().parse(template):
+        if not field_name:
+            continue
+        # `field_name` can be "name", "name.attr", "name[0]", or just "0" for positional.
+        bare = field_name.split(".", 1)[0].split("[", 1)[0]
+        if bare and bare != "status" and bare not in seen:
+            seen.append(bare)
+    return tuple(seen)

--- a/src/vla_eval/benchmarks/recording.py
+++ b/src/vla_eval/benchmarks/recording.py
@@ -1,45 +1,36 @@
 """Per-episode video recording helper, shared across benchmarks.
 
-Most benchmarks have a "save the agent's view of each episode as an mp4"
-need (failure-case debugging, demo browsing, qualitative analysis).
-This module is one home for the pattern so each benchmark doesn't
+Most benchmarks have a "save the agent's view of each episode as an mp4" need (failure-case debugging,
+demo browsing, qualitative analysis).  This module is one home for the pattern so each benchmark doesn't
 reinvent it.
 
 ## Design notes
 
-* **Streaming write**: frames are encoded to disk as they arrive
-  (``imageio.get_writer`` + ``append_data``).  Memory is O(1)
-  regardless of episode length — a 1300-step 256×256×3 episode that
-  would have buffered ~250 MB now holds one frame at a time.
-* **Filename can encode success/fail status**: the final filename
-  often depends on whether the episode succeeded, which isn't known
-  until the episode ends.  ``record()`` therefore writes to a hidden
-  working file (``.recorder-<uid>.mp4`` in ``output_dir``); ``save()``
-  resolves the final filename and renames the working file into place.
-* **Required-context fail-fast**: ``filename`` declares the template,
-  and ``required_context`` declares the keys the caller will pass at
-  ``start()``.  Missing keys raise at ``start()``, before frames are
-  recorded — not as a silent ``KeyError`` -> dropped mp4 at ``save()``.
-  For ``str.format`` templates, ``required_context`` is auto-derived
-  from the field names so callers don't have to repeat themselves.
-* **Collision detection at save**: if the resolved final path already
-  exists and the recorder wasn't constructed with ``overwrite=True``,
-  ``save()`` raises ``FileExistsError`` and leaves the working file
+* **Streaming write**: frames are encoded to disk as they arrive (``imageio.get_writer`` + ``append_data``).
+  Memory is O(1) regardless of episode length — a 1300-step 256×256×3 episode that would have buffered
+  ~250 MB now holds one frame at a time.
+* **Filename can encode success/fail status**: the final filename often depends on whether the episode
+  succeeded, which isn't known until the episode ends.  ``record()`` therefore writes to a hidden working
+  file (``.recorder-<uid>.mp4`` in ``output_dir``); ``save()`` resolves the final filename and renames the
+  working file into place.
+* **Required-context fail-fast**: ``filename`` declares the template, and ``required_context`` declares
+  the keys the caller will pass at ``start()``.  Missing keys raise at ``start()``, before frames are
+  recorded — not as a silent ``KeyError`` -> dropped mp4 at ``save()``.  For ``str.format`` templates,
+  ``required_context`` is auto-derived from the field names so callers don't have to repeat themselves.
+* **Collision detection at save**: if the resolved final path already exists and the recorder wasn't
+  constructed with ``overwrite=True``, ``save()`` raises ``FileExistsError`` and leaves the working file
   on disk so the caller can recover the frames.
 
 ## Filename layout
 
 Two non-obvious things that catch users out:
 
-1. **Zero-pad ``episode_idx``**: ``"ep{episode_idx:04d}"`` not
-   ``"ep{episode_idx}"`` — alphabetic sort otherwise puts ``ep10``
-   before ``ep2``.
-2. **Put the field you'd want to scan adjacent files by first.**
-   For multi-camera recording (front + wrist + ...), the views of
-   the same episode are usually what you want to compare side-by-side,
-   so ``"ep{episode_idx:04d}_{view}_{status}.mp4"`` keeps them
-   adjacent.  For multi-task single-camera, the task is more useful
-   first: ``"{task}_ep{episode_idx:04d}_{status}.mp4"``.
+1. **Zero-pad ``episode_idx``**: ``"ep{episode_idx:04d}"`` not ``"ep{episode_idx}"`` — alphabetic sort
+   otherwise puts ``ep10`` before ``ep2``.
+2. **Put the field you'd want to scan adjacent files by first.**  For multi-camera recording (front +
+   wrist + ...), the views of the same episode are usually what you want to compare side-by-side, so
+   ``"ep{episode_idx:04d}_{view}_{status}.mp4"`` keeps them adjacent.  For multi-task single-camera, the
+   task is more useful first: ``"{task}_ep{episode_idx:04d}_{status}.mp4"``.
 
 ## Caller pattern
 
@@ -63,9 +54,8 @@ Two non-obvious things that catch users out:
     # In benchmark.cleanup():
     recorder.discard()  # drops any in-flight working file
 
-Each recorder records a single stream.  To capture multiple views
-(e.g. front + wrist), construct one recorder per view; they don't
-share state.
+Each recorder records a single stream.  To capture multiple views (e.g. front + wrist), construct one
+recorder per view; they don't share state.
 """
 
 from __future__ import annotations
@@ -83,23 +73,20 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# A `str.format`-style template, or a callable taking the resolved context
-# (caller's start() context + injected ``status``) and returning a filename
-# relative to ``output_dir``.
+# A `str.format`-style template, or a callable taking the resolved context (caller's start() context +
+# injected ``status``) and returning a filename relative to ``output_dir``.
 FilenameSpec = str | Callable[[Mapping[str, Any]], str]
 
 
 class EpisodeVideoRecorder:
     """Streaming per-episode video recorder.
 
-    Lifecycle: ``start()`` → ``record()`` × N → ``save()`` (or
-    ``discard()``).  ``start()`` may be called again to begin a new
-    episode; if a previous episode never reached
-    ``save()``/``discard()``, its working file is dropped first.
+    Lifecycle: ``start()`` → ``record()`` × N → ``save()`` (or ``discard()``).  ``start()`` may be called
+    again to begin a new episode; if a previous episode never reached ``save()``/``discard()``, its
+    working file is dropped first.
 
-    Inactive (no episode in progress) is a valid state: ``record()`` /
-    ``save()`` / ``discard()`` are no-ops then, so callers don't need
-    defensive ``if recorder.active`` checks.
+    Inactive (no episode in progress) is a valid state: ``record()`` / ``save()`` / ``discard()`` are
+    no-ops then, so callers don't need defensive ``if recorder.active`` checks.
     """
 
     def __init__(
@@ -109,40 +96,27 @@ class EpisodeVideoRecorder:
         required_context: Sequence[str] | None = None,
         fps: int = 20,
         overwrite: bool = False,
-        writer_kwargs: Mapping[str, Any] | None = None,
     ) -> None:
         """
         Args:
-            output_dir: Directory the final mp4 lands in.  Created on
-                first ``start()`` if missing.  Filename templates may
-                include subdirectories (``"{suite}/{task}_..."``);
-                intermediate dirs are created at ``save()`` time.
-            filename: ``str.format`` template or callable producing the
-                filename relative to ``output_dir``.  Resolved at
-                ``save()`` time over ``{**start_context, "status": status}``.
-                Required because every benchmark identifies tasks
-                differently (``env_id``, ``task_id``, ``suite/task``);
-                there is no universally safe default.
-            required_context: Keys that must be present in the dict
-                passed to ``start()``.  ``ValueError`` is raised at
-                ``start()`` if any are missing.  When ``None`` (the
-                default) and ``filename`` is a ``str.format`` template,
-                this is auto-derived from the template's field names
-                (``status`` excluded, since ``save()`` injects it) —
-                callers don't have to repeat themselves.  When the
-                ``filename`` is a callable, this must be specified
-                explicitly: there's no way to introspect a callable's
-                key dependencies.  An explicit value is allowed to be
-                a subset of the template's keys (i.e. some keys can be
-                optional — they'll fail at ``save()`` time if
-                ultimately missing).
+            output_dir: Directory the final mp4 lands in.  Created on first ``start()`` if missing.
+                Filename templates may include subdirectories (``"{suite}/{task}_..."``); intermediate
+                dirs are created at ``save()`` time.
+            filename: ``str.format`` template or callable producing the filename relative to
+                ``output_dir``.  Resolved at ``save()`` time over ``{**start_context, "status": status}``.
+                Required because every benchmark identifies tasks differently (``env_id``, ``task_id``,
+                ``suite/task``); there is no universally safe default.
+            required_context: Keys that must be present in the dict passed to ``start()``.  ``ValueError``
+                is raised at ``start()`` if any are missing.  When ``None`` (the default) and ``filename``
+                is a ``str.format`` template, this is auto-derived from the template's field names
+                (``status`` excluded, since ``save()`` injects it) — callers don't have to repeat
+                themselves.  When the ``filename`` is a callable, this must be specified explicitly:
+                there's no way to introspect a callable's key dependencies.  An explicit value is allowed
+                to be a subset of the template's keys (i.e. some keys can be optional — they'll fail at
+                ``save()`` time if ultimately missing).
             fps: Output framerate.
-            overwrite: When False (default), ``save()`` raises
-                ``FileExistsError`` if the resolved final path is already
-                taken.  When True, an existing file is replaced.
-            writer_kwargs: Extra kwargs forwarded to
-                ``imageio.get_writer`` (e.g. ``{"codec": "libx264",
-                "quality": 8}``).
+            overwrite: When False (default), ``save()`` raises ``FileExistsError`` if the resolved final
+                path is already taken.  When True, an existing file is replaced.
         """
         self.output_dir = Path(output_dir)
         self._filename_spec = filename
@@ -156,21 +130,18 @@ class EpisodeVideoRecorder:
             required_context = _fields_from_template(filename)
         self._required_context = tuple(required_context)
         self._overwrite = overwrite
-        self._writer_kwargs = dict(writer_kwargs or {})
 
-        # One working file per recorder instance, reused across episodes.
-        # Hidden (`.recorder-`) so it doesn't show up in casual listings,
-        # uuid-suffixed so concurrent recorders sharing output_dir don't
-        # collide.
+        # One working file per recorder instance, reused across episodes.  Hidden (`.recorder-`) so it
+        # doesn't show up in casual listings, uuid-suffixed so concurrent recorders sharing output_dir
+        # don't collide.
         self._working_path = self.output_dir / f".recorder-{uuid.uuid4().hex[:12]}.mp4"
 
         # Lifecycle state — None whenever no episode is in progress.
         self._writer: Any = None
         self._context: dict[str, Any] | None = None
         self._frames_written = 0
-        # Latched on the first record() failure so the writer being
-        # wedged (corrupt subprocess pipe, etc.) doesn't produce one
-        # warning per step.
+        # Latched on the first record() failure so the writer being wedged (corrupt subprocess pipe, etc.)
+        # doesn't produce one warning per step.
         self._record_failed = False
 
     @property
@@ -180,11 +151,10 @@ class EpisodeVideoRecorder:
     def start(self, context: Mapping[str, Any]) -> None:
         """Begin a new episode.
 
-        Validates required context keys, opens a streaming writer to
-        the working file.  If a previous episode is still in flight
-        (no ``save()`` / ``discard()``) it is dropped first.  On
-        writer-open failure the recorder stays inactive and subsequent
-        ``record()`` / ``save()`` are no-ops; the failure is logged.
+        Validates required context keys, opens a streaming writer to the working file.  If a previous
+        episode is still in flight (no ``save()`` / ``discard()``) it is dropped first.  On writer-open
+        failure the recorder stays inactive and subsequent ``record()`` / ``save()`` are no-ops; the
+        failure is logged.
         """
         missing = [k for k in self._required_context if k not in context]
         if missing:
@@ -200,7 +170,7 @@ class EpisodeVideoRecorder:
             self.output_dir.mkdir(parents=True, exist_ok=True)
             import imageio
 
-            self._writer = imageio.get_writer(str(self._working_path), fps=self.fps, **self._writer_kwargs)
+            self._writer = imageio.get_writer(str(self._working_path), fps=self.fps)
         except Exception as e:
             logger.warning("Failed to open video writer for context=%r: %s", self._context, e)
             self._writer = None
@@ -210,17 +180,14 @@ class EpisodeVideoRecorder:
     def record(self, frame: np.ndarray) -> None:
         """Append a frame to the in-flight episode.
 
-        On the default ``.mp4`` / ffmpeg path, imageio serializes the
-        frame via ``ndarray.tobytes()`` before piping it to the encoder
-        subprocess — that's a synchronous copy, so the caller can mutate
-        the underlying buffer once this returns.  If you configure a
-        non-ffmpeg writer that retains references (e.g. the pillow
-        plugin appends ``Image.fromarray(arr)`` to a list flushed at
-        close), pass copies yourself.
+        On the default ``.mp4`` / ffmpeg path, imageio serializes the frame via ``ndarray.tobytes()``
+        before piping it to the encoder subprocess — that's a synchronous copy, so the caller can mutate
+        the underlying buffer once this returns.  If you configure a non-ffmpeg writer that retains
+        references (e.g. the pillow plugin appends ``Image.fromarray(arr)`` to a list flushed at close),
+        pass copies yourself.
 
-        No-op if no episode is in progress.  The first encode failure
-        latches the recorder so subsequent ``record()`` calls become
-        no-ops rather than flooding the log.
+        No-op if no episode is in progress.  The first encode failure latches the recorder so subsequent
+        ``record()`` calls become no-ops rather than flooding the log.
         """
         if not self.active or self._record_failed:
             return
@@ -239,17 +206,14 @@ class EpisodeVideoRecorder:
     def save(self, status: str = "success") -> Path | None:
         """Finalize the in-flight episode.
 
-        Closes the writer, resolves the final filename from
-        ``{**context, "status": status}``, and moves the working file
-        into place.  Returns the final ``Path``, or ``None`` if the
-        recorder was inactive or filename resolution / writer close
-        failed.
+        Closes the writer, resolves the final filename from ``{**context, "status": status}``, and moves
+        the working file into place.  Returns the final ``Path``, or ``None`` if the recorder was inactive
+        or filename resolution / writer close failed.
 
         Raises:
-            FileExistsError: if the resolved final path already exists
-                and the recorder was constructed with ``overwrite=False``
-                (the default).  The working file is left on disk so the
-                caller can recover the frames manually.
+            FileExistsError: if the resolved final path already exists and the recorder was constructed
+                with ``overwrite=False`` (the default).  The working file is left on disk so the caller
+                can recover the frames manually.
         """
         if not self.active:
             return None
@@ -297,8 +261,8 @@ class EpisodeVideoRecorder:
     def discard(self) -> None:
         """Abandon the in-flight episode without producing an mp4.
 
-        Closes the writer (best-effort) and removes the working file.
-        Safe to call when no episode is in progress (no-op).
+        Closes the writer (best-effort) and removes the working file.  Safe to call when no episode is in
+        progress (no-op).
         """
         writer = self._writer
         self._writer = None
@@ -329,13 +293,10 @@ def _safe_unlink(path: Path) -> None:
 def _fields_from_template(template: str) -> tuple[str, ...]:
     """Extract top-level field names from a ``str.format`` template.
 
-    ``status`` is excluded — ``save()`` always injects it and it would
-    just cause a spurious "missing required context key" failure if
-    treated as required.  Format specs (``:04d``) and attribute /
-    indexing access are stripped: ``"{episode_idx:04d}"`` →
-    ``"episode_idx"``, ``"{task.name}"`` → ``"task"``.  Order is
-    preserved (first occurrence wins) so error messages are
-    deterministic.
+    ``status`` is excluded — ``save()`` always injects it and it would just cause a spurious "missing
+    required context key" failure if treated as required.  Format specs (``:04d``) and attribute /
+    indexing access are stripped: ``"{episode_idx:04d}"`` → ``"episode_idx"``, ``"{task.name}"`` →
+    ``"task"``.  Order is preserved (first occurrence wins) so error messages are deterministic.
     """
     seen: list[str] = []
     for _, field_name, _, _ in string.Formatter().parse(template):

--- a/src/vla_eval/benchmarks/recording.py
+++ b/src/vla_eval/benchmarks/recording.py
@@ -1,0 +1,299 @@
+"""Per-episode video recording helper, shared across benchmarks.
+
+Most benchmarks have a "save the agent's view of each episode as an mp4"
+need (failure-case debugging, demo browsing, public showcase, qualitative
+analysis).  This module is a single home for that pattern so each
+benchmark doesn't reinvent it.
+
+## Design
+
+* **Streaming**: frames are encoded to disk as they arrive
+  (``imageio.get_writer`` + ``append_data``) rather than buffered in RAM.
+  Memory is O(1) regardless of episode length; a 1300-step 256×256×3
+  episode that previously held ~250 MB now holds one frame at a time.
+  A side benefit is that a partially-written mp4 is left on disk if the
+  process is killed mid-episode — playable up to the last completed
+  frame, useful for debugging crashes.
+* **Atomic finalize**: frames stream into a tempfile in the same output
+  directory; ``save()`` resolves the final filename (which usually
+  depends on success/failure status) and ``os.replace``-s the tempfile
+  into place.  Concurrent jobs sharing a directory don't collide.
+* **Logging-style filename templating**: the filename is a ``str.format``
+  template (or callable) over a context dict that the caller passes at
+  ``start()`` time, plus a ``status`` key injected at ``save()`` time.
+  ``filename`` and ``required_context`` are required at construction time
+  — there is no universal default because every benchmark names tasks
+  differently (``env_id``, ``task_id``, ``suite/task`` …).  Forcing the
+  caller to spell it out catches mismatched context keys at ``start()``
+  rather than as a silent dropped mp4 at ``save()``.
+* **Best-effort**: every encode-side failure logs a warning with the
+  context for debuggability and clears state — a corrupted video should
+  never bring down an otherwise good eval episode.
+
+## Caller pattern
+
+    from vla_eval.benchmarks.recording import EpisodeVideoRecorder
+
+    recorder = EpisodeVideoRecorder(
+        output_dir="/workspace/results/videos",
+        filename="{env_id}_ep{episode_idx}_{status}.mp4",
+        required_context=("env_id", "episode_idx"),
+        fps=20,
+    )
+
+    # In benchmark.reset(task):
+    recorder.start({"env_id": task["env_id"], "episode_idx": task["episode_idx"]})
+    recorder.record(initial_frame)
+
+    # In benchmark.step(action):
+    recorder.record(frame)  # default ffmpeg path copies via .tobytes() —
+                            # see record() docstring for backend caveats
+
+    # In benchmark.get_step_result(step_result):
+    recorder.save(status="success" if success else "fail")
+
+    # In benchmark.cleanup():
+    recorder.discard()  # drops any in-flight writer + tempfile
+
+## Multi-camera
+
+The recorder is single-stream by design.  Benchmarks with multiple views
+(e.g. front + wrist) instantiate one recorder per view with different
+``filename`` templates (e.g. ``"{view}_ep{episode_idx}_{status}.mp4"``,
+substituting the view name into the context at ``start()``).  This keeps
+each recorder simple and lets callers mix-and-match resolutions, fps,
+and codecs per view.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# Either a `str.format`-style template or a callable that takes the resolved
+# context (caller's start() context + injected ``status``) and returns a
+# filename relative to ``output_dir``.
+FilenameSpec = str | Callable[[Mapping[str, Any]], str]
+
+
+class EpisodeVideoRecorder:
+    """Streaming per-episode video recorder.
+
+    Lifecycle: ``start()`` → ``record()`` × N → ``save()`` (or
+    ``discard()``).  ``start()`` may be called again to begin a new
+    episode; if a previous episode never reached ``save()``/``discard()``
+    (e.g. orchestrator crash) the in-flight writer is closed and its
+    tempfile cleaned up first.
+
+    Inactive (no episode in progress) is a valid state: ``record()`` /
+    ``save()`` / ``discard()`` are no-ops in that case so callers don't
+    need defensive ``if recorder.active`` checks.
+    """
+
+    def __init__(
+        self,
+        output_dir: str | os.PathLike[str],
+        filename: FilenameSpec,
+        required_context: Sequence[str],
+        fps: int = 20,
+        writer_kwargs: Mapping[str, Any] | None = None,
+    ) -> None:
+        """
+        Args:
+            output_dir: Directory the final mp4 lands in.  Created if missing.
+                Filename templates may include subdirectories (e.g.
+                ``"{suite}/{task}_..."``); intermediate dirs are also created.
+            filename: ``str.format`` template or callable producing the
+                filename relative to ``output_dir``.  Resolved at ``save()``
+                time over ``{**start_context, "status": status}``.  Required
+                because every benchmark identifies tasks differently
+                (``env_id``, ``task_id``, ``suite/task``) — there is no
+                universally safe default.
+            required_context: Keys that must be present in the dict passed to
+                ``start()``.  ``ValueError`` is raised at ``start()`` if any
+                are missing.  Required so callers explicitly declare the
+                template's expectations; failing fast at ``start()`` avoids
+                a silent ``KeyError`` -> dropped mp4 at ``save()`` time.
+                Should include every key the ``filename`` template references.
+            fps: Output framerate.
+            writer_kwargs: Extra kwargs forwarded to ``imageio.get_writer``
+                (e.g. ``{"codec": "libx264", "quality": 8}``).
+        """
+        self.output_dir = Path(output_dir)
+        self._filename_spec = filename
+        self.fps = fps
+        self._required_context = tuple(required_context)
+        self._writer_kwargs = dict(writer_kwargs or {})
+
+        # Lifecycle state — None whenever no episode is in progress.
+        self._writer: Any = None
+        self._tempfile: Path | None = None
+        self._context: dict[str, Any] | None = None
+        self._frames_written = 0
+        # Latched on the first record() failure so we don't log-spam every
+        # subsequent step with the same warning when the underlying writer
+        # is wedged (corrupt subprocess pipe, etc.).
+        self._record_failed = False
+
+    @property
+    def active(self) -> bool:
+        return self._writer is not None
+
+    def start(self, context: Mapping[str, Any]) -> None:
+        """Begin a new episode.
+
+        Validates required context keys, opens a streaming writer to a
+        tempfile in ``output_dir``.  If a previous episode is still in
+        flight (no ``save``/``discard`` called) it is discarded first.
+        On writer-open failure the recorder stays inactive and subsequent
+        ``record()``/``save()`` are no-ops; the failure is logged.
+        """
+        missing = [k for k in self._required_context if k not in context]
+        if missing:
+            raise ValueError(f"EpisodeVideoRecorder.start: missing required context keys: {missing}")
+
+        if self.active:
+            self.discard()
+
+        self._context = dict(context)
+        self._record_failed = False
+        try:
+            self.output_dir.mkdir(parents=True, exist_ok=True)
+            # Tempfile keeps a real `.mp4` suffix so imageio's format
+            # auto-detection works; the `.recorder-` prefix marks it as ours.
+            fd, temp_path = tempfile.mkstemp(
+                prefix=".recorder-",
+                suffix=".mp4",
+                dir=str(self.output_dir),
+            )
+            os.close(fd)
+            self._tempfile = Path(temp_path)
+
+            import imageio
+
+            self._writer = imageio.get_writer(str(self._tempfile), fps=self.fps, **self._writer_kwargs)
+        except Exception as e:
+            logger.warning("Failed to open video writer for context=%r: %s", self._context, e)
+            _safe_unlink(self._tempfile)
+            self._tempfile = None
+            self._writer = None
+            self._context = None
+
+    def record(self, frame: np.ndarray) -> None:
+        """Append a frame to the in-flight episode.
+
+        On the default ``.mp4`` / ffmpeg path, imageio serializes the
+        frame via ``np.ndarray.tobytes()`` before piping it to the
+        encoder subprocess — that's a synchronous copy, so the caller
+        can mutate the underlying buffer once this returns.  If you
+        configure a non-ffmpeg writer that retains references (e.g.
+        the pillow plugin appends ``Image.fromarray(arr)`` to a list
+        flushed at close), you must pass copies yourself.
+
+        No-op if no episode is in progress.  The first encode failure
+        latches the recorder so subsequent ``record()`` calls become
+        no-ops rather than flooding the log.
+        """
+        if not self.active or self._record_failed:
+            return
+        try:
+            self._writer.append_data(frame)
+            self._frames_written += 1
+        except Exception as e:
+            logger.warning(
+                "record() failed for context=%r at frame %d: %s; remaining frames in this episode will be dropped",
+                self._context,
+                self._frames_written,
+                e,
+            )
+            self._record_failed = True
+
+    def save(self, status: str = "success") -> Path | None:
+        """Finalize the in-flight episode.
+
+        Closes the streaming writer, resolves the final filename from
+        ``{**context, "status": status}``, and atomically moves the
+        tempfile into place.  Returns the final ``Path`` on success,
+        ``None`` if the recorder was inactive or any finalize step
+        failed.  After this call the recorder is inactive again.
+        """
+        if not self.active:
+            return None
+
+        writer, tempfile_path, context = self._writer, self._tempfile, self._context
+        frames_written = self._frames_written
+        try:
+            try:
+                writer.close()
+            except Exception as e:
+                logger.warning("Failed to close video writer for context=%r: %s", context, e)
+                _safe_unlink(tempfile_path)
+                return None
+
+            try:
+                relative_name = self._resolve_filename({**(context or {}), "status": status})
+            except Exception as e:
+                logger.warning("Failed to resolve filename for context=%r status=%r: %s", context, status, e)
+                _safe_unlink(tempfile_path)
+                return None
+
+            final_path = self.output_dir / relative_name
+            try:
+                final_path.parent.mkdir(parents=True, exist_ok=True)
+                os.replace(str(tempfile_path), str(final_path))
+            except Exception as e:
+                logger.warning("Failed to finalize video at %s for context=%r: %s", final_path, context, e)
+                _safe_unlink(tempfile_path)
+                return None
+
+            logger.info("Saved episode video: %s (%d frames)", final_path, frames_written)
+            return final_path
+        finally:
+            self._writer = None
+            self._tempfile = None
+            self._context = None
+            self._frames_written = 0
+            self._record_failed = False
+
+    def discard(self) -> None:
+        """Abandon the in-flight episode without producing an mp4.
+
+        Closes the writer (best-effort) and removes the tempfile.  Safe
+        to call when no episode is in progress (no-op).
+        """
+        writer, tempfile_path = self._writer, self._tempfile
+        self._writer = None
+        self._tempfile = None
+        self._context = None
+        self._frames_written = 0
+        self._record_failed = False
+        if writer is not None:
+            try:
+                writer.close()
+            except Exception:
+                pass
+        _safe_unlink(tempfile_path)
+
+    def _resolve_filename(self, context: Mapping[str, Any]) -> str:
+        spec = self._filename_spec
+        if isinstance(spec, str):
+            return spec.format(**context)
+        return spec(context)
+
+
+def _safe_unlink(path: Path | None) -> None:
+    if path is None:
+        return
+    try:
+        path.unlink(missing_ok=True)
+    except Exception:
+        pass

--- a/src/vla_eval/benchmarks/robomme/benchmark.py
+++ b/src/vla_eval/benchmarks/robomme/benchmark.py
@@ -17,6 +17,7 @@ from typing import Any, Literal
 import numpy as np
 
 from vla_eval.benchmarks.base import StepBenchmark, StepResult
+from vla_eval.benchmarks.recording import EpisodeVideoRecorder
 from vla_eval.specs import IMAGE_RGB, LANGUAGE, RAW, DimSpec
 from vla_eval.types import Action, EpisodeResult, Observation, Task
 
@@ -191,8 +192,16 @@ class RoboMMEBenchmark(StepBenchmark):
         self.send_video_history = send_video_history
         self.send_subgoal = send_subgoal
         self.subgoal_mode = subgoal_mode
-        self.save_episode_video = save_episode_video
-        self.video_dir = video_dir or "/workspace/results/videos"
+        self._recorder: EpisodeVideoRecorder | None = (
+            EpisodeVideoRecorder(
+                output_dir=video_dir or "/workspace/results/videos",
+                filename="{env_id}_ep{episode_idx}_{status}.mp4",
+                required_context=("env_id", "episode_idx"),
+                fps=20,
+            )
+            if save_episode_video
+            else None
+        )
 
         self._env: Any = None
         self._task: Task | None = None
@@ -200,7 +209,6 @@ class RoboMMEBenchmark(StepBenchmark):
         self._video_frames: list[np.ndarray] = []
         self._wrist_video_frames: list[np.ndarray] = []
         self._current_subgoal: str = ""
-        self._episode_frames: list[np.ndarray] = []
 
     def get_tasks(self) -> list[Task]:
         return [{"name": t, "env_id": t} for t in self.tasks]
@@ -340,7 +348,7 @@ class RoboMMEBenchmark(StepBenchmark):
 
             _backend_mod.parse_sim_and_render_backend = _patched_parse
 
-            import mani_skill.envs.sapien_env  # type: ignore
+            import mani_skill.envs.sapien_env
 
             mani_skill.envs.sapien_env.parse_sim_and_render_backend = _patched_parse
         except Exception as e:
@@ -360,12 +368,7 @@ class RoboMMEBenchmark(StepBenchmark):
             except Exception:
                 pass
 
-        # Drop any state left over from a previous episode that didn't reach
-        # get_step_result (orchestrator crash, mid-episode abort) so frames
-        # don't accumulate across resets.
-        self._episode_frames = []
-
-        if self.save_episode_video and "episode_idx" not in task:
+        if self._recorder is not None and "episode_idx" not in task:
             # Without a unique episode_idx, multi-episode runs would all
             # write to "<task>_ep0_<status>.mp4" and silently overwrite.
             raise ValueError(
@@ -397,10 +400,11 @@ class RoboMMEBenchmark(StepBenchmark):
         if self.send_subgoal:
             self._current_subgoal = self._extract_subgoal(info_flat)
 
-        if self.save_episode_video:
+        if self._recorder is not None:
+            self._recorder.start({"env_id": task["env_id"], "episode_idx": episode_idx})
             front_list = obs_batch.get("front_rgb_list", [])
             if front_list:
-                self._episode_frames.append(np.array(front_list[-1], copy=True))
+                self._recorder.record(front_list[-1])
 
         return obs_batch
 
@@ -419,12 +423,12 @@ class RoboMMEBenchmark(StepBenchmark):
         if self.send_subgoal:
             self._current_subgoal = self._extract_subgoal(info)
 
-        if self.save_episode_video and obs:
+        if self._recorder is not None and obs:
             front_list = obs.get("front_rgb_list", [])
             if front_list:
-                # Copy explicitly: ManiSkill may reuse the same buffer across steps,
-                # which would make every saved frame identical to the last one.
-                self._episode_frames.append(np.array(front_list[-1], copy=True))
+                # imageio's ffmpeg writer copies via tobytes() before piping,
+                # so passing the raw (potentially reused) ManiSkill buffer is fine.
+                self._recorder.record(front_list[-1])
 
         # Cast potential torch scalars
         terminated = bool(terminated)
@@ -433,21 +437,6 @@ class RoboMMEBenchmark(StepBenchmark):
         done = terminated or truncated or info.get("status") == "error"
 
         return StepResult(obs=obs, reward=reward, done=done, info=info)
-
-    def _save_episode_video(self, task: Task, success: bool) -> None:
-        try:
-            import imageio
-
-            os.makedirs(self.video_dir, exist_ok=True)
-            task_name = task.get("name", task.get("env_id", "unknown"))
-            status = "success" if success else "fail"
-            fname = f"{task_name}_ep{task['episode_idx']}_{status}.mp4"
-            path = os.path.join(self.video_dir, fname)
-            imageio.mimsave(path, self._episode_frames, fps=20)
-            logger.info("Saved episode video: %s (%d frames)", path, len(self._episode_frames))
-        except Exception as e:
-            logger.warning("Failed to save episode video: %s", e)
-        self._episode_frames = []
 
     def _extract_subgoal(self, info: dict[str, Any]) -> str:
         """Pick the configured subgoal text from the env's info dict.
@@ -510,8 +499,8 @@ class RoboMMEBenchmark(StepBenchmark):
 
     def get_step_result(self, step_result: StepResult) -> EpisodeResult:
         success = step_result.info.get("status") == "success"
-        if self.save_episode_video and self._episode_frames and self._task is not None:
-            self._save_episode_video(task=self._task, success=success)
+        if self._recorder is not None:
+            self._recorder.save(status="success" if success else "fail")
         return {"success": success}
 
     def get_metadata(self) -> dict[str, Any]:
@@ -540,7 +529,8 @@ class RoboMMEBenchmark(StepBenchmark):
             except Exception:
                 pass
             self._env = None
-        self._episode_frames = []
+        if self._recorder is not None:
+            self._recorder.discard()
         self._video_frames = []
         self._wrist_video_frames = []
         self._task = None

--- a/src/vla_eval/benchmarks/robomme/benchmark.py
+++ b/src/vla_eval/benchmarks/robomme/benchmark.py
@@ -195,8 +195,8 @@ class RoboMMEBenchmark(StepBenchmark):
         self._recorder: EpisodeVideoRecorder | None = (
             EpisodeVideoRecorder(
                 output_dir=video_dir or "/workspace/results/videos",
-                filename="{env_id}_ep{episode_idx}_{status}.mp4",
-                required_context=("env_id", "episode_idx"),
+                # Zero-padded `episode_idx` so files alpha-sort numerically.
+                filename="{env_id}_ep{episode_idx:04d}_{status}.mp4",
                 fps=20,
             )
             if save_episode_video

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -1,9 +1,10 @@
 """Unit tests for ``vla_eval.benchmarks.recording.EpisodeVideoRecorder``.
 
 Exercises the full lifecycle (start → record → save / discard), filename
-templating (str + callable), required-context validation, error paths
-(writer-open failure, encode failure, missing context key at save), and
-state isolation between episodes.
+templating (str + callable), required-context auto-derivation,
+required-context validation, error paths (writer-open failure, encode
+failure, missing context key at save), state isolation between episodes,
+and collision detection at save time.
 
 Frames are 4×4 RGB ``uint8`` stubs — small enough that ``imageio``'s
 ffmpeg writer copes without external codec setup, but real enough that
@@ -21,7 +22,7 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 
-from vla_eval.benchmarks.recording import EpisodeVideoRecorder
+from vla_eval.benchmarks.recording import EpisodeVideoRecorder, _fields_from_template
 
 
 def _frame() -> np.ndarray:
@@ -40,16 +41,14 @@ def _count_frames(path: Path) -> int:
 def _rec(tmp_path: Path, **overrides: Any) -> EpisodeVideoRecorder:
     """Construct a recorder with stable test-suite defaults.
 
-    The recorder itself has no defaults for ``filename`` /
-    ``required_context`` (every benchmark spells them out explicitly).
-    Tests don't need to repeat that boilerplate, so this helper picks
-    the same ``task_name``/``episode_idx`` template the original
-    test data assumed.
+    The recorder itself has no defaults for ``filename`` (every benchmark
+    spells it out).  Tests don't need to repeat that boilerplate, so
+    this helper picks a ``task_name`` + ``episode_idx`` template and lets
+    auto-derivation discover the required keys.
     """
     kwargs: dict[str, Any] = {
         "output_dir": tmp_path,
-        "filename": "{task_name}_ep{episode_idx}_{status}.mp4",
-        "required_context": ("task_name", "episode_idx"),
+        "filename": "{task_name}_ep{episode_idx:04d}_{status}.mp4",
     }
     kwargs.update(overrides)
     return EpisodeVideoRecorder(**kwargs)
@@ -68,7 +67,7 @@ def test_save_writes_mp4_with_correct_framecount(tmp_path: Path) -> None:
     final = rec.save(status="success")
 
     assert final is not None
-    assert final == tmp_path / "PickCube_ep0_success.mp4"
+    assert final == tmp_path / "PickCube_ep0000_success.mp4"
     assert final.exists()
     assert _count_frames(final) == 5
 
@@ -79,7 +78,7 @@ def test_save_uses_status_in_filename(tmp_path: Path) -> None:
     rec.record(_frame())
     final = rec.save(status="fail")
     assert final is not None
-    assert final == tmp_path / "T_ep7_fail.mp4"
+    assert final == tmp_path / "T_ep0007_fail.mp4"
     assert final.exists()
 
 
@@ -100,12 +99,12 @@ def test_consecutive_episodes_each_produce_their_own_file(tmp_path: Path) -> Non
         rec.record(_frame())
         final = rec.save(status="success")
         assert final is not None
-        assert final == tmp_path / f"T_ep{ep}_success.mp4"
+        assert final == tmp_path / f"T_ep{ep:04d}_success.mp4"
         assert final.exists()
     assert sorted(p.name for p in tmp_path.glob("T_ep*.mp4")) == [
-        "T_ep0_success.mp4",
-        "T_ep1_success.mp4",
-        "T_ep2_success.mp4",
+        "T_ep0000_success.mp4",
+        "T_ep0001_success.mp4",
+        "T_ep0002_success.mp4",
     ]
 
 
@@ -118,7 +117,6 @@ def test_filename_template_with_subdirectories(tmp_path: Path) -> None:
     rec = EpisodeVideoRecorder(
         output_dir=tmp_path,
         filename="{suite}/{task_name}_ep{episode_idx:04d}_{status}.mp4",
-        required_context=("suite", "task_name", "episode_idx"),
     )
     rec.start({"suite": "Counting", "task_name": "PickX", "episode_idx": 12})
     rec.record(_frame())
@@ -128,10 +126,15 @@ def test_filename_template_with_subdirectories(tmp_path: Path) -> None:
     assert final.exists()
 
 
-def test_filename_callable(tmp_path: Path) -> None:
+def test_filename_callable_requires_explicit_required_context(tmp_path: Path) -> None:
     def naming(ctx: Mapping[str, Any]) -> str:
         return f"{ctx['run_id']}-{ctx['episode_idx']}-{ctx['status']}.mp4"
 
+    # Callable + required_context=None → ValueError at construction.
+    with pytest.raises(ValueError, match="required_context must be specified when filename is a callable"):
+        EpisodeVideoRecorder(output_dir=tmp_path, filename=naming)
+
+    # Explicit required_context unblocks it.
     rec = EpisodeVideoRecorder(
         output_dir=tmp_path,
         filename=naming,
@@ -144,20 +147,51 @@ def test_filename_callable(tmp_path: Path) -> None:
 
 
 def test_save_with_template_key_not_in_required_context_is_handled(tmp_path: Path) -> None:
-    # required_context is the caller's contract for what must be present at
-    # start(); it's permitted to be a subset of the keys the template uses
-    # (e.g. an optional `seed`).  When a template key is genuinely missing
-    # at save() time, resolution should fail gracefully rather than raise.
+    # An explicit required_context is allowed to be a SUBSET of template keys —
+    # callers may want some keys to be optional (e.g. `seed`).  Auto-derivation
+    # would have included `seed`, but here the caller deliberately overrides
+    # to make `seed` optional, so start() doesn't enforce it.  When a template
+    # key is missing at save() time, resolution should fail gracefully rather
+    # than raise.
     rec = EpisodeVideoRecorder(
         output_dir=tmp_path,
         filename="{task_name}_{seed}_{status}.mp4",
-        required_context=("task_name",),
+        required_context=("task_name",),  # explicit subset
     )
     rec.start({"task_name": "T"})  # `seed` missing
     rec.record(_frame())
     final = rec.save(status="success")
     assert final is None
     assert list(tmp_path.glob(".recorder-*.mp4")) == []
+
+
+# ---------------------------------------------------------------------------
+# required_context auto-derivation
+# ---------------------------------------------------------------------------
+
+
+def test_required_context_auto_derived_from_template(tmp_path: Path) -> None:
+    rec = EpisodeVideoRecorder(
+        output_dir=tmp_path,
+        filename="{a}_{b:04d}_{status}.mp4",
+    )
+    # Auto-derivation strips `:format_spec` and excludes `status`.
+    assert rec._required_context == ("a", "b")  # type: ignore[attr-defined]
+    # And the validation actually applies:
+    with pytest.raises(ValueError, match="missing required context keys"):
+        rec.start({"a": "x"})  # `b` missing
+
+
+def test_fields_from_template_helper() -> None:
+    # Direct unit test of the helper since it's the engine for auto-derivation.
+    assert _fields_from_template("{a}_{b}_{status}.mp4") == ("a", "b")
+    assert _fields_from_template("{episode_idx:04d}_{status}.mp4") == ("episode_idx",)
+    assert _fields_from_template("{suite}/{task}_ep{i:04d}.mp4") == ("suite", "task", "i")
+    assert _fields_from_template("plain.mp4") == ()
+    # Duplicates collapsed, order preserved.
+    assert _fields_from_template("{a}_{b}_{a}_{status}.mp4") == ("a", "b")
+    # Attribute/indexing access — bare name only.
+    assert _fields_from_template("{ctx.task}_{arr[0]}.mp4") == ("ctx", "arr")
 
 
 # ---------------------------------------------------------------------------
@@ -194,11 +228,50 @@ def test_writer_open_failure_leaves_recorder_inactive(tmp_path: Path) -> None:
     with patch("imageio.get_writer", side_effect=RuntimeError("nope")):
         rec.start({"task_name": "T", "episode_idx": 0})
     assert rec.active is False
-    # No leftover tempfile.
+    # No leftover working file.
     assert list(tmp_path.glob(".recorder-*.mp4")) == []
     # Subsequent record/save are no-ops.
     rec.record(_frame())
     assert rec.save() is None
+
+
+# ---------------------------------------------------------------------------
+# Collision detection at save
+# ---------------------------------------------------------------------------
+
+
+def test_save_raises_on_collision_by_default(tmp_path: Path) -> None:
+    rec = _rec(tmp_path)
+    rec.start({"task_name": "T", "episode_idx": 0})
+    rec.record(_frame())
+    rec.save(status="success")  # writes T_ep0000_success.mp4
+
+    # Programmer error: same context, same status, second time around.
+    rec.start({"task_name": "T", "episode_idx": 0})
+    rec.record(_frame())
+    with pytest.raises(FileExistsError, match="already exists"):
+        rec.save(status="success")
+    # Original file is untouched, working file remains for manual recovery.
+    assert (tmp_path / "T_ep0000_success.mp4").exists()
+    assert len(list(tmp_path.glob(".recorder-*.mp4"))) == 1
+
+
+def test_save_overwrites_when_overwrite_true(tmp_path: Path) -> None:
+    rec = _rec(tmp_path, overwrite=True)
+    rec.start({"task_name": "T", "episode_idx": 0})
+    rec.record(_frame())
+    rec.record(_frame())
+    first = rec.save(status="success")
+    assert first is not None
+    assert _count_frames(first) == 2
+
+    rec.start({"task_name": "T", "episode_idx": 0})
+    for _ in range(5):
+        rec.record(_frame())
+    second = rec.save(status="success")
+    assert second is not None
+    assert second == first  # same final path
+    assert _count_frames(second) == 5  # but new content
 
 
 # ---------------------------------------------------------------------------
@@ -215,14 +288,14 @@ def test_start_again_without_save_discards_prior_episode(tmp_path: Path) -> None
     rec.record(_frame())
     final = rec.save(status="success")
     assert final is not None
-    assert final == tmp_path / "T_ep1_success.mp4"
-    # Only ep1 mp4 should exist; ep0's tempfile was cleaned up.
+    assert final == tmp_path / "T_ep0001_success.mp4"
+    # Only ep1 mp4 should exist; ep0's working file was cleaned up.
     mp4s = sorted(p.name for p in tmp_path.glob("*.mp4"))
-    assert mp4s == ["T_ep1_success.mp4"]
+    assert mp4s == ["T_ep0001_success.mp4"]
     assert list(tmp_path.glob(".recorder-*.mp4")) == []
 
 
-def test_discard_cleans_up_tempfile(tmp_path: Path) -> None:
+def test_discard_cleans_up_working_file(tmp_path: Path) -> None:
     rec = _rec(tmp_path)
     rec.start({"task_name": "T", "episode_idx": 0})
     rec.record(_frame())

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -1,0 +1,259 @@
+"""Unit tests for ``vla_eval.benchmarks.recording.EpisodeVideoRecorder``.
+
+Exercises the full lifecycle (start → record → save / discard), filename
+templating (str + callable), required-context validation, error paths
+(writer-open failure, encode failure, missing context key at save), and
+state isolation between episodes.
+
+Frames are 4×4 RGB ``uint8`` stubs — small enough that ``imageio``'s
+ffmpeg writer copes without external codec setup, but real enough that
+the produced mp4 has a verifiable framecount.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from vla_eval.benchmarks.recording import EpisodeVideoRecorder
+
+
+def _frame() -> np.ndarray:
+    return np.zeros((4, 4, 3), dtype=np.uint8)
+
+
+def _count_frames(path: Path) -> int:
+    # imageio's `_BaseReaderWriter` type stub omits __iter__; the concrete
+    # Reader returned for mp4 is iterable in practice.
+    import imageio
+
+    with imageio.get_reader(str(path)) as r:
+        return sum(1 for _ in r)  # ty: ignore[not-iterable]
+
+
+def _rec(tmp_path: Path, **overrides: Any) -> EpisodeVideoRecorder:
+    """Construct a recorder with stable test-suite defaults.
+
+    The recorder itself has no defaults for ``filename`` /
+    ``required_context`` (every benchmark spells them out explicitly).
+    Tests don't need to repeat that boilerplate, so this helper picks
+    the same ``task_name``/``episode_idx`` template the original
+    test data assumed.
+    """
+    kwargs: dict[str, Any] = {
+        "output_dir": tmp_path,
+        "filename": "{task_name}_ep{episode_idx}_{status}.mp4",
+        "required_context": ("task_name", "episode_idx"),
+    }
+    kwargs.update(overrides)
+    return EpisodeVideoRecorder(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_save_writes_mp4_with_correct_framecount(tmp_path: Path) -> None:
+    rec = _rec(tmp_path, fps=10)
+    rec.start({"task_name": "PickCube", "episode_idx": 0})
+    for _ in range(5):
+        rec.record(_frame())
+    final = rec.save(status="success")
+
+    assert final is not None
+    assert final == tmp_path / "PickCube_ep0_success.mp4"
+    assert final.exists()
+    assert _count_frames(final) == 5
+
+
+def test_save_uses_status_in_filename(tmp_path: Path) -> None:
+    rec = _rec(tmp_path)
+    rec.start({"task_name": "T", "episode_idx": 7})
+    rec.record(_frame())
+    final = rec.save(status="fail")
+    assert final is not None
+    assert final == tmp_path / "T_ep7_fail.mp4"
+    assert final.exists()
+
+
+def test_active_flag_tracks_lifecycle(tmp_path: Path) -> None:
+    rec = _rec(tmp_path)
+    assert rec.active is False
+    rec.start({"task_name": "T", "episode_idx": 0})
+    assert rec.active is True
+    rec.save()
+    assert rec.active is False
+
+
+def test_consecutive_episodes_each_produce_their_own_file(tmp_path: Path) -> None:
+    rec = _rec(tmp_path)
+    for ep in range(3):
+        rec.start({"task_name": "T", "episode_idx": ep})
+        rec.record(_frame())
+        rec.record(_frame())
+        final = rec.save(status="success")
+        assert final is not None
+        assert final == tmp_path / f"T_ep{ep}_success.mp4"
+        assert final.exists()
+    assert sorted(p.name for p in tmp_path.glob("T_ep*.mp4")) == [
+        "T_ep0_success.mp4",
+        "T_ep1_success.mp4",
+        "T_ep2_success.mp4",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Filename templating
+# ---------------------------------------------------------------------------
+
+
+def test_filename_template_with_subdirectories(tmp_path: Path) -> None:
+    rec = EpisodeVideoRecorder(
+        output_dir=tmp_path,
+        filename="{suite}/{task_name}_ep{episode_idx:04d}_{status}.mp4",
+        required_context=("suite", "task_name", "episode_idx"),
+    )
+    rec.start({"suite": "Counting", "task_name": "PickX", "episode_idx": 12})
+    rec.record(_frame())
+    final = rec.save(status="success")
+    assert final is not None
+    assert final == tmp_path / "Counting" / "PickX_ep0012_success.mp4"
+    assert final.exists()
+
+
+def test_filename_callable(tmp_path: Path) -> None:
+    def naming(ctx: Mapping[str, Any]) -> str:
+        return f"{ctx['run_id']}-{ctx['episode_idx']}-{ctx['status']}.mp4"
+
+    rec = EpisodeVideoRecorder(
+        output_dir=tmp_path,
+        filename=naming,
+        required_context=("run_id", "episode_idx"),
+    )
+    rec.start({"run_id": "abc", "episode_idx": 3})
+    rec.record(_frame())
+    final = rec.save(status="ok")
+    assert final == tmp_path / "abc-3-ok.mp4"
+
+
+def test_save_with_template_key_not_in_required_context_is_handled(tmp_path: Path) -> None:
+    # required_context is the caller's contract for what must be present at
+    # start(); it's permitted to be a subset of the keys the template uses
+    # (e.g. an optional `seed`).  When a template key is genuinely missing
+    # at save() time, resolution should fail gracefully rather than raise.
+    rec = EpisodeVideoRecorder(
+        output_dir=tmp_path,
+        filename="{task_name}_{seed}_{status}.mp4",
+        required_context=("task_name",),
+    )
+    rec.start({"task_name": "T"})  # `seed` missing
+    rec.record(_frame())
+    final = rec.save(status="success")
+    assert final is None
+    assert list(tmp_path.glob(".recorder-*.mp4")) == []
+
+
+# ---------------------------------------------------------------------------
+# Validation / error paths
+# ---------------------------------------------------------------------------
+
+
+def test_start_missing_required_context_raises(tmp_path: Path) -> None:
+    rec = _rec(tmp_path)
+    with pytest.raises(ValueError, match="missing required context keys"):
+        rec.start({"task_name": "T"})  # episode_idx missing
+    assert rec.active is False
+
+
+def test_record_before_start_is_noop(tmp_path: Path) -> None:
+    rec = _rec(tmp_path)
+    rec.record(_frame())  # must not raise
+    assert rec.active is False
+
+
+def test_save_before_start_returns_none(tmp_path: Path) -> None:
+    rec = _rec(tmp_path)
+    assert rec.save() is None
+
+
+def test_discard_before_start_is_noop(tmp_path: Path) -> None:
+    rec = _rec(tmp_path)
+    rec.discard()  # must not raise
+    assert rec.active is False
+
+
+def test_writer_open_failure_leaves_recorder_inactive(tmp_path: Path) -> None:
+    rec = _rec(tmp_path)
+    with patch("imageio.get_writer", side_effect=RuntimeError("nope")):
+        rec.start({"task_name": "T", "episode_idx": 0})
+    assert rec.active is False
+    # No leftover tempfile.
+    assert list(tmp_path.glob(".recorder-*.mp4")) == []
+    # Subsequent record/save are no-ops.
+    rec.record(_frame())
+    assert rec.save() is None
+
+
+# ---------------------------------------------------------------------------
+# Mid-episode interruption / cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_start_again_without_save_discards_prior_episode(tmp_path: Path) -> None:
+    rec = _rec(tmp_path)
+    rec.start({"task_name": "T", "episode_idx": 0})
+    rec.record(_frame())
+    # Simulate orchestrator skipping save() / discard() and starting next ep:
+    rec.start({"task_name": "T", "episode_idx": 1})
+    rec.record(_frame())
+    final = rec.save(status="success")
+    assert final is not None
+    assert final == tmp_path / "T_ep1_success.mp4"
+    # Only ep1 mp4 should exist; ep0's tempfile was cleaned up.
+    mp4s = sorted(p.name for p in tmp_path.glob("*.mp4"))
+    assert mp4s == ["T_ep1_success.mp4"]
+    assert list(tmp_path.glob(".recorder-*.mp4")) == []
+
+
+def test_discard_cleans_up_tempfile(tmp_path: Path) -> None:
+    rec = _rec(tmp_path)
+    rec.start({"task_name": "T", "episode_idx": 0})
+    rec.record(_frame())
+    rec.discard()
+    assert rec.active is False
+    assert list(tmp_path.glob(".recorder-*.mp4")) == []
+    assert list(tmp_path.glob("*.mp4")) == []
+
+
+# ---------------------------------------------------------------------------
+# Output dir created if missing
+# ---------------------------------------------------------------------------
+
+
+def test_output_dir_created_lazily(tmp_path: Path) -> None:
+    target = tmp_path / "nested" / "videos"
+    assert not target.exists()
+    rec = _rec(target)
+    rec.start({"task_name": "T", "episode_idx": 0})
+    rec.record(_frame())
+    final = rec.save()
+    assert final is not None
+    assert final.exists()
+    assert target.is_dir()
+
+
+def test_str_path_accepted(tmp_path: Path) -> None:
+    rec = _rec(tmp_path, output_dir=str(tmp_path))
+    rec.start({"task_name": "T", "episode_idx": 0})
+    rec.record(_frame())
+    final = rec.save()
+    assert final is not None
+    assert final.exists()
+    assert os.fspath(final).startswith(str(tmp_path))


### PR DESCRIPTION
## What

#53 wired episode mp4 saving directly into `RoboMMEBenchmark` — a buffered list of frames + `imageio.mimsave` at episode end. Lift that pattern out of RoboMME and into `vla_eval.benchmarks.recording.EpisodeVideoRecorder` so the next benchmark that wants agent-view captures doesn't reinvent it.

## Improvements over #53's inline implementation

### Streaming write

`imageio.get_writer().append_data()` — O(1) memory regardless of episode length. A 1300-step 256×256×3 episode that previously held ~250 MB of pending frames now holds one.

### Filename templating with status

`save(status=...)` injects a status string into the filename, which is only known at episode end. The recorder writes to a hidden working file (`.recorder-<uid>.mp4`) during the episode and renames to the resolved final filename at `save()` time — necessary because of the status dependency, not for cross-process safety.

### Collision detection

If the resolved final path already exists, `save()` raises `FileExistsError` by default and leaves the working file in place so the caller can recover the frames. Pass `overwrite=True` to opt into replace semantics. Catches the "duplicate `episode_idx` silently overwrote prior frames" failure mode the inline implementation had.

### Required-context fail-fast

`required_context` declares which keys must be present in the dict passed to `start()`; a missing key raises before frames are recorded, not as a silent `KeyError` -> dropped mp4 at `save()`.

For `str.format` templates this is auto-derived from the template's field names (status excluded), so callers don't have to repeat themselves:

```python
EpisodeVideoRecorder(
    output_dir=...,
    filename=\"{env_id}_ep{episode_idx:04d}_{status}.mp4\",
    # required_context auto-derives to (\"env_id\", \"episode_idx\")
)
```

Callable templates still require an explicit value — there's no way to introspect a callable's key dependencies. Explicit values are also allowed and treated as deliberate, so a caller can pass a subset to make some keys optional (failing only at `save()` if ultimately missing).

### Latched encode failures

The first `record()` failure disables the recorder for the rest of the episode, so a wedged ffmpeg subprocess pipe doesn't flood the log with one warning per step.

## Filename layout

Two papercuts the docstring now calls out explicitly, because they bite first-time users:

1. **Zero-pad `episode_idx`** (`:04d`) — without it, `ep10` sorts before `ep2` in any directory listing.
2. **Put the field you'd want adjacent files by first.** Multi-camera setups want episode-first (`ep{idx:04d}_{view}_{status}.mp4`) so views of the same episode are next to each other; multi-task single-camera wants task-first.

## RoboMME wiring

`RoboMMEBenchmark` now constructs an `EpisodeVideoRecorder` (when `save_episode_video=True`) using `\"{env_id}_ep{episode_idx:04d}_{status}.mp4\"` and routes the same `reset → step → save` hooks through it. Public flags (`save_episode_video`, `video_dir`) and behaviour are preserved; the internal `_episode_frames` buffer + `_save_episode_video` method are removed.

## Caller pattern

```python
from vla_eval.benchmarks.recording import EpisodeVideoRecorder

recorder = EpisodeVideoRecorder(
    output_dir=\"/workspace/results/videos\",
    filename=\"{env_id}_ep{episode_idx:04d}_{status}.mp4\",
    fps=20,
)

# In benchmark.reset(task):
recorder.start({\"env_id\": task[\"env_id\"], \"episode_idx\": task[\"episode_idx\"]})
recorder.record(initial_frame)

# In benchmark.step(action):
recorder.record(frame)

# In benchmark.get_step_result(step_result):
recorder.save(status=\"success\" if success else \"fail\")

# In benchmark.cleanup():
recorder.discard()
```

Each recorder records a single stream. To capture multiple views (e.g. front + wrist), construct one recorder per view; they don't share state.

## Deps

`imageio[ffmpeg]` added as a runtime dep. Adds three packages (~79 MB, mostly the bundled ffmpeg binary in `imageio-ffmpeg`).

## Tests

`tests/test_recording.py` — 20 tests, ~1 s:

- happy path (mp4 written, framecount verified via imageio reader)
- filename templating: str template, callable, subdirectories, missing template key at `save()` (logs and returns `None`)
- `required_context` auto-derivation from str template (incl. `_fields_from_template` direct tests for format-spec stripping and order preservation)
- callable filename rejects `required_context=None` at construction
- `record`/`save`/`discard` before `start` are no-ops
- writer-open failure leaves recorder inactive, no leftover working file
- mid-episode `start()` again discards prior episode + working file
- `discard()` cleans up working file
- collision: `save()` raises `FileExistsError` by default, replaces with `overwrite=True`
- output dir created lazily, `str` path accepted