### PR TITLE
feat(robomme): GT subgoal exposure + H100 SAPIEN/Vulkan hang workaround

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -28,11 +28,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # ── Vulkan ICD for NVIDIA GPU ────────────────────────────────────────
+# Skip writes when the ICD file is already present — on hosts whose Docker
+# default-runtime is `nvidia`, nvidia-container-runtime bind-mounts these
+# JSONs read-only into every container (including the build container), so
+# an unconditional write would fail with "Read-only file system".
 RUN mkdir -p /usr/share/vulkan/icd.d /usr/share/glvnd/egl_vendor.d \
-    && printf '{"file_format_version":"1.0.0","ICD":{"library_path":"libGLX_nvidia.so.0","api_version":"1.2.155"}}\n' \
-        > /usr/share/vulkan/icd.d/nvidia_icd.json \
-    && printf '{"file_format_version":"1.0.0","ICD":{"library_path":"libEGL_nvidia.so.0"}}\n' \
-        > /usr/share/glvnd/egl_vendor.d/10_nvidia.json
+    && { [ -s /usr/share/vulkan/icd.d/nvidia_icd.json ] \
+         || printf '{"file_format_version":"1.0.0","ICD":{"library_path":"libGLX_nvidia.so.0","api_version":"1.2.155"}}\n' \
+            > /usr/share/vulkan/icd.d/nvidia_icd.json; } \
+    && { [ -s /usr/share/glvnd/egl_vendor.d/10_nvidia.json ] \
+         || printf '{"file_format_version":"1.0.0","ICD":{"library_path":"libEGL_nvidia.so.0"}}\n' \
+            > /usr/share/glvnd/egl_vendor.d/10_nvidia.json; }
 
 # ── Miniforge (lightweight conda, conda-forge defaults) ──────────────
 RUN wget -qO /tmp/miniforge.sh \

--- a/src/vla_eval/benchmarks/robomme/benchmark.py
+++ b/src/vla_eval/benchmarks/robomme/benchmark.py
@@ -7,13 +7,98 @@ is sent to the model server as ``video_history`` on the first observation.
 
 from __future__ import annotations
 
-from typing import Any
+import logging
+import os
+import re
+import subprocess
+import sys
+from typing import Any, Literal
 
 import numpy as np
 
 from vla_eval.benchmarks.base import StepBenchmark, StepResult
 from vla_eval.specs import IMAGE_RGB, LANGUAGE, RAW, DimSpec
 from vla_eval.types import Action, EpisodeResult, Observation, Task
+
+logger = logging.getLogger(__name__)
+
+# A grounded subgoal that hasn't had its `<obj_center>`-style placeholders
+# substituted with image coords still has bracketed identifiers (alpha/_).
+# Filled coords look like `<70, 84>` — the first char inside `<` is a digit.
+_UNFILLED_PLACEHOLDER_RE = re.compile(r"<[A-Za-z_]")
+
+# Probe script for ROBOMME_USE_LAVAPIPE=auto. Runs in a child process so a hang
+# in SAPIEN's Vulkan instance creation can be timed out without poisoning the
+# parent process (SAPIEN's VkInstance is created at import time and cannot be
+# reset in-process). subprocess.run's timeout is the watchdog — the child has
+# no internal timer.
+_NATIVE_PROBE = """
+import sapien
+import sapien.render
+import sapien.physx as physx
+rs = sapien.render.RenderSystem('cuda:0')
+scene = sapien.Scene([physx.PhysxCpuSystem(), rs])
+cam = scene.add_camera(name='t', width=64, height=64, fovy=1.0, near=0.01, far=10.0)
+cam.set_pose(sapien.Pose([0, 0, 1]))
+scene.step()
+scene.update_render()
+cam.take_picture()
+cam.get_picture('Color')
+"""
+
+
+def native_render_path_works(timeout_s: int = 15) -> bool:
+    """Probe whether SAPIEN's native NVIDIA Vulkan path works on this host.
+
+    Spawns a child Python that does ``RenderSystem('cuda:0')`` → scene → camera
+    → ``take_picture`` → ``get_picture('Color')``. The hang on affected hosts
+    shows up at ``get_picture`` (Vulkan fence wait that never signals) —
+    ``subprocess.run`` times out and SIGKILLs the child while we abort it.
+
+    Returns True if the child completes successfully within the timeout, False
+    if it hangs, crashes, or any unexpected error occurs. Conservative: any
+    non-zero exit means "fall back to lavapipe".
+
+    Public so launchers can health-check a host before scheduling work on it.
+    """
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", _NATIVE_PROBE],
+            timeout=timeout_s,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return result.returncode == 0
+    except subprocess.TimeoutExpired:
+        return False
+    except Exception as e:
+        logger.warning("Native render-path probe error: %s", e)
+        return False
+
+
+def _resolve_lavapipe_icd() -> str | None:
+    """Find the lavapipe ICD path. Returns None if not available.
+
+    Honors ``ROBOMME_LAVAPIPE_ICD`` if explicitly set — falling back silently
+    when an explicit user setting points to a missing file would be surprising,
+    so that case logs an error and returns None instead. The implicit default
+    paths (``/opt/lavapipe/lvp_icd.json`` then the Mesa-shipped
+    ``/usr/share/vulkan/icd.d/lvp_icd.x86_64.json``) are tried in order.
+    """
+    user_icd = os.environ.get("ROBOMME_LAVAPIPE_ICD")
+    if user_icd:
+        if os.path.isfile(user_icd):
+            return user_icd
+        logger.error(
+            "ROBOMME_LAVAPIPE_ICD=%s does not exist; refusing to silently fall back to a different ICD path",
+            user_icd,
+        )
+        return None
+    for candidate in ("/opt/lavapipe/lvp_icd.json", "/usr/share/vulkan/icd.d/lvp_icd.x86_64.json"):
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
 
 _DEFAULT_TASK_LIST = [
     "PickXtimes",
@@ -61,7 +146,24 @@ class RoboMMEBenchmark(StepBenchmark):
         send_wrist_image: Include wrist camera in observations.
         send_state: Include proprioceptive state in observations.
         send_video_history: Send conditioning video on the first observation.
+        send_subgoal: Attach the per-step subgoal text to ``obs["subgoal"]``.
+        subgoal_mode: ``"grounded"`` sends ``info['grounded_subgoal_online']``
+            (subgoal with image-coord placeholders filled, e.g. ``"pick up the
+            green cube at <77, 170>"``); ``"simple"`` sends
+            ``info['simple_subgoal_online']`` (no coords).  Both come from
+            ``DemonstrationWrapper`` in the upstream robomme env.  ``"grounded"``
+            falls back to simple if grounded is empty.
+        save_episode_video: Encode an mp4 of the agentview frames per episode
+            and write it to ``video_dir`` on episode end.  Requires
+            ``task["episode_idx"]`` to be set on each ``reset(task)`` call so
+            per-episode files don't collide.
+        video_dir: Output directory for per-episode videos.  Ignored unless
+            ``save_episode_video=True``.  Defaults to
+            ``/workspace/results/videos`` so the file lands inside the bench
+            container's standard results bind-mount.
     """
+
+    _rendering_configured: bool = False
 
     def __init__(
         self,
@@ -72,8 +174,14 @@ class RoboMMEBenchmark(StepBenchmark):
         send_wrist_image: bool = True,
         send_state: bool = True,
         send_video_history: bool = True,
+        send_subgoal: bool = False,
+        subgoal_mode: Literal["grounded", "simple"] = "grounded",
+        save_episode_video: bool = False,
+        video_dir: str | None = None,
     ) -> None:
         super().__init__()
+        if subgoal_mode not in ("grounded", "simple"):
+            raise ValueError(f"subgoal_mode must be 'grounded' or 'simple', got {subgoal_mode!r}")
         self.tasks = tasks or list(_DEFAULT_TASK_LIST)
         self.action_space = action_space
         self.dataset = dataset
@@ -81,24 +189,167 @@ class RoboMMEBenchmark(StepBenchmark):
         self.send_wrist_image = send_wrist_image
         self.send_state = send_state
         self.send_video_history = send_video_history
+        self.send_subgoal = send_subgoal
+        self.subgoal_mode = subgoal_mode
+        self.save_episode_video = save_episode_video
+        self.video_dir = video_dir or "/workspace/results/videos"
 
         self._env: Any = None
+        self._task: Task | None = None
         self._task_description: str = ""
         self._video_frames: list[np.ndarray] = []
         self._wrist_video_frames: list[np.ndarray] = []
-
-    # ------------------------------------------------------------------
-    # Helpers
-    # ------------------------------------------------------------------
-
-    # ------------------------------------------------------------------
-    # Benchmark ABC
-    # ------------------------------------------------------------------
+        self._current_subgoal: str = ""
+        self._episode_frames: list[np.ndarray] = []
 
     def get_tasks(self) -> list[Task]:
         return [{"name": t, "env_id": t} for t in self.tasks]
 
+    @staticmethod
+    def _setup_rendering() -> None:
+        """Optionally switch SAPIEN to lavapipe software Vulkan.
+
+        On a small subset of hosts, SAPIEN's ``RenderSystem("cuda:0")`` path
+        hangs at the first ``take_picture`` — observed as 100%% GPU util with
+        no progress past ``_setup_scene``. Symptom matches SAPIEN #290
+        (closed as host-specific). Empirically, the kernel module flavor is
+        not the discriminator: across our DGX-H100 fleet, both the closed
+        ``NVIDIA`` and the open ``Dual MIT/GPL`` modules reproduce the hang
+        on some nodes and not others, with byte-identical packages. The
+        difference appears to be hardware/firmware-level.
+
+        ``ROBOMME_USE_LAVAPIPE`` (env var) controls the workaround:
+            - unset / ``0`` / ``false`` (default): native NVIDIA path,
+              ~30–80 fps at 256×256. Will hang on affected hosts.
+            - ``1`` / ``true`` / ``yes``: always engage lavapipe.
+            - ``auto``: probe the native path in a child process (with
+              a watchdog timeout). If it returns successfully, leave SAPIEN
+              alone. If it hangs, engage lavapipe in this process.
+              ``auto`` adds ~5–10 s of startup probe time on healthy hosts
+              but lets a single launcher work across the whole fleet.
+
+        Decision is cached per-process via ``_rendering_configured``;
+        changing ``ROBOMME_USE_LAVAPIPE`` after the first ``reset()`` has no
+        effect (Vulkan ICD is loaded at the first ``import sapien.render``
+        and cannot be re-bound in-process).
+
+        Lavapipe path (when engaged) is ~5–10× slower than the native path
+        (~4–12 fps vs ~33–80 fps). When engaged we also set
+        ``LP_NUM_THREADS=4`` and ``OMP_NUM_THREADS=1`` (empirical sweet spot
+        for Mesa lavapipe with 256×256 frames; recovers ~30%% over the
+        unset default). Three-piece patch:
+
+        1. ``VK_ICD_FILENAMES`` → lavapipe (so Vulkan dispatch goes to
+           the Mesa software renderer, bypassing the broken interop path).
+        2. Wrap ``sapien.render.RenderSystem`` to drop the ``device``
+           positional arg — lavapipe has no CUDA backend, so calling
+           ``RenderSystem("cuda:0")`` raises "Failed to find a supported
+           physical device".
+        3. Patch ``mani_skill ... parse_sim_and_render_backend`` so the
+           render backend resolves to ``sapien_cpu``, matching the device
+           that lavapipe actually uses.
+        """
+        if RoboMMEBenchmark._rendering_configured:
+            return
+
+        mode = os.environ.get("ROBOMME_USE_LAVAPIPE", "").strip().lower()
+        if mode == "auto":
+            if native_render_path_works():
+                logger.info("SAPIEN auto-detect: native NVIDIA Vulkan path works, skipping lavapipe")
+                RoboMMEBenchmark._rendering_configured = True
+                return
+            logger.warning(
+                "SAPIEN auto-detect: native render path hung within watchdog timeout; engaging lavapipe fallback"
+            )
+        elif mode not in ("1", "true", "yes", "on"):
+            RoboMMEBenchmark._rendering_configured = True
+            return
+
+        # Engagement requested (mode in {"1","true","yes","on","auto"+hang}).
+        # If the patch can't take effect, the next take_picture would silently
+        # hang — fail loudly so the launcher knows to either fix the host or
+        # set ROBOMME_USE_LAVAPIPE before any sapien import.
+        if not RoboMMEBenchmark._engage_lavapipe():
+            raise RuntimeError(
+                "Lavapipe rendering requested (ROBOMME_USE_LAVAPIPE={!r}) but could not "
+                "be engaged. Check earlier log lines for the specific reason "
+                "(sapien.render already imported, ICD missing, etc.); continuing on the "
+                "native NVIDIA path would hang on affected hosts.".format(mode)
+            )
+        RoboMMEBenchmark._rendering_configured = True
+
+    @staticmethod
+    def _engage_lavapipe() -> bool:
+        """Apply the three-piece lavapipe patch + perf-tuning env vars.
+
+        Must be called BEFORE ``import sapien.render`` in this process for
+        ``VK_ICD_FILENAMES`` and ``LP_NUM_THREADS`` to take effect (Vulkan
+        ICD is loaded at first ``import sapien.render``).
+
+        Returns True on success, False if the patch could not be applied
+        (sapien.render already imported, lavapipe ICD missing, etc.). The
+        caller is responsible for treating False as fatal — silently
+        continuing on the native path would hang on affected hosts.
+        """
+        if "sapien.render" in sys.modules:
+            logger.error(
+                "Cannot engage lavapipe: sapien.render is already imported. "
+                "VK_ICD_FILENAMES / LP_NUM_THREADS only take effect on first "
+                "Vulkan init. Set ROBOMME_USE_LAVAPIPE before any sapien import."
+            )
+            return False
+
+        lavapipe_icd = _resolve_lavapipe_icd()
+        if lavapipe_icd is None:
+            logger.error("Lavapipe ICD not found; cannot engage lavapipe rendering")
+            return False
+
+        # Mesa lavapipe perf tuning. Empirical sweep on A100 with RoboMME's
+        # 256×256 frames: LP=4, OMP=1 is the sweet spot (~4.8 fps vs ~3.3 fps
+        # at LP=1 vs ~3.7 fps unset). Don't override if user already set them.
+        os.environ.setdefault("LP_NUM_THREADS", "4")
+        os.environ.setdefault("OMP_NUM_THREADS", "1")
+        os.environ.setdefault("MKL_NUM_THREADS", "1")
+
+        os.environ["VK_ICD_FILENAMES"] = lavapipe_icd
+        logger.info("SAPIEN rendering: using lavapipe software Vulkan (%s)", lavapipe_icd)
+
+        import sapien.render as sr
+
+        _OrigRenderSystem = sr.RenderSystem
+
+        def _lavapipe_render_system(*args, **kwargs):
+            return _OrigRenderSystem()
+
+        sr.RenderSystem = _lavapipe_render_system
+
+        # Patch parse_sim_and_render_backend in BOTH places: the source module
+        # (so any later imports get the patched version) AND already-imported
+        # `mani_skill.envs.sapien_env` (which captured the unpatched reference
+        # at its own import time via `from ... import parse_sim_and_render_backend`).
+        try:
+            from mani_skill.envs.utils.system import backend as _backend_mod
+
+            _orig_parse = _backend_mod.parse_sim_and_render_backend
+
+            def _patched_parse(sim_backend, render_backend):
+                result = _orig_parse(sim_backend, render_backend)
+                if result.render_backend == "sapien_cuda":
+                    result.render_backend = "sapien_cpu"
+                return result
+
+            _backend_mod.parse_sim_and_render_backend = _patched_parse
+
+            import mani_skill.envs.sapien_env  # type: ignore
+
+            mani_skill.envs.sapien_env.parse_sim_and_render_backend = _patched_parse
+        except Exception as e:
+            logger.warning("Could not patch mani_skill render backend to sapien_cpu: %s", e)
+
+        return True
+
     def reset(self, task: Task) -> Any:
+        self._setup_rendering()
         import robomme.robomme_env  # noqa: F401 — registers gym environments
         from robomme.env_record_wrapper import BenchmarkEnvBuilder
 
@@ -109,6 +360,21 @@ class RoboMMEBenchmark(StepBenchmark):
             except Exception:
                 pass
 
+        # Drop any state left over from a previous episode that didn't reach
+        # get_step_result (orchestrator crash, mid-episode abort) so frames
+        # don't accumulate across resets.
+        self._episode_frames = []
+
+        if self.save_episode_video and "episode_idx" not in task:
+            # Without a unique episode_idx, multi-episode runs would all
+            # write to "<task>_ep0_<status>.mp4" and silently overwrite.
+            raise ValueError(
+                "save_episode_video=True requires task['episode_idx'] to be set "
+                "(otherwise per-episode videos collide on the same filename)"
+            )
+
+        episode_idx = task.get("episode_idx", 0)
+        self._task = task
         builder = BenchmarkEnvBuilder(
             env_id=task["env_id"],
             dataset=self.dataset,
@@ -116,7 +382,7 @@ class RoboMMEBenchmark(StepBenchmark):
             gui_render=False,
             max_steps=self.max_steps,
         )
-        self._env = builder.make_env_for_episode(task.get("episode_idx", 0))
+        self._env = builder.make_env_for_episode(episode_idx)
         obs_batch, info_flat = self._env.reset()
 
         # Store conditioning video frames (demo trajectory, excluding final init frame)
@@ -127,6 +393,14 @@ class RoboMMEBenchmark(StepBenchmark):
         # Extract task description
         task_goal = info_flat["task_goal"]
         self._task_description = task_goal[0] if isinstance(task_goal, list) else str(task_goal)
+
+        if self.send_subgoal:
+            self._current_subgoal = self._extract_subgoal(info_flat)
+
+        if self.save_episode_video:
+            front_list = obs_batch.get("front_rgb_list", [])
+            if front_list:
+                self._episode_frames.append(np.array(front_list[-1], copy=True))
 
         return obs_batch
 
@@ -142,6 +416,16 @@ class RoboMMEBenchmark(StepBenchmark):
         assert self._env is not None
         obs, reward, terminated, truncated, info = self._env.step(raw_action)
 
+        if self.send_subgoal:
+            self._current_subgoal = self._extract_subgoal(info)
+
+        if self.save_episode_video and obs:
+            front_list = obs.get("front_rgb_list", [])
+            if front_list:
+                # Copy explicitly: ManiSkill may reuse the same buffer across steps,
+                # which would make every saved frame identical to the last one.
+                self._episode_frames.append(np.array(front_list[-1], copy=True))
+
         # Cast potential torch scalars
         terminated = bool(terminated)
         truncated = bool(truncated)
@@ -149,6 +433,37 @@ class RoboMMEBenchmark(StepBenchmark):
         done = terminated or truncated or info.get("status") == "error"
 
         return StepResult(obs=obs, reward=reward, done=done, info=info)
+
+    def _save_episode_video(self, task: Task, success: bool) -> None:
+        try:
+            import imageio
+
+            os.makedirs(self.video_dir, exist_ok=True)
+            task_name = task.get("name", task.get("env_id", "unknown"))
+            status = "success" if success else "fail"
+            fname = f"{task_name}_ep{task['episode_idx']}_{status}.mp4"
+            path = os.path.join(self.video_dir, fname)
+            imageio.mimsave(path, self._episode_frames, fps=20)
+            logger.info("Saved episode video: %s (%d frames)", path, len(self._episode_frames))
+        except Exception as e:
+            logger.warning("Failed to save episode video: %s", e)
+        self._episode_frames = []
+
+    def _extract_subgoal(self, info: dict[str, Any]) -> str:
+        """Pick the configured subgoal text from the env's info dict.
+
+        ``DemonstrationWrapper`` always populates ``simple_subgoal_online`` and
+        ``grounded_subgoal_online``; grounded may be empty OR may still hold
+        the raw placeholder template (e.g. ``"pick up the green cube at
+        <obj_center>"``) when segmentation hasn't been computed for the
+        current frame. Fall back to simple in either case so the model never
+        sees an unfilled template.
+        """
+        if self.subgoal_mode == "grounded":
+            grounded = str(info.get("grounded_subgoal_online") or "")
+            if grounded and not _UNFILLED_PLACEHOLDER_RE.search(grounded):
+                return grounded
+        return str(info.get("simple_subgoal_online") or "")
 
     def make_obs(self, raw_obs: Any, task: Task) -> Observation:
         # Handle error cases (FailAwareWrapper → None, IK failure → {})
@@ -185,13 +500,19 @@ class RoboMMEBenchmark(StepBenchmark):
             self._video_frames = []
             self._wrist_video_frames = []
 
+        if self.send_subgoal:
+            obs["subgoal"] = self._current_subgoal
+
         return obs
 
     def check_done(self, step_result: StepResult) -> bool:
         return step_result.done
 
     def get_step_result(self, step_result: StepResult) -> EpisodeResult:
-        return {"success": step_result.info.get("status") == "success"}
+        success = step_result.info.get("status") == "success"
+        if self.save_episode_video and self._episode_frames and self._task is not None:
+            self._save_episode_video(task=self._task, success=success)
+        return {"success": success}
 
     def get_metadata(self) -> dict[str, Any]:
         return {"max_steps": self.max_steps, "action_space": self.action_space}
@@ -208,6 +529,8 @@ class RoboMMEBenchmark(StepBenchmark):
             spec["wrist"] = IMAGE_RGB
         if self.send_state:
             spec["state"] = RAW
+        if self.send_subgoal:
+            spec["subgoal"] = LANGUAGE
         return spec
 
     def cleanup(self) -> None:
@@ -217,3 +540,7 @@ class RoboMMEBenchmark(StepBenchmark):
             except Exception:
                 pass
             self._env = None
+        self._episode_frames = []
+        self._video_frames = []
+        self._wrist_video_frames = []
+        self._task = None


### PR DESCRIPTION
Re-opening with proper attribution. The earlier #51 squash-merge dropped @lastdefiance20 from the author list; this PR's commit is authored by him with @MilkClouds as co-author. Content is identical to the previous merge — same tree, same opt-in behavior, same defaults.

## What

Two RoboMME-specific opt-ins, plus a small Dockerfile.base fix. All defaults match prior behavior.

### Subgoal exposure (`send_subgoal`, `subgoal_mode`)

Default off. When enabled, attaches per-step subgoal text to `obs["subgoal"]` and declares `subgoal: LANGUAGE` in the observation spec. Pulled from `info["grounded_subgoal_online"]` (placeholders filled with image coords) or `info["simple_subgoal_online"]` (no coords) — both already populated by `DemonstrationWrapper` upstream; this just exposes them. `"grounded"` falls back to `"simple"` when grounded is empty or still holds an unfilled `<obj_center>`-style placeholder.

### H100 SAPIEN/Vulkan hang workaround (`ROBOMME_USE_LAVAPIPE`)

SAPIEN's Vulkan path hangs at `take_picture()` on a non-deterministic subset of H100 hosts (and a few A100s). Reproducible across software configs; identical packages + open NVIDIA kernel module produce both hang and no-hang outcomes depending on the physical host.

Workaround: route SAPIEN's Vulkan calls through Mesa lavapipe (a software rasterizer) instead of `libGLX_nvidia`. Three modes via `ROBOMME_USE_LAVAPIPE`:
- `0` (default) — native NVIDIA path, matches prior behavior
- `1` — force lavapipe
- `auto` — probe the native path with a 15-s subprocess watchdog (`native_render_path_works`); if it doesn't return a frame, switch to lavapipe before the parent process imports `sapien.render` (the switch is irreversible at the SAPIEN level, so it has to happen pre-import)

Lavapipe engagement does three things:
1. Set `VK_ICD_FILENAMES` to the lavapipe ICD, capping the device list to a CPU-only Vulkan implementation
2. Tune `LP_NUM_THREADS=4` (empirically the sweet spot — more threads contended on context-switching costs in our 1-pp benchmarks)
3. Patch `parse_sim_and_render_backend` in both the source module (`mani_skill.envs.utils.system.backend`) and the already-imported `mani_skill.envs.sapien_env`, resolving render backend to `sapien_cpu`

If engagement is requested but can't take effect (sapien.render already imported, ICD missing), `_setup_rendering` raises `RuntimeError` rather than silently continuing on the known-bad native path.

`native_render_path_works(timeout_s=15) -> bool` is exposed publicly so launchers can health-check a host outside the benchmark lifecycle.

### Dockerfile.base: idempotent NVIDIA ICD writes

On hosts whose Docker `default-runtime` is `nvidia`, nvidia-container-runtime bind-mounts the NVIDIA ICD JSONs read-only into every container including the build container; the unconditional `printf > file` then fails with "Read-only file system". Switched to `[ -s file ] || printf > file` — skip when the bind-mount already provides the file. No-op on regular-runtime hosts.

## Note

This re-lands the content of the (now-reverted) #51. #52 (video recorder infra) sits on top of this PR.