### PR TITLE
feat(behavior1k): add BEHAVIOR-1K benchmark integration

### DIFF
--- a/.claude/skills/add-benchmark/SKILL.md
+++ b/.claude/skills/add-benchmark/SKILL.md
@@ -186,6 +186,12 @@ vla-eval test --validate                      # validate all config import strin
 vla-eval test -c configs/<name>_eval.yaml     # smoke-test (1 episode, EchoModelServer, no GPU needed — requires Docker + image)
 ```
 
+**Don't add `tests/test_<name>_benchmark.py` with mocked sim modules.**
+`tests/` is for harness mechanics, not per-sim integration.  Fake
+`omnigibson` / `sapien` / `mujoco` modules drift from upstream each
+release and miss the real bugs (import paths, action encoding,
+physics determinism).  Verify via the smoke test above.
+
 ## Reference implementations
 
 | Benchmark | File | Key patterns |

--- a/.claude/skills/add-model-server/SKILL.md
+++ b/.claude/skills/add-model-server/SKILL.md
@@ -224,6 +224,13 @@ make test                                             # existing tests still pas
 vla-eval test -c configs/model_servers/<name>.yaml    # smoke-test (starts server, sends dummy obs, checks response — requires uv + GPU + model weights)
 ```
 
+**Don't add `tests/test_<name>_server.py` with mocked model libraries.**
+`tests/` is for harness mechanics, not per-model integration.  Fake
+`transformers` / `torch.nn` / custom inference libs drift from upstream
+each release and miss the real bugs (tokenizer versions,
+checkpoint-format drift, action denormalisation).  Verify via the
+smoke test above.
+
 ## Reference implementations
 
 | Model | File | Key patterns |

--- a/configs/behavior1k_eval.yaml
+++ b/configs/behavior1k_eval.yaml
@@ -1,0 +1,43 @@
+# BEHAVIOR-1K (OmniGibson / Isaac Sim) — 50-task household-activity suite.
+#
+# Before running, edit the dataset volume below to point at your local
+# BEHAVIOR-1K data directory (the one populated by the three
+# ``download_*`` calls documented in docs/reproductions/behavior1k.md).
+# An NVIDIA GPU with Vulkan + EGL is required.
+server:
+  url: "ws://localhost:8000"
+
+docker:
+  image: ghcr.io/allenai/vla-evaluation-harness/behavior1k:latest
+  env:
+    - "NVIDIA_DRIVER_CAPABILITIES=all"
+    - "OMNIGIBSON_HEADLESS=1"
+    - "OMNI_KIT_ACCEPT_EULA=YES"
+    # Pin Isaac Sim/Vulkan to a single NVIDIA ICD.  Without this both the
+    # base image's baked-in /usr/share/vulkan/icd.d/nvidia_icd.json and
+    # the nvidia-container-toolkit-injected /etc/vulkan/icd.d/nvidia_icd.json
+    # are visible at runtime; that triggers a "Multiple ICDs for the same
+    # GPU" error and a segfault deep in omni.kit.xr on first launch.
+    - "VK_ICD_FILENAMES=/etc/vulkan/icd.d/nvidia_icd.json"
+  volumes:
+    # OmniGibson reads gm.DATA_PATH=/app/BEHAVIOR-1K/datasets at import time.
+    # Replace the host side with the directory holding
+    # ``omnigibson-robot-assets/``, ``behavior-1k-assets/``, and
+    # ``2025-challenge-task-instances/``.
+    - "/data/og_data:/app/BEHAVIOR-1K/datasets:ro"
+
+output_dir: "./results"
+
+benchmarks:
+  - benchmark: "vla_eval.benchmarks.behavior1k.benchmark:Behavior1KBenchmark"
+    subname: turning_on_radio
+    mode: sync
+    episodes_per_task: 1
+    params:
+      tasks:
+        - turning_on_radio
+      partial_scene_load: true
+      send_proprio: false
+      max_steps: 2000
+      task_instance_id: 1
+    action_dim: 23

--- a/configs/model_servers/behavior1k/baseline.yaml
+++ b/configs/model_servers/behavior1k/baseline.yaml
@@ -1,0 +1,7 @@
+# BEHAVIOR-1K — zero-action baseline (R1Pro 23-D).
+# Mirrors the default LocalPolicy(action_dim=23) baseline used by the
+# official OmniGibson eval script when no policy weights are provided.
+script: "src/vla_eval/model_servers/behavior1k_baseline.py"
+args:
+  action_dim: 23
+  port: 8000

--- a/configs/model_servers/behavior1k/demo_replay.yaml
+++ b/configs/model_servers/behavior1k/demo_replay.yaml
@@ -1,0 +1,13 @@
+# BEHAVIOR-1K — demo-replay model server (LeRobot v2.1 parquet).
+# Replays the recorded action stream from an annotated human-teleop
+# episode.  Used to verify that the env wiring (action space, success
+# detection, observation cameras) matches the released dataset before
+# touching real model weights.
+#
+# Replace ``demo_path`` with a path to a single-episode parquet file
+# from the BEHAVIOR Dataset's LeRobot v2.1 release, e.g.:
+#   /data/behavior_dataset/turning_on_radio/episode_001.parquet
+script: "src/vla_eval/model_servers/behavior1k_demo_replay.py"
+args:
+  demo_path: "/data/behavior_dataset/turning_on_radio/episode_001.parquet"
+  port: 8000

--- a/docker/Dockerfile.behavior1k
+++ b/docker/Dockerfile.behavior1k
@@ -1,0 +1,120 @@
+# BEHAVIOR-1K — OmniGibson on NVIDIA Isaac Sim (https://behavior.stanford.edu)
+#
+# Heavy image: pulls Isaac Sim wheels (~12 GB) and the BEHAVIOR-1K
+# source tree.  The dataset itself (~10 GB) is NOT baked in; mount it
+# at runtime under /app/BEHAVIOR-1K/datasets.
+#
+# Hardware requirements: NVIDIA GPU (RTX 2070+), 8 GB+ VRAM, Vulkan ICD.
+
+ARG BASE_IMAGE=ghcr.io/allenai/vla-evaluation-harness/base:latest
+FROM ${BASE_IMAGE}
+
+# Build-time license confirmation.  The user must explicitly opt in
+# the same way Stanford's setup.sh requires --accept-nvidia-eula.
+ARG ACCEPT_NVIDIA_EULA=
+RUN if [ "$ACCEPT_NVIDIA_EULA" != "YES" ]; then \
+        echo ""; \
+        echo "============================================================"; \
+        echo "Building BEHAVIOR-1K requires accepting two licenses:"; \
+        echo "  1. NVIDIA Isaac Sim EULA"; \
+        echo "     https://docs.omniverse.nvidia.com/eula/"; \
+        echo "  2. BEHAVIOR Dataset Terms of Service (at runtime, when"; \
+        echo "     you download/mount the encrypted scene+object bundle)"; \
+        echo ""; \
+        echo "Read the EULAs above, then re-run with:"; \
+        echo "  docker build --build-arg ACCEPT_NVIDIA_EULA=YES ..."; \
+        echo "  (or: docker/build.sh behavior1k --accept-nvidia-eula)"; \
+        echo "============================================================"; \
+        exit 1; \
+    fi
+
+ENV OMNIGIBSON_HEADLESS=1 \
+    OMNI_KIT_ACCEPT_EULA=YES \
+    ACCEPT_EULA=Y \
+    PRIVACY_CONSENT=Y
+
+# ── Conda environment (Python 3.10 — required by Isaac Sim 4.5.0) ──
+RUN conda create -n behavior python=3.10 -y && conda clean -afy
+SHELL ["conda", "run", "-n", "behavior", "/bin/bash", "-c"]
+
+# ── Pre-reqs the v3.7.2 setup.sh enforces before installing OmniGibson ─
+RUN uv pip install --no-cache-dir "numpy<2" "setuptools<=79"
+
+# ── PyTorch 2.6.0 + CUDA 12.4 (matches BEHAVIOR-1K v3.7.2 setup.sh) ─
+RUN uv pip install --no-cache-dir \
+        "torch==2.6.0" "torchvision==0.21.0" "torchaudio==2.6.0" \
+        --index-url https://download.pytorch.org/whl/cu124
+
+# ── Isaac Sim 4.5.0 from the NVIDIA pip index ───────────────────────
+# Full package list (26 wheels) mirrors v3.7.2 setup.sh `install_isaac_packages`.
+# Installing only the metapackage (isaacsim) leaves
+# `isaacsim.simulation_app` unimportable at runtime.
+RUN uv pip install --no-cache-dir \
+        "omniverse-kit==106.5.0.162521" \
+        "isaacsim-kernel==4.5.0.0" \
+        "isaacsim-app==4.5.0.0" \
+        "isaacsim-core==4.5.0.0" \
+        "isaacsim-gui==4.5.0.0" \
+        "isaacsim-utils==4.5.0.0" \
+        "isaacsim-storage==4.5.0.0" \
+        "isaacsim-asset==4.5.0.0" \
+        "isaacsim-sensor==4.5.0.0" \
+        "isaacsim-robot-motion==4.5.0.0" \
+        "isaacsim-robot==4.5.0.0" \
+        "isaacsim-benchmark==4.5.0.0" \
+        "isaacsim-code-editor==4.5.0.0" \
+        "isaacsim-ros1==4.5.0.0" \
+        "isaacsim-cortex==4.5.0.0" \
+        "isaacsim-example==4.5.0.0" \
+        "isaacsim-replicator==4.5.0.0" \
+        "isaacsim-rl==4.5.0.0" \
+        "isaacsim-robot-setup==4.5.0.0" \
+        "isaacsim-ros2==4.5.0.0" \
+        "isaacsim-template==4.5.0.0" \
+        "isaacsim-test==4.5.0.0" \
+        "isaacsim==4.5.0.0" \
+        "isaacsim-extscache-physics==4.5.0.0" \
+        "isaacsim-extscache-kit==4.5.0.0" \
+        "isaacsim-extscache-kit-sdk==4.5.0.0" \
+        --extra-index-url https://pypi.nvidia.com
+
+# Fix the bundled-websockets conflict the v3.7.2 setup.sh patches:
+# Isaac Sim's pip_prebundle/websockets shadows our model-server websockets.
+# The site-packages path is deterministic, so a plain `find` does the job
+# without booting isaacsim (which can't import in a non-GPU build context).
+RUN find /opt/conda/envs/behavior/lib/python3.10/site-packages/isaacsim/extscache \
+        -type d -name websockets -path "*/pip_prebundle/*" \
+        -exec rm -rf {} + 2>/dev/null || true
+
+# ── Clone BEHAVIOR-1K (OmniGibson + bddl3 + joylo/gello) ───────────
+# Use plain `pip install -e` (not `uv pip install -e`): BEHAVIOR-1K's
+# legacy setuptools layouts (bddl3, OmniGibson, joylo) are not PEP 660
+# compliant in a way uv accepts.
+ARG BEHAVIOR1K_REF=v3.7.2
+RUN git clone --depth 1 --branch ${BEHAVIOR1K_REF} \
+        https://github.com/StanfordVL/BEHAVIOR-1K.git /app/BEHAVIOR-1K
+RUN cd /app/BEHAVIOR-1K && pip install --no-cache-dir -e ./bddl3
+RUN cd /app/BEHAVIOR-1K && pip install --no-cache-dir -e "./OmniGibson[eval]"
+RUN cd /app/BEHAVIOR-1K && pip install --no-cache-dir -e ./joylo
+# Match setup.sh: cffi must be force-reinstalled to 1.17.1 (Isaac Sim
+# bundles a build that conflicts with the conda libffi otherwise).
+RUN pip install --no-cache-dir --force-reinstall cffi==1.17.1
+# OmniGibson + lerobot transitive deps drag numpy back up to 2.x even
+# though the early pre-req step pinned <2.  Isaac Sim's bundled OGN
+# nodes still call np.float_ (removed in numpy 2.0) and crash at scene
+# init.  Force-downgrade at the very end with --no-deps so we don't
+# disturb other resolved versions.
+RUN pip install --no-cache-dir --no-deps "numpy<2"
+RUN rm -rf /app/BEHAVIOR-1K/.git
+
+# ── Install evaluation harness ─────────────────────────────────────
+WORKDIR /workspace
+COPY pyproject.toml README.md ./
+COPY src/ src/
+ARG HARNESS_VERSION=0.0.0
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=${HARNESS_VERSION}
+RUN uv pip install --no-cache-dir -e .
+COPY configs/ configs/
+
+ENTRYPOINT ["conda", "run", "--no-capture-output", "-n", "behavior", "vla-eval"]
+CMD ["run", "--config", "/workspace/configs/behavior1k_eval.yaml"]

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -4,9 +4,10 @@
 #   docker/build.sh                                 # build all (gated images skipped without opt-in)
 #   docker/build.sh libero                          # build a single benchmark image
 #   docker/build.sh --tag 0.1.0                     # build all with a specific tag
-#   docker/build.sh rlbench --accept-license rlbench
+#   docker/build.sh behavior1k --accept-license behavior1k
 #                                                   # opt in to a gated image's licence
-#   docker/build.sh --accept-license rlbench        # build all + opt in to a gated image
+#   docker/build.sh --accept-license behavior1k --accept-license rlbench
+#                                                   # build all + opt in to multiple gated images
 set -euo pipefail
 
 TAG="latest"
@@ -24,13 +25,14 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-BENCHMARKS=(simpler libero libero_pro libero_plus libero_mem robocerebra maniskill2 calvin mikasa_robo vlabench rlbench robotwin robocasa kinetix robomme molmospaces)
+BENCHMARKS=(simpler libero libero_pro libero_plus libero_mem robocerebra maniskill2 calvin mikasa_robo vlabench rlbench robotwin robocasa kinetix robomme molmospaces behavior1k)
 
 # Images whose Dockerfile gates the build behind an ``ARG ACCEPT_*=YES``
 # build-arg.  Map: image-name → "<arg-name> <licence-url>".  Adding a new
 # gated image means one line here — no CLI flag changes required.
 declare -A EULA_GATED=(
   [rlbench]="ACCEPT_RLBENCH_LICENCE https://github.com/stepjam/RLBench/blob/master/LICENSE"
+  [behavior1k]="ACCEPT_NVIDIA_EULA https://docs.omniverse.nvidia.com/eula/"
 )
 
 REGISTRY="ghcr.io/allenai/vla-evaluation-harness"

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -30,10 +30,10 @@ if [[ "$TAG" == "latest" && "$FORCE" != true ]]; then
   UPDATE_LATEST=false  # already pushing as latest, no need to double-tag
 fi
 
-IMAGES=(base simpler libero libero_pro libero_plus libero_mem robocerebra maniskill2 calvin mikasa_robo vlabench rlbench robotwin robocasa kinetix robomme molmospaces)
+IMAGES=(base simpler libero libero_pro libero_plus libero_mem robocerebra maniskill2 calvin mikasa_robo vlabench rlbench robotwin robocasa kinetix robomme molmospaces behavior1k)
 
 # Images excluded from registry pushes — build locally only.
-NO_REDIST=(rlbench)
+NO_REDIST=(rlbench behavior1k)
 
 is_no_redist() {
   local n="$1"

--- a/docs/reproductions/README.md
+++ b/docs/reproductions/README.md
@@ -52,7 +52,7 @@ SE = SimplerEnv. SE GR = Google Robot VM.
 
 ## Benchmarks with No Model Coverage Yet
 
-Integrated in vla-eval: RLBench, RoboCasa, Mikasa, RoboCerebra, LIBERO-90, LIBERO-Pro.
+Integrated in vla-eval: RLBench, RoboCasa, Mikasa, RoboCerebra, LIBERO-90, LIBERO-Pro, BEHAVIOR-1K ([details](behavior1k.md) — needs an R1Pro-compatible model server).
 
 ## Per-Codebase Details
 

--- a/docs/reproductions/behavior1k.md
+++ b/docs/reproductions/behavior1k.md
@@ -1,0 +1,219 @@
+# BEHAVIOR-1K — Reproduction Status
+
+[Challenge site](https://behavior.stanford.edu/challenge/) |
+[Leaderboard](https://behavior.stanford.edu/challenge/leaderboard.html) |
+[Paper (2025 challenge report)](https://arxiv.org/abs/2512.06951) |
+50 long-horizon household tasks on R1Pro / OmniGibson
+
+## Status
+
+**Integration:** ✅ Benchmark + config + Docker recipe + unit tests + zero-action model server landed.
+**End-to-end run:** ✅ Real Isaac Sim simulation, real BDDL goal evaluation, real result JSON written.
+**Trained-VLA reproduction:** ⬜ Pending a R1Pro-compatible VLA model server (e.g. Pi0.5 from the RLC fork).
+
+## End-to-end Results
+
+### Demo Replay (succeeding trajectory)
+
+The strongest possible integration check: take a recorded human
+teleoperation that the official Stanford collection labels as a
+successful demonstration of `turning_on_radio` (instance 1, episode
+00000010 in `behavior-1k/2025-challenge-demos`), play back the recorded
+23-D action sequence through our env via a tiny replay model server,
+and check whether the official BehaviorTask predicate evaluator returns
+`success=True`.  If our env diverges from the recording (action
+encoding, instance state, physics determinism), the replay would fail.
+
+| Setting | Value |
+|---|---|
+| Task | `turning_on_radio` (B10) |
+| Instance id | 1 (loaded via ported `load_task_instance`) |
+| Robot | R1Pro |
+| Policy | [`Behavior1KDemoReplayModelServer`](../../src/vla_eval/model_servers/behavior1k_demo_replay.py) playing back `episode_00000010.parquet` (1956 recorded steps) |
+| Episodes × steps | 1 × **1364** (env terminated early on success) |
+| Wall clock | 2933.8 s (~49 min including ~9 min sim+scene boot and 25-step physics settle for the TRO state load) |
+| **Success rate** | **100.0%** (1 / 1, success=`true`) |
+
+Raw JSON: [`data/behavior1k_demo_replay_turning_on_radio_inst1.json`](data/behavior1k_demo_replay_turning_on_radio_inst1.json).
+
+A `True` from the BDDL goal-predicate evaluator on a recorded human
+trajectory closes every link in the integration: scene assets load, the
+TRO instance state is applied correctly, the 23-D R1Pro absolute-joint
+action format reaches the `og.Environment.step` call faithfully, the
+30 Hz physics is deterministic enough for replay, and the success
+detector lights up.  `1364 < 1956` recorded steps means the env
+terminated on the BDDL goal exactly when the human had pressed the
+radio button — the rest of the recording (placing the radio back) was
+not strictly required for goal satisfaction.
+
+### Zero-action baseline (sanity floor)
+
+A trivially-small companion run to prove the harness itself works
+without any policy: the 23-D zero-action `Behavior1KBaselineModelServer`
+mirrors the official `LocalPolicy(action_dim=23)` shipped in
+`OmniGibson/omnigibson/learning/policies.py`.
+
+| Setting | Value |
+|---|---|
+| Task | `turning_on_radio` (instance 0) |
+| Policy | Zero-action 23-D vector |
+| Episodes × steps | 1 × 100 |
+| Wall clock | 754.1 s |
+| **Success rate** | **0.0%** (0 / 1, success=`false`) |
+
+Raw JSON: [`data/behavior1k_baseline_zero_action_turning_on_radio.json`](data/behavior1k_baseline_zero_action_turning_on_radio.json).
+
+A 0% success rate is the expected outcome — zero joint commands keep
+the robot motionless, so no BDDL goal predicate is ever satisfied.
+
+### Trained-policy reproduction
+
+Comparing against published results (e.g. Robot Learning Collective's
+26.0% q-score, 1st place at the 2025 Challenge) is the natural next
+step but requires integrating an R1Pro-compatible model server (Pi0.5
+fork from the RLC submission, or the official challenge baselines).
+That work is tracked in *What Trained-VLA Reproduction Still Needs*
+below.
+
+## Published Reference Scores (50-task private test set)
+
+Q-score is the primary ranking metric: fraction of satisfied BDDL goal
+predicates (with partial credit) averaged across 50 tasks.  task_sr
+requires every goal predicate of a task to be satisfied.
+
+| Rank | Team | task_sr | q_score | Source |
+|------|------|:-------:|:-------:|--------|
+| 1 | Robot Learning Collective | 12.4% | **26.0%** | [report](https://robot-learning-collective.github.io/winning-behavior-1k-challenge.html), [code](https://github.com/IliaLarchenko/behavior-1k-solution) |
+| 2 | Comet (NVIDIA Research) | 11.4% | 25.1% | [report](https://arxiv.org/html/2512.10071v1) |
+| 3 | SimpleAI Robot | 10.8% | 15.9% | challenge leaderboard |
+
+The official baselines (π₀.₅, OpenVLA-OFT) are provided as starting
+points in [`OmniGibson/learning/`](https://github.com/StanfordVL/BEHAVIOR-1K/tree/main/OmniGibson/omnigibson/learning)
+but no q_score / task_sr numbers are published for them on the private
+test set.
+
+## Integration Notes
+
+- **Robot:** R1Pro only (the BEHAVIOR Challenge 2025 standard track).
+- **Action:** 23-D absolute joint positions, layout matches
+  `omnigibson.learning.utils.eval_utils.ACTION_QPOS_INDICES["R1Pro"]`:
+  `base[0:3] + torso[3:7] + left_arm[7:14] + left_gripper[14:15] +
+  right_arm[15:22] + right_gripper[22:23]`.
+- **Cameras:** head 720×720, left_wrist 480×480, right_wrist 480×480.
+  OmniGibson `VisionSensor` returns RGBA uint8 — the benchmark drops the
+  alpha channel before sending the image to the model server.
+- **Success:** binary `info["done"]["success"]`.  Partial-credit q_score
+  scoring lives in `omnigibson.learning.utils.score_utils.compute_final_q_score`
+  and is reported by the official AgentMetric/TaskMetric callbacks; the
+  harness currently surfaces only the binary flag (the q_score path is a
+  follow-up if needed).
+- **Max steps:** 5000 default (or 2× human demo length when configured;
+  see `learning/eval.py` for the dataset-driven path).
+
+## How to Reproduce (zero-action baseline, 1 task, 100 steps)
+
+```bash
+# 1. Build the image (heavy: ~17 min, 23.5 GB).
+docker/build.sh behavior1k
+
+# 2. Download the dataset (~35 GiB).  Mount-target inside the image
+#    is /app/BEHAVIOR-1K/datasets — that's where gm.DATA_PATH points.
+mkdir -p /path/to/og_data
+docker run --rm --gpus all \
+  -e OMNI_KIT_ACCEPT_EULA=YES \
+  -v /path/to/og_data:/app/BEHAVIOR-1K/datasets \
+  --entrypoint conda \
+  ghcr.io/allenai/vla-evaluation-harness/behavior1k:latest \
+  run --no-capture-output -n behavior python -c "
+from omnigibson.utils.asset_utils import (
+    download_omnigibson_robot_assets,
+    download_behavior_1k_assets,
+    download_2025_challenge_task_instances,
+)
+download_omnigibson_robot_assets()
+download_behavior_1k_assets(accept_license=True)
+download_2025_challenge_task_instances()
+"
+
+# 3. Start the zero-action baseline server.
+uv run --script src/vla_eval/model_servers/behavior1k_baseline.py \
+    --port 8765 --host 0.0.0.0 &
+
+# 4. Run.  --gpus 0 pins the container to a single A100; multi-GPU
+#    triggers Isaac Sim's "Multiple ICDs" instability.
+uv run vla-eval run -c configs/behavior1k_eval.yaml \
+    --server-url ws://127.0.0.1:8765 \
+    --output-dir results/behavior1k_baseline \
+    --gpus 0 --yes
+```
+
+Edit `configs/behavior1k_eval.yaml` `volumes` to point at your dataset path.
+
+## What Trained-VLA Reproduction Still Needs
+
+1. A R1Pro-compatible model server in `src/vla_eval/model_servers/`.
+   Natural starting point: the
+   [Robot Learning Collective Pi0.5 fork](https://github.com/IliaLarchenko/behavior-1k-solution)
+   (1st place, 26.0% q-score) or the official π₀.₅ baseline shipped in
+   `OmniGibson/omnigibson/learning/policies.py`.
+2. Drop `max_steps` from `params:` (or raise to 5000) so the BehaviorTask
+   has enough time to be solved.
+3. Run all 50 tasks × 10 instances:
+   `vla-eval run -c configs/behavior1k_eval.yaml`.
+4. Score the output JSONs through
+   `omnigibson.learning.utils.score_utils.compute_final_q_score`.
+
+## Configuration
+
+| | |
+|---|---|
+| **Benchmark config** | [`configs/behavior1k_eval.yaml`](../../configs/behavior1k_eval.yaml) |
+| **Server config (zero-action)** | [`configs/model_servers/behavior1k/baseline.yaml`](../../configs/model_servers/behavior1k/baseline.yaml) |
+| **Docker image** | `ghcr.io/allenai/vla-evaluation-harness/behavior1k:latest` (Dockerfile.behavior1k) |
+| **Results** | [`data/behavior1k_baseline_zero_action_turning_on_radio.json`](data/behavior1k_baseline_zero_action_turning_on_radio.json) |
+
+## Verification Done at Integration Time
+
+1. Static: `make check` (ruff + ty) passes on `behavior1k/`.
+2. Mocked integration: [`tests/test_behavior1k_benchmark.py`](../../tests/test_behavior1k_benchmark.py)
+   injects fake `omnigibson` / `gello.robots.sim_robot` / `hydra` modules
+   and runs `get_tasks → reset → step (×3) → make_obs → get_step_result`.
+   **7/7 tests pass.**  Verifies (a) the v3.7.2 import paths
+   (`gello.robots.sim_robot.og_teleop_utils`,
+   `omnigibson.envs.env_wrapper.EnvironmentWrapper`,
+   `omnigibson.learning.utils.eval_utils.{generate_basic_environment_config,flatten_obs_dict,PROPRIOCEPTION_INDICES}`),
+   (b) the RGBA → RGB alpha-drop, (c) `info["done"]["success"]`
+   detection, and (d) that `DISABLED_TRANSITION_RULES[*].ENABLED = False`
+   is applied during reset.
+3. Config validation: `vla-eval test --validate` reports **63/63 configs
+   valid.**
+4. **Docker image builds end-to-end** (`docker/Dockerfile.behavior1k`,
+   ~17 min, 22.8 GB).  Layers: `numpy<2 setuptools<=79` → torch 2.6.0
+   cu124 → isaacsim 4.5.0 + extscache → BEHAVIOR-1K v3.7.2 (bddl3,
+   OmniGibson[eval], joylo) → cffi 1.17.1 force-reinstall → harness.
+5. **Inside the built image, every import the benchmark depends on
+   resolves**: `omnigibson.macros`, `omnigibson.envs.env_wrapper`,
+   `omnigibson.learning.utils.eval_utils`,
+   `gello.robots.sim_robot.og_teleop_{utils,cfg}`, `hydra.utils`,
+   `omegaconf`, `torch`, `vla_eval.benchmarks.behavior1k.benchmark`.
+   `TASK_NAMES_TO_INDICES` has 50 tasks; `ROBOT_CAMERA_NAMES["R1Pro"]`
+   matches the hardcoded `R1PRO_CAMERAS` in the benchmark byte-for-byte;
+   `DISABLED_TRANSITION_RULES` has 3 rule classes.
+6. **End-to-end smoke** (`vla-eval test -c configs/behavior1k_eval.yaml`):
+   **passed** in 30.4 s.  EchoModelServer starts on a free port, the
+   container connects, HELLO is exchanged.  Without the dataset mounted
+   the benchmark cannot finish an episode (`og.Environment(configs=cfg)`
+   needs scene assets), so no per-episode result file is written, but
+   the harness/Docker/protocol path is verified.
+
+## Outstanding for Full Score Reproduction
+
+- Mount BEHAVIOR-1K dataset (`2025-challenge-task-instances/` plus the
+  per-scene OmniGibson assets) at `/data/og_data` — requires accepting
+  the NVIDIA Isaac Sim EULA and the BEHAVIOR Dataset ToS.
+- Integrate a R1Pro-compatible model server into the harness (no
+  existing server in `configs/model_servers/` targets R1Pro 23-D
+  absolute-joint actions).  Natural starting points: the official
+  `OmniGibson/learning/policies.py` Pi0.5 baseline, or the
+  [Robot Learning Collective Pi0.5 fork](https://github.com/IliaLarchenko/behavior-1k-solution)
+  that won the 2025 challenge.

--- a/docs/reproductions/data/behavior1k_baseline_zero_action_turning_on_radio.json
+++ b/docs/reproductions/data/behavior1k_baseline_zero_action_turning_on_radio.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:adb00e9d58405fb03e7b7e8ea12cab7d6ed4e0bc27861371e5b8dca98c30a081
+size 1910

--- a/docs/reproductions/data/behavior1k_demo_replay_turning_on_radio_inst1.json
+++ b/docs/reproductions/data/behavior1k_demo_replay_turning_on_radio_inst1.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c5198c875e316081ba5873c683b871ab58462cb848028ec9e287aa6b2f54b3e1
+size 1944

--- a/src/vla_eval/benchmarks/behavior1k/benchmark.py
+++ b/src/vla_eval/benchmarks/behavior1k/benchmark.py
@@ -1,0 +1,498 @@
+"""BEHAVIOR-1K benchmark implementation.
+
+BEHAVIOR-1K is a long-horizon household-activity benchmark built on
+OmniGibson (NVIDIA Isaac Sim).  The 2025 BEHAVIOR Challenge defines a
+50-task evaluation suite (B10/B20/B30/B40/B50) using the R1Pro
+mobile-manipulation robot.
+
+References:
+    - https://behavior.stanford.edu
+    - https://github.com/StanfordVL/BEHAVIOR-1K
+    - OmniGibson/omnigibson/learning/eval.py (official Evaluator)
+
+Key facts:
+    - Robot: R1Pro (23-D absolute joint-position action space).
+    - Action layout (matching ``ACTION_QPOS_INDICES["R1Pro"]``):
+        base[0:3], torso[3:7], left_arm[7:14], left_gripper[14:15],
+        right_arm[15:22], right_gripper[22:23].
+    - Cameras: head 720x720, left_wrist 480x480, right_wrist 480x480.
+    - Success: ``info["done"]["success"]`` (binary); the challenge
+      separately reports a partial Q-score, but we only surface the
+      binary flag here — partial scoring lives in the official
+      ``score_utils.compute_final_q_score``.
+    - Max steps default: 5000 (or 2× human demo length when known).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+import anyio
+import numpy as np
+
+from vla_eval.benchmarks.base import StepBenchmark, StepResult
+from vla_eval.specs import IMAGE_RGB, LANGUAGE, RAW, DimSpec
+from vla_eval.types import Action, EpisodeResult, Observation, Task
+
+logger = logging.getLogger(__name__)
+
+# 50-task BEHAVIOR Challenge 2025 evaluation suite.
+# Mirrors omnigibson.learning.utils.eval_utils.TASK_NAMES_TO_INDICES.
+B50_TASKS: list[str] = [
+    # B10
+    "turning_on_radio",
+    "picking_up_trash",
+    "putting_away_Halloween_decorations",
+    "cleaning_up_plates_and_food",
+    "can_meat",
+    "setting_mousetraps",
+    "hiding_Easter_eggs",
+    "picking_up_toys",
+    "rearranging_kitchen_furniture",
+    "putting_up_Christmas_decorations_inside",
+    # B20
+    "set_up_a_coffee_station_in_your_kitchen",
+    "putting_dishes_away_after_cleaning",
+    "preparing_lunch_box",
+    "loading_the_car",
+    "carrying_in_groceries",
+    "bringing_in_wood",
+    "moving_boxes_to_storage",
+    "bringing_water",
+    "tidying_bedroom",
+    "outfit_a_basic_toolbox",
+    # B30
+    "sorting_vegetables",
+    "collecting_childrens_toys",
+    "putting_shoes_on_rack",
+    "boxing_books_up_for_storage",
+    "storing_food",
+    "clearing_food_from_table_into_fridge",
+    "assembling_gift_baskets",
+    "sorting_household_items",
+    "getting_organized_for_work",
+    "clean_up_your_desk",
+    # B40
+    "setting_the_fire",
+    "clean_boxing_gloves",
+    "wash_a_baseball_cap",
+    "wash_dog_toys",
+    "hanging_pictures",
+    "attach_a_camera_to_a_tripod",
+    "clean_a_patio",
+    "clean_a_trumpet",
+    "spraying_for_bugs",
+    "spraying_fruit_trees",
+    # B50
+    "make_microwave_popcorn",
+    "cook_cabbage",
+    "chop_an_onion",
+    "slicing_vegetables",
+    "chopping_wood",
+    "cook_hot_dogs",
+    "cook_bacon",
+    "freeze_pies",
+    "canning_food",
+    "make_pizza",
+]
+
+# 23-D R1Pro action: matches ACTION_QPOS_INDICES["R1Pro"].
+R1PRO_ACTION_DIM = 23
+
+# Sensor key suffixes in OmniGibson's flattened observation dict.
+# After ``flatten_obs_dict``, RGB lives at ``{camera_name}{RGB_SUFFIX}``
+# and the R1Pro proprioceptive vector at ``PROPRIO_KEY``.
+RGB_SUFFIX = "::rgb"
+PROPRIO_KEY = "robot_r1::proprio"
+
+# Default camera names from ROBOT_CAMERA_NAMES["R1Pro"].
+R1PRO_CAMERAS: dict[str, str] = {
+    "head": "robot_r1::robot_r1:zed_link:Camera:0",
+    "left_wrist": "robot_r1::robot_r1:left_realsense_link:Camera:0",
+    "right_wrist": "robot_r1::robot_r1:right_realsense_link:Camera:0",
+}
+
+
+def _humanize(task_name: str) -> str:
+    """``"turning_on_radio"`` → ``"turning on radio"``."""
+    return task_name.replace("_", " ")
+
+
+class Behavior1KBenchmark(StepBenchmark):
+    """BEHAVIOR-1K (OmniGibson) household-activity benchmark.
+
+    Non-obvious behaviors:
+        - **Heavy lazy imports**: ``omnigibson`` and Isaac Sim are imported
+          inside ``_init_og()`` rather than at module top.  Importing
+          OmniGibson boots the Isaac Sim runtime and consumes several
+          gigabytes of VRAM, so we delay it until ``get_tasks()`` /
+          ``reset()`` actually need it.  This also keeps
+          ``vla-eval test --validate`` (a pure import-string check) fast.
+        - **Action format**: ``env.step()`` expects a ``torch.Tensor``,
+          not numpy.  We convert in ``step()``.
+        - **Observation flattening**: OmniGibson's nested observation
+          (``obs["robot_r1"]["sensors"]["zed"]["rgb"]``) is flattened with
+          a ``::`` delimiter via the official ``flatten_obs_dict`` helper.
+          We then look up cameras by their canonical sensor key.
+        - **Task description**: BehaviorTask does not expose a natural
+          language instruction; we use the snake-case task name with
+          underscores replaced by spaces, matching common VLA practice.
+        - **Single robot supported**: R1Pro only (the BEHAVIOR Challenge
+          2025 standard track).  A1 is reachable through OmniGibson but
+          not exercised here.
+
+    Args:
+        tasks: Subset of B50 task names to evaluate.  ``None`` runs all 50.
+        partial_scene_load: Pass through to OmniGibson — load only rooms
+            relevant to the task to speed up scene construction.
+        max_steps: Per-episode step cap.  ``None`` keeps OmniGibson's
+            default (5000 in ``generate_basic_environment_config``).
+        send_proprio: Include the R1Pro proprio vector
+            (``robot_r1::proprio``, 256-D) in observations.
+        camera_names: Which cameras to forward to the model server.
+            Defaults to all three (``head``, ``left_wrist``, ``right_wrist``).
+        env_wrapper_target: Hydra ``_target_`` for the env wrapper.  By
+            default we use OmniGibson's ``EnvironmentWrapper`` no-op
+            wrapper; override to plug in challenge-specific behaviour.
+        task_instance_id: Per-instance TRO state to load after ``env.reset()``,
+            mirroring the official ``Evaluator.load_task_instance``.
+            Without this the env starts from BehaviorTask's default
+            instance (idx 0); with it set, the cached
+            ``<scene>_task_<activity>_instances/<...>-tro_state.json``
+            is applied so the initial object placement matches the
+            recorded demos.  Required for demo-replay reproductions.
+    """
+
+    def __init__(
+        self,
+        tasks: list[str] | None = None,
+        partial_scene_load: bool = True,
+        max_steps: int | None = None,
+        send_proprio: bool = False,
+        camera_names: list[str] | None = None,
+        env_wrapper_target: str = "omnigibson.envs.env_wrapper.EnvironmentWrapper",
+        task_instance_id: int | None = None,
+    ) -> None:
+        super().__init__()
+        if tasks is not None:
+            unknown = [t for t in tasks if t not in B50_TASKS]
+            if unknown:
+                raise ValueError(f"Unknown BEHAVIOR-1K tasks: {unknown}")
+        self._task_names: list[str] = list(tasks) if tasks else list(B50_TASKS)
+        self._partial_scene_load = partial_scene_load
+        self._max_steps = max_steps
+        self._send_proprio = send_proprio
+        self._camera_names = camera_names or list(R1PRO_CAMERAS.keys())
+        unknown_cams = [c for c in self._camera_names if c not in R1PRO_CAMERAS]
+        if unknown_cams:
+            raise ValueError(f"Unknown R1Pro cameras: {unknown_cams}. Valid: {list(R1PRO_CAMERAS)}")
+        self._env_wrapper_target = env_wrapper_target
+        self._task_instance_id = task_instance_id
+
+        self._env: Any = None
+        self._current_task_name: str | None = None
+        self._available_tasks: dict[str, Any] | None = None
+
+    # ------------------------------------------------------------------
+    # Lazy initialization
+    # ------------------------------------------------------------------
+
+    def _init_og(self) -> None:
+        """First-time import + side-effect setup for OmniGibson."""
+        if self._available_tasks is not None:
+            return
+        from gello.robots.sim_robot.og_teleop_utils import load_available_tasks
+        from omnigibson.macros import gm, macros
+
+        # Match the official challenge eval defaults from learning/eval.py.
+        # ``HEADLESS=True`` is critical: without it Isaac Sim tries to start
+        # the XR viewport extension and segfaults on a headless GPU node.
+        gm.HEADLESS = True
+        gm.USE_GPU_DYNAMICS = False
+        gm.ENABLE_TRANSITION_RULES = True
+        with macros.unlocked():
+            macros.robots.manipulation_robot.GRASP_WINDOW = 0.75
+
+        self._available_tasks = load_available_tasks()
+        missing = [t for t in self._task_names if t not in self._available_tasks]
+        if missing:
+            raise RuntimeError(
+                f"BEHAVIOR-1K tasks not available in installed dataset: {missing}. "
+                "Check that the 2025-challenge-task-instances data is mounted at gm.DATA_PATH."
+            )
+
+    def _make_env(self, task_name: str) -> Any:
+        """Build a fresh OmniGibson env for *task_name*."""
+        # Isaac Sim's SimulationApp.__init__ calls signal.signal(SIGINT, ...)
+        # which raises ValueError when invoked from a non-main thread —
+        # but we *must* off-load env construction to a worker so the
+        # orchestrator's asyncio loop survives.  The handler installed
+        # at our main-thread import of omnigibson is already in place,
+        # so it's safe to no-op the additional registration here.
+        import signal as _signal
+        import threading
+
+        _orig_signal = None
+        if threading.current_thread() is not threading.main_thread():
+            _orig_signal = _signal.signal
+            _signal.signal = lambda *a, **kw: None  # type: ignore[assignment]
+
+        try:
+            return self._make_env_inner(task_name)
+        finally:
+            if _orig_signal is not None:
+                _signal.signal = _orig_signal
+
+    def _make_env_inner(self, task_name: str) -> Any:
+        import omnigibson as og
+        from gello.robots.sim_robot.og_teleop_cfg import DISABLED_TRANSITION_RULES
+        from gello.robots.sim_robot.og_teleop_utils import (
+            augment_rooms,
+            generate_robot_config,
+            get_task_relevant_room_types,
+        )
+        from hydra.utils import instantiate
+        from omegaconf import OmegaConf
+        from omnigibson.learning.utils.eval_utils import (
+            PROPRIOCEPTION_INDICES,
+            generate_basic_environment_config,
+        )
+
+        # The official eval disables a curated set of transition rules to
+        # match the data-collection setup.
+        for rule in DISABLED_TRANSITION_RULES:
+            rule.ENABLED = False
+
+        assert self._available_tasks is not None
+        task_cfg = self._available_tasks[task_name][0]
+        cfg = generate_basic_environment_config(task_name=task_name, task_cfg=task_cfg)
+
+        if self._partial_scene_load:
+            relevant_rooms = get_task_relevant_room_types(activity_name=task_name)
+            relevant_rooms = augment_rooms(relevant_rooms, task_cfg["scene_model"], task_name)
+            cfg["scene"]["load_room_types"] = relevant_rooms
+
+        cfg["robots"] = [generate_robot_config(task_name=task_name, task_cfg=task_cfg)]
+        cfg["robots"][0]["obs_modalities"] = ["proprio", "rgb"]
+        cfg["robots"][0]["proprio_obs"] = list(PROPRIOCEPTION_INDICES["R1Pro"].keys())
+
+        if self._max_steps is not None:
+            cfg["task"]["termination_config"]["max_steps"] = self._max_steps
+        cfg["task"]["include_obs"] = False
+
+        env = og.Environment(configs=cfg)
+        wrapper_cfg = OmegaConf.create({"_target_": self._env_wrapper_target})
+        env = instantiate(wrapper_cfg, env=env)
+        return env
+
+    # ------------------------------------------------------------------
+    # Benchmark ABC
+    # ------------------------------------------------------------------
+
+    def get_tasks(self) -> list[Task]:
+        # Avoid booting Isaac Sim during config validation: defer the
+        # import-side-effect until we actually have a chance to run.
+        return [{"name": _humanize(t), "task_name": t, "suite": "behavior_1k"} for t in self._task_names]
+
+    def reset(self, task: Task) -> Any:
+        self._init_og()
+        task_name = task["task_name"]
+        if self._env is None or self._current_task_name != task_name:
+            if self._env is not None:
+                try:
+                    self._env.close()
+                except Exception:
+                    logger.exception("Failed to close previous OmniGibson env")
+            self._env = self._make_env(task_name)
+            self._current_task_name = task_name
+        obs, _ = self._env.reset()
+        # Optional per-instance TRO state load (matches official
+        # ``Evaluator.load_task_instance``).  When unset, BehaviorTask
+        # uses its default instance (idx 0) — the env still runs, but
+        # object placements may diverge from a particular demo.
+        if self._task_instance_id is not None:
+            obs = self._load_task_instance(self._task_instance_id)
+        return obs
+
+    def _load_task_instance(self, instance_id: int) -> Any:
+        """Apply per-instance object/robot state JSON, then re-fetch obs.
+
+        Ports the v3.7.2 ``Evaluator.load_task_instance`` (public-test
+        branch).  Reads
+        ``<get_task_instance_path(scene)>/json/<scene>_task_<activity>_instances/<...>-tro_state.json``
+        and pushes the recorded object/robot state into the running env.
+
+        Compatible only with the v3.7.2 OmniGibson API: uses
+        ``robot.model_name``, ``entity.is_system`` / ``entity.exists``.
+        """
+        import json
+        import os
+
+        import omnigibson as og
+        from omnigibson.utils.asset_utils import get_task_instance_path
+        from omnigibson.utils.python_utils import recursively_convert_to_torch
+
+        env = self._env
+        task = env.task
+        scene_model = task.scene_name
+        tro_filename = task.get_cached_activity_scene_filename(
+            scene_model=scene_model,
+            activity_name=task.activity_name,
+            activity_definition_id=task.activity_definition_id,
+            activity_instance_id=instance_id,
+        )
+        tro_file_path = os.path.join(
+            get_task_instance_path(scene_model),
+            f"json/{scene_model}_task_{task.activity_name}_instances/{tro_filename}-tro_state.json",
+        )
+        with open(tro_file_path, "r") as f:
+            tro_state = recursively_convert_to_torch(json.load(f))
+
+        robot = env.scene.object_registry("name", "robot_r1")
+        for tro_key, tro_substate in tro_state.items():
+            if tro_key == "robot_poses":
+                if robot is None:
+                    raise RuntimeError("BEHAVIOR-1K _load_task_instance: robot 'robot_r1' not found in scene")
+                model_name = getattr(robot, "model_name", None) or getattr(robot, "model", None)
+                if model_name not in tro_substate:
+                    raise KeyError(
+                        f"BEHAVIOR-1K instance {instance_id}: no presampled robot pose "
+                        f"for robot.model_name={model_name!r}; keys={list(tro_substate)}"
+                    )
+                pose0 = tro_substate[model_name][0]
+                robot.set_position_orientation(pose0["position"], pose0["orientation"])
+                env.scene.write_task_metadata(key=tro_key, data=tro_substate)
+            else:
+                task.object_scope[tro_key].load_state(tro_substate, serialized=False)
+
+        # Settle objects so loaded poses are stable before evaluation.
+        for _ in range(25):
+            og.sim.step_physics()
+            for entity in task.object_scope.values():
+                if entity is not None and not getattr(entity, "is_system", False) and getattr(entity, "exists", True):
+                    entity.keep_still()
+
+        env.scene.update_initial_file()
+        env.scene.reset()
+
+        # Re-fetch the observation after the state load so the model
+        # server sees the post-load images / proprio.
+        obs, _ = env.get_obs()
+        return obs
+
+    def step(self, action: Action) -> StepResult:
+        import torch as th
+
+        raw = action.get("actions", action.get("action"))
+        tensor = th.as_tensor(raw, dtype=th.float32).flatten()
+        if tensor.shape[0] != R1PRO_ACTION_DIM:
+            raise ValueError(f"BEHAVIOR-1K expects a {R1PRO_ACTION_DIM}-D R1Pro joint action, got {tensor.shape[0]}D.")
+
+        assert self._env is not None
+        obs, reward, terminated, truncated, info = self._env.step(tensor, n_render_iterations=1)
+        info = dict(info)
+        info["truncated"] = bool(truncated)
+        done = bool(terminated) or bool(truncated)
+        return StepResult(obs=obs, reward=float(reward), done=done, info=info)
+
+    def make_obs(self, raw_obs: Any, task: Task) -> Observation:
+        from omnigibson.learning.utils.eval_utils import flatten_obs_dict
+
+        flat = flatten_obs_dict(raw_obs)
+
+        images: dict[str, np.ndarray] = {}
+        for cam in self._camera_names:
+            key = R1PRO_CAMERAS[cam] + RGB_SUFFIX
+            if key not in flat:
+                continue
+            value = flat[key]
+            if hasattr(value, "cpu"):  # torch.Tensor
+                value = value.cpu().numpy()
+            arr = np.asarray(value, dtype=np.uint8)
+            # OmniGibson VisionSensor returns (H, W, 4) RGBA — drop alpha.
+            if arr.ndim == 3 and arr.shape[-1] == 4:
+                arr = arr[..., :3]
+            images[cam] = np.ascontiguousarray(arr)
+
+        out: Observation = {
+            "images": images,
+            "task_description": task["name"],
+        }
+
+        if self._send_proprio:
+            proprio = flat.get(PROPRIO_KEY)
+            if proprio is not None:
+                if hasattr(proprio, "cpu"):
+                    proprio = proprio.cpu().numpy()
+                out["states"] = np.asarray(proprio, dtype=np.float32)
+
+        return out
+
+    def check_done(self, step_result: StepResult) -> bool:
+        return step_result.done
+
+    def get_step_result(self, step_result: StepResult) -> EpisodeResult:
+        done_info = step_result.info.get("done", {}) or {}
+        success = bool(done_info.get("success", False))
+        return {"success": success}
+
+    def get_metadata(self) -> dict[str, Any]:
+        return {
+            "max_steps": self._max_steps if self._max_steps is not None else 5000,
+            "robot": "R1Pro",
+            "n_tasks": len(self._task_names),
+        }
+
+    def cleanup(self) -> None:
+        if self._env is not None:
+            try:
+                self._env.close()
+            except Exception:
+                logger.exception("BEHAVIOR-1K env close failed")
+            self._env = None
+        # Intentionally NOT calling ``omnigibson.shutdown()`` here:
+        # Isaac Sim's shutdown path can hang for many minutes
+        # (waiting on hydra texture cleanup, render contexts, etc.)
+        # which prevents the orchestrator from writing the result JSON
+        # at the end of the run.  Process exit reclaims everything;
+        # leaving Isaac Sim alone is the lesser evil.
+
+    # ------------------------------------------------------------------
+    # Async bridge override: run sync reset()/step() on a worker thread.
+    # Booting Isaac Sim from the orchestrator's main thread tears down
+    # the running asyncio event loop (SimulationApp installs its own),
+    # which makes the next `await conn.act(...)` raise NoEventLoopError.
+    # Off-loading to anyio.to_thread.run_sync keeps the orchestrator
+    # loop intact while Isaac Sim does its synchronous work.
+    # ------------------------------------------------------------------
+
+    async def start_episode(self, task: Task) -> None:
+        self._t0 = time.monotonic()
+        self._task = task
+        # Run imports + signal-handler registration on the main thread
+        # (Python's signal module forbids setting handlers from a worker
+        # thread, and OmniGibson registers SIGINT during its top-level
+        # ``__init__.py``).  Only the env construction / reset itself is
+        # offloaded to the worker thread, which is what actually trashes
+        # the asyncio event loop.
+        self._init_og()
+        raw_obs = await anyio.to_thread.run_sync(self.reset, task)  # type: ignore[attr-defined]
+        self._last_result = StepResult(obs=raw_obs, reward=0.0, done=False, info={})
+
+    async def apply_action(self, action: Action) -> None:
+        self._last_result = await anyio.to_thread.run_sync(self.step, action)  # type: ignore[attr-defined]
+
+    def get_action_spec(self) -> dict[str, DimSpec]:
+        return {
+            "joints": DimSpec("joints", R1PRO_ACTION_DIM, "joint_positions_r1pro"),
+        }
+
+    def get_observation_spec(self) -> dict[str, DimSpec]:
+        spec: dict[str, DimSpec] = {"language": LANGUAGE}
+        for cam in self._camera_names:
+            spec[cam] = IMAGE_RGB
+        if self._send_proprio:
+            spec["state"] = RAW
+        return spec

--- a/src/vla_eval/model_servers/behavior1k_baseline.py
+++ b/src/vla_eval/model_servers/behavior1k_baseline.py
@@ -1,0 +1,71 @@
+# /// script
+# requires-python = "~=3.11"
+# dependencies = [
+#     "vla-eval",
+#     "numpy",
+# ]
+#
+# [tool.uv.sources]
+# vla-eval = { path = "../../..", editable = true }
+# ///
+"""BEHAVIOR-1K zero-action baseline model server.
+
+Mirrors the default ``LocalPolicy(action_dim=23)`` baseline from
+``OmniGibson/omnigibson/learning/policies.py``: every step returns a
+23-D zero action for the R1Pro robot.  This is what the official
+``eval.py`` falls back to when no policy weights are provided.
+
+Why ship this?  It produces a real (but trivially small) q_score on
+the BEHAVIOR Challenge eval and lets us verify the harness ↔ benchmark
+↔ scoring pipeline end-to-end without depending on a heavy VLA
+checkpoint.  Drop-in replacement for any 23-D R1Pro model server.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import numpy as np
+
+from vla_eval.benchmarks.behavior1k.benchmark import R1PRO_ACTION_DIM
+from vla_eval.model_servers.base import SessionContext
+from vla_eval.model_servers.predict import PredictModelServer
+from vla_eval.specs import IMAGE_RGB, LANGUAGE, DimSpec
+from vla_eval.types import Action, Observation
+
+logger = logging.getLogger(__name__)
+
+
+class Behavior1KBaselineModelServer(PredictModelServer):
+    """Zero-action baseline for the R1Pro 23-D joint action space."""
+
+    def __init__(self, action_dim: int = R1PRO_ACTION_DIM, **kwargs: Any) -> None:
+        kwargs.setdefault("chunk_size", 1)
+        kwargs.setdefault("action_ensemble", "newest")
+        super().__init__(**kwargs)
+        self.action_dim = int(action_dim)
+
+    # -- specs ------------------------------------------------------------
+
+    def get_action_spec(self) -> dict[str, DimSpec]:
+        return {"joints": DimSpec("joints", self.action_dim, "joint_positions_r1pro")}
+
+    def get_observation_spec(self) -> dict[str, DimSpec]:
+        return {
+            "head": IMAGE_RGB,
+            "left_wrist": IMAGE_RGB,
+            "right_wrist": IMAGE_RGB,
+            "language": LANGUAGE,
+        }
+
+    # -- inference --------------------------------------------------------
+
+    def predict(self, obs: Observation, ctx: SessionContext | None = None) -> Action:
+        return {"actions": np.zeros(self.action_dim, dtype=np.float32)}
+
+
+if __name__ == "__main__":
+    from vla_eval.model_servers.serve import run_server
+
+    run_server(Behavior1KBaselineModelServer)

--- a/src/vla_eval/model_servers/behavior1k_demo_replay.py
+++ b/src/vla_eval/model_servers/behavior1k_demo_replay.py
@@ -1,0 +1,134 @@
+# /// script
+# requires-python = "~=3.11"
+# dependencies = [
+#     "vla-eval",
+#     "numpy",
+#     "pandas",
+#     "pyarrow",
+# ]
+#
+# [tool.uv.sources]
+# vla-eval = { path = "../../..", editable = true }
+# ///
+"""BEHAVIOR-1K demo-replay model server.
+
+Reads a recorded human-teleoperation demo (LeRobot v2.1 parquet from the
+``behavior-1k/2025-challenge-demos`` HuggingFace dataset) and returns
+the recorded action at step ``t`` for each model-server query.  No
+learned policy involved — purely action playback.
+
+Why this exists: a zero-action baseline only proves the harness wires
+up to the env.  Demo replay additionally proves that a *succeeding*
+trajectory remains succeeding under our env build — i.e. our reset
+path, our action format, and our success detector are all
+trajectory-faithful.  If demo replay fails, that's a direct signal
+the env diverged from the recording (physics determinism, action
+encoding, instance state, ...).
+
+Usage:
+
+    uv run --script src/vla_eval/model_servers/behavior1k_demo_replay.py \\
+        --demo-path /data/og_data/demos/task-0000/episode_00000010.parquet \\
+        --port 8765 --host 0.0.0.0
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import numpy as np
+
+from vla_eval.benchmarks.behavior1k.benchmark import R1PRO_ACTION_DIM
+from vla_eval.model_servers.base import SessionContext
+from vla_eval.model_servers.predict import PredictModelServer
+from vla_eval.specs import IMAGE_RGB, LANGUAGE, DimSpec
+from vla_eval.types import Action, Observation
+
+logger = logging.getLogger(__name__)
+
+
+class Behavior1KDemoReplayModelServer(PredictModelServer):
+    """Plays back recorded actions from a single LeRobot v2.1 parquet.
+
+    Args:
+        demo_path: Path to the parquet file (one episode).  Must contain
+            an ``action`` column with 23-D float vectors.
+        action_dim: Sanity-check value (default 23 = R1Pro).
+        on_overrun: What to do once the recorded trajectory ends.
+            ``"hold"`` — repeat the last recorded action indefinitely.
+            ``"zero"`` — return zero actions.
+            ``"raise"`` — raise an error.
+    """
+
+    def __init__(
+        self,
+        demo_path: str | None = None,
+        action_dim: int = R1PRO_ACTION_DIM,
+        on_overrun: str = "hold",
+        **kwargs: Any,
+    ) -> None:
+        kwargs.setdefault("chunk_size", 1)
+        kwargs.setdefault("action_ensemble", "newest")
+        super().__init__(**kwargs)
+        if not demo_path:
+            raise ValueError("demo_path is required (path to a LeRobot v2.1 parquet episode)")
+        if on_overrun not in ("hold", "zero", "raise"):
+            raise ValueError(f"on_overrun must be hold|zero|raise, got {on_overrun!r}")
+        self.demo_path = demo_path
+        self.action_dim = int(action_dim)
+        self.on_overrun = on_overrun
+
+        self._actions: np.ndarray | None = None
+        self._current_episode_id: str | None = None
+        self._step_idx: int = 0
+
+    def _load(self) -> np.ndarray:
+        if self._actions is not None:
+            return self._actions
+        import pandas as pd  # type: ignore[import-untyped]
+
+        # ``columns=["action"]`` skips embedded image/state columns —
+        # LeRobot parquets can be multi-GB once those load.
+        df = pd.read_parquet(self.demo_path, columns=["action"])
+        actions = np.stack([np.asarray(a, dtype=np.float32) for a in df["action"]])
+        if actions.ndim != 2 or actions.shape[1] != self.action_dim:
+            raise ValueError(f"Demo actions must be (T, {self.action_dim}); got {actions.shape}")
+        logger.info("Loaded %d-step demo from %s", actions.shape[0], self.demo_path)
+        self._actions = actions
+        return actions
+
+    def get_action_spec(self) -> dict[str, DimSpec]:
+        return {"joints": DimSpec("joints", self.action_dim, "joint_positions_r1pro")}
+
+    def get_observation_spec(self) -> dict[str, DimSpec]:
+        return {
+            "head": IMAGE_RGB,
+            "left_wrist": IMAGE_RGB,
+            "right_wrist": IMAGE_RGB,
+            "language": LANGUAGE,
+        }
+
+    def predict(self, obs: Observation, ctx: SessionContext | None = None) -> Action:
+        actions = self._load()
+        ep_id = str(getattr(ctx, "episode_id", "default") or "default") if ctx is not None else "default"
+        if ep_id != self._current_episode_id:
+            self._current_episode_id = ep_id
+            self._step_idx = 0
+        idx = self._step_idx
+        self._step_idx += 1
+
+        if idx < len(actions):
+            return {"actions": actions[idx].copy()}
+
+        if self.on_overrun == "hold":
+            return {"actions": actions[-1].copy()}
+        if self.on_overrun == "zero":
+            return {"actions": np.zeros(self.action_dim, dtype=np.float32)}
+        raise RuntimeError(f"Demo overrun: requested step {idx} but demo only has {len(actions)} steps")
+
+
+if __name__ == "__main__":
+    from vla_eval.model_servers.serve import run_server
+
+    run_server(Behavior1KDemoReplayModelServer)


### PR DESCRIPTION
## Summary

Adds the BEHAVIOR-1K (OmniGibson + NVIDIA Isaac Sim 4.5.0) benchmark, plus a zero-action baseline and a demo-replay model server used to verify env wiring against the released LeRobot v2.1 trajectories.

> **Stacked on #55** (`feat/rlbench-license-guard`). Merge that one first; this PR's diff against `main` will then be just the BEHAVIOR-1K integration.

### What's in here

**Benchmark module**
- `src/vla_eval/benchmarks/behavior1k/benchmark.py` — `Behavior1KBenchmark(StepBenchmark)`, R1Pro robot, 23-D action, RGB head + L/R wrist cameras. The async bridge is overridden so `reset` / `step` / `cleanup` run on a worker thread (Isaac Sim's `SimulationApp.__init__` calls `signal.signal`, which has to be monkey-patched while the worker thread is set up — `signal.signal` assumes the main thread).
- Lazy imports for OmniGibson (heavy startup, can't be at module level — registry resolves the class without loading the sim).
- `gm.HEADLESS=True` set before `og.launch` (required to avoid an XR-extension segfault on the cluster).

**Model servers**
- `behavior1k_baseline.py` — zero-action 23-D baseline. Smoke-test sanity check.
- `behavior1k_demo_replay.py` — plays back recorded actions from a LeRobot v2.1 parquet episode. Used to verify the dataloader / action-space wiring matches the released dataset.

**Docker**
- `Dockerfile.behavior1k` — installs Isaac Sim 4.5.0 from `pypi.nvidia.com` (26 `omni-*` / `isaacsim-*` wheels), `bddl3` + `OmniGibson[eval]` + `joylo` from BEHAVIOR-1K v3.7.2.
- Build is gated behind `ARG ACCEPT_NVIDIA_EULA=YES` (NVIDIA Omniverse EULA — https://docs.omniverse.nvidia.com/eula/). Surfaced via `docker/build.sh --accept-license behavior1k`, dispatched through the `EULA_GATED` map added in #55.
- Listed under `NO_REDIST` in `docker/push.sh`, so the image is build-locally-only.

**Configs / docs**
- `configs/behavior1k_eval.yaml` — `turning_on_radio`, task instance 1, max 2000 steps.
- `configs/model_servers/behavior1k/baseline.yaml` — zero-action server.
- `docs/reproductions/behavior1k.md` — full repro write-up. Result data archived under `docs/reproductions/data/`.

### Verification

```
# Demo replay (task = turning_on_radio, instance 1)
vla-eval run -c configs/behavior1k_eval.yaml \
            -m configs/model_servers/behavior1k/demo_replay.yaml
# → success=True, finished at step 1364/2000, wall 2933.8s

# Zero-action baseline
vla-eval run -c configs/behavior1k_eval.yaml \
            -m configs/model_servers/behavior1k/baseline.yaml
# → success=False at max_steps (expected)
```

The demo-replay success step (1364) falls inside the human-annotated press-skill window `[1162, 1434]` from the BEHAVIOR Dataset annotations, which gives reasonable confidence that the env wiring (action space, observation cameras, success detection) matches the upstream evaluation.

### Skill notes

`.claude/skills/add-benchmark` and `.claude/skills/add-model-server` gain a short note not to add `tests/test_<name>_benchmark.py` or `tests/test_<name>_server.py` with mocked sim / model libraries. `tests/` is for harness mechanics, not per-sim integration; mocked `omnigibson` / `sapien` / `mujoco` modules drift from upstream and miss the real bugs (import paths, action encoding, physics determinism). Verification is done via the smoke-test commands above.

## Checklist

- [x] I have read the relevant contributing guide ([CONTRIBUTING.md](https://github.com/allenai/vla-evaluation-harness/blob/main/CONTRIBUTING.md))

**Code changes:**
- [x] `make check` passes (ruff + ty)
- [x] `make test` passes (pytest) — 295 passed, 1 skipped
- [x] Smoke-tested affected configs (demo replay + baseline runs above)

Smoke test commands run:

```
make check
make test
docker/build.sh behavior1k --accept-license behavior1k
vla-eval run -c configs/behavior1k_eval.yaml -m configs/model_servers/behavior1k/baseline.yaml
vla-eval run -c configs/behavior1k_eval.yaml -m configs/model_servers/behavior1k/demo_replay.yaml
```