### PR TITLE
docker: opt-in license gate for rlbench builds

### DIFF
--- a/docker/Dockerfile.rlbench
+++ b/docker/Dockerfile.rlbench
@@ -5,6 +5,23 @@
 ARG BASE_IMAGE=ghcr.io/allenai/vla-evaluation-harness/base:latest
 FROM ${BASE_IMAGE}
 
+ARG ACCEPT_RLBENCH_LICENCE=
+RUN if [ "$ACCEPT_RLBENCH_LICENCE" != "YES" ]; then \
+        echo ""; \
+        echo "============================================================"; \
+        echo "Building rlbench requires accepting two licences:"; \
+        echo "  1. RLBench (Imperial College London) — academic / non-commercial"; \
+        echo "     https://github.com/stepjam/RLBench/blob/master/LICENSE"; \
+        echo "  2. CoppeliaSim Edu — educational entities, non-commercial"; \
+        echo "     https://manual.coppeliarobotics.com/en/licensing.htm"; \
+        echo ""; \
+        echo "Read the licences above, then re-run with:"; \
+        echo "  docker build --build-arg ACCEPT_RLBENCH_LICENCE=YES ..."; \
+        echo "  (or: docker/build.sh rlbench --accept-license rlbench)"; \
+        echo "============================================================"; \
+        exit 1; \
+    fi
+
 # ── Xvfb for headless CoppeliaSim ─────────────────────────────────
 RUN apt-get update && apt-get install -y --no-install-recommends \
         xvfb libfontconfig1 tini \

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,25 +1,38 @@
 #!/usr/bin/env bash
 # Build Docker images locally.
 # Usage:
-#   docker/build.sh              # build all (base first, then benchmarks)
-#   docker/build.sh libero       # build a single benchmark image
-#   docker/build.sh --tag 0.1.0  # build all with a specific tag
+#   docker/build.sh                                 # build all (gated images skipped without opt-in)
+#   docker/build.sh libero                          # build a single benchmark image
+#   docker/build.sh --tag 0.1.0                     # build all with a specific tag
+#   docker/build.sh rlbench --accept-license rlbench
+#                                                   # opt in to a gated image's licence
+#   docker/build.sh --accept-license rlbench        # build all + opt in to a gated image
 set -euo pipefail
 
 TAG="latest"
 BASE_IMAGE=""
 TARGET=""
+ACCEPTED_LICENSES=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --tag)        TAG="$2"; shift 2 ;;
-    --base-image) BASE_IMAGE="$2"; shift 2 ;;
-    -*)           echo "Unknown flag: $1"; exit 1 ;;
-    *)            TARGET="$1"; shift ;;
+    --tag)              TAG="$2"; shift 2 ;;
+    --base-image)       BASE_IMAGE="$2"; shift 2 ;;
+    --accept-license)   ACCEPTED_LICENSES+=("$2"); shift 2 ;;
+    -*)                 echo "Unknown flag: $1"; exit 1 ;;
+    *)                  TARGET="$1"; shift ;;
   esac
 done
 
 BENCHMARKS=(simpler libero libero_pro libero_plus libero_mem robocerebra maniskill2 calvin mikasa_robo vlabench rlbench robotwin robocasa kinetix robomme molmospaces)
+
+# Images whose Dockerfile gates the build behind an ``ARG ACCEPT_*=YES``
+# build-arg.  Map: image-name → "<arg-name> <licence-url>".  Adding a new
+# gated image means one line here — no CLI flag changes required.
+declare -A EULA_GATED=(
+  [rlbench]="ACCEPT_RLBENCH_LICENCE https://github.com/stepjam/RLBench/blob/master/LICENSE"
+)
+
 REGISTRY="ghcr.io/allenai/vla-evaluation-harness"
 
 # Default BASE_IMAGE follows TAG unless explicitly overridden
@@ -27,6 +40,14 @@ BASE_IMAGE="${BASE_IMAGE:-${REGISTRY}/base:${TAG}}"
 
 # Derive harness version via hatch-vcs (PEP 440 compliant)
 HARNESS_VERSION="$(uvx hatch version 2>/dev/null || echo "0.0.0")"
+
+is_license_accepted() {
+  local n="$1"
+  for a in "${ACCEPTED_LICENSES[@]+"${ACCEPTED_LICENSES[@]}"}"; do
+    [[ "$a" == "$n" ]] && return 0
+  done
+  return 1
+}
 
 build_image() {
   local name="$1"
@@ -37,6 +58,16 @@ build_image() {
 
   if [[ "$name" != "base" ]]; then
     build_args=(--build-arg "BASE_IMAGE=${BASE_IMAGE}" --build-arg "HARNESS_VERSION=${HARNESS_VERSION}")
+  fi
+
+  if [[ -n "${EULA_GATED[$name]:-}" ]]; then
+    read -r arg_name url <<< "${EULA_GATED[$name]}"
+    if ! is_license_accepted "$name"; then
+      echo "Skipping ${image_tag}: pass --accept-license ${name} to build it"
+      echo "  See ${url}"
+      return 0
+    fi
+    build_args+=(--build-arg "${arg_name}=YES")
   fi
 
   echo "========================================="

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -32,10 +32,28 @@ fi
 
 IMAGES=(base simpler libero libero_pro libero_plus libero_mem robocerebra maniskill2 calvin mikasa_robo vlabench rlbench robotwin robocasa kinetix robomme molmospaces)
 
+# Images excluded from registry pushes — build locally only.
+NO_REDIST=(rlbench)
+
+is_no_redist() {
+  local n="$1"
+  for g in "${NO_REDIST[@]}"; do
+    [[ "$g" == "$n" ]] && return 0
+  done
+  return 1
+}
+
 push_image() {
   local name="$1"
   local image_name="${name//_/-}"
   local versioned="${REGISTRY}/${image_name}:${TAG}"
+
+  if is_no_redist "$name"; then
+    echo "Refusing to push ${versioned}: image bundles proprietary-licensed"
+    echo "binaries that may not be redistributed to a public registry."
+    echo "(See docs/reproductions/${name}.md for the license rationale.)"
+    return 0
+  fi
 
   echo "Pushing: ${versioned}"
   if ! docker push "${versioned}"; then


### PR DESCRIPTION
## Summary

Add a build-time gate to the `rlbench` Docker image. The image bundles CoppeliaSim Edu and RLBench, both of which carry non-redistribution clauses, so:

- `Dockerfile.rlbench` now requires `ACCEPT_RLBENCH_LICENCE=YES` as a build-arg; without it the build fails with the relevant licence URLs printed.
- `docker/build.sh` exposes a single repeatable `--accept-license <name>` flag, dispatched via an `EULA_GATED` associative array. Adding another gated image in the future is one line in that map (no new CLI flags).
- `docker/push.sh` short-circuits `push_image()` for entries listed in `NO_REDIST`, so `rlbench` is skipped on registry uploads.

End result: someone who clones the repo and runs `make build` gets every other image but is asked to opt in for `rlbench`, and `docker/push.sh` won't accidentally upload it.

## Checklist

- [x] I have read the relevant contributing guide ([CONTRIBUTING.md](https://github.com/allenai/vla-evaluation-harness/blob/main/CONTRIBUTING.md))

**Code changes:**
- [x] `make check` passes (ruff + ty) — no Python touched
- [x] `make test` passes (pytest) — no Python touched
- [x] Smoke-tested affected configs

Smoke test commands run:

```
# rlbench skipped without opt-in
docker/build.sh rlbench
# → Skipping ghcr.io/allenai/vla-evaluation-harness/rlbench:latest:
#   pass --accept-license rlbench to build it

# rlbench builds with opt-in
docker/build.sh rlbench --accept-license rlbench
# → builds normally

# build-all skips rlbench
docker/build.sh
# → builds base + every other benchmark; rlbench skipped

# push-all skips rlbench
docker/push.sh --tag latest -y
# → Refusing to push ghcr.io/allenai/vla-evaluation-harness/rlbench:latest …
```