### PR TITLE
feat(simpler): add Google Robot VA config and variant kwargs plumbing

### DIFF
--- a/configs/simpler_google_robot_va_tasks.yaml
+++ b/configs/simpler_google_robot_va_tasks.yaml
@@ -1,0 +1,118 @@
+# SimplerEnv evaluation - Google Robot Variant Aggregation (VA) tasks.
+#
+# This config enumerates SimplerEnv's variant-level Google Robot VA tasks.
+# VA tests scene-variant generalization: different object orientations,
+# target placements, and drawer positions than the visual-matching configs.
+#
+# Leaderboard/reporting should aggregate these 12 entries into canonical
+# VA task scores:
+#   - pick_coke_can_va         (3 sub-variants: horizontal, vertical, standing)
+#   - move_near_va             (2 sub-variants: v0, v1)
+#   - open_close_drawer_va     (6 sub-variants: open/close x top/middle/bottom)
+#   - place_apple_in_drawer_va (1 entry, optional 4th sub-score only)
+#
+# The overall VA score is the 3-task average of pick_coke_can_va, move_near_va,
+# and open_close_drawer_va. place_apple_in_drawer_va is reported separately
+# as an optional sub-score when present.
+#
+# Task names come from simpler_env.ENVIRONMENT_MAP at the pinned commit.
+server:
+  url: "ws://localhost:8000"
+
+docker:
+  image: ghcr.io/allenai/vla-evaluation-harness/simpler:latest
+  env:
+    - "NVIDIA_DRIVER_CAPABILITIES=all"
+  volumes:
+    - "/usr/share/vulkan/icd.d:/usr/share/vulkan/icd.d:ro"
+
+output_dir: "./results"
+
+benchmarks:
+  # -- Pick Coke Can variants (3 entries) --------------------------------
+  - benchmark: "vla_eval.benchmarks.simpler.benchmark:SimplerEnvBenchmark"
+    subname: pick_horizontal_coke_can_va
+    mode: sync
+    episodes_per_task: 24
+    params:
+      task_name: "google_robot_pick_horizontal_coke_can"
+
+  - benchmark: "vla_eval.benchmarks.simpler.benchmark:SimplerEnvBenchmark"
+    subname: pick_vertical_coke_can_va
+    mode: sync
+    episodes_per_task: 24
+    params:
+      task_name: "google_robot_pick_vertical_coke_can"
+
+  - benchmark: "vla_eval.benchmarks.simpler.benchmark:SimplerEnvBenchmark"
+    subname: pick_standing_coke_can_va
+    mode: sync
+    episodes_per_task: 24
+    params:
+      task_name: "google_robot_pick_standing_coke_can"
+
+  # -- Move Near variants (2 entries) ------------------------------------
+  - benchmark: "vla_eval.benchmarks.simpler.benchmark:SimplerEnvBenchmark"
+    subname: move_near_v0_va
+    mode: sync
+    episodes_per_task: 24
+    params:
+      task_name: "google_robot_move_near_v0"
+
+  - benchmark: "vla_eval.benchmarks.simpler.benchmark:SimplerEnvBenchmark"
+    subname: move_near_v1_va
+    mode: sync
+    episodes_per_task: 24
+    params:
+      task_name: "google_robot_move_near_v1"
+
+  # -- Open/Close Drawer variants (6 entries) ----------------------------
+  - benchmark: "vla_eval.benchmarks.simpler.benchmark:SimplerEnvBenchmark"
+    subname: open_top_drawer_va
+    mode: sync
+    episodes_per_task: 24
+    params:
+      task_name: "google_robot_open_top_drawer"
+
+  - benchmark: "vla_eval.benchmarks.simpler.benchmark:SimplerEnvBenchmark"
+    subname: open_middle_drawer_va
+    mode: sync
+    episodes_per_task: 24
+    params:
+      task_name: "google_robot_open_middle_drawer"
+
+  - benchmark: "vla_eval.benchmarks.simpler.benchmark:SimplerEnvBenchmark"
+    subname: open_bottom_drawer_va
+    mode: sync
+    episodes_per_task: 24
+    params:
+      task_name: "google_robot_open_bottom_drawer"
+
+  - benchmark: "vla_eval.benchmarks.simpler.benchmark:SimplerEnvBenchmark"
+    subname: close_top_drawer_va
+    mode: sync
+    episodes_per_task: 24
+    params:
+      task_name: "google_robot_close_top_drawer"
+
+  - benchmark: "vla_eval.benchmarks.simpler.benchmark:SimplerEnvBenchmark"
+    subname: close_middle_drawer_va
+    mode: sync
+    episodes_per_task: 24
+    params:
+      task_name: "google_robot_close_middle_drawer"
+
+  - benchmark: "vla_eval.benchmarks.simpler.benchmark:SimplerEnvBenchmark"
+    subname: close_bottom_drawer_va
+    mode: sync
+    episodes_per_task: 24
+    params:
+      task_name: "google_robot_close_bottom_drawer"
+
+  # -- Place Apple in Drawer (4th task, sub-score only, 1 entry) ---------
+  - benchmark: "vla_eval.benchmarks.simpler.benchmark:SimplerEnvBenchmark"
+    subname: place_apple_in_closed_top_drawer_va
+    mode: sync
+    episodes_per_task: 24
+    params:
+      task_name: "google_robot_place_apple_in_closed_top_drawer"

--- a/src/vla_eval/benchmarks/simpler/benchmark.py
+++ b/src/vla_eval/benchmarks/simpler/benchmark.py
@@ -42,6 +42,9 @@ class SimplerEnvBenchmark(StepBenchmark):
         send_state: Include proprioceptive state (base_pose, tcp_pose,
             EE pose) in observations for models that need it.
         seed: Random seed for ``env.reset()``.
+        variant_kwargs: Extra kwargs forwarded to ``simpler_env.make()``.
+            Use for Variant Aggregation configs that need env-level
+            overrides (e.g. ``{"lr_switch": True}``).
     """
 
     def __init__(
@@ -54,6 +57,7 @@ class SimplerEnvBenchmark(StepBenchmark):
         deterministic_episodes: bool = True,
         control_mode: str | None = None,
         gripper_mode: str = "binary",
+        variant_kwargs: dict[str, Any] | None = None,
     ) -> None:
         super().__init__()
         assert success_mode in ("truncation", "early_stop", "accumulate"), (
@@ -68,6 +72,7 @@ class SimplerEnvBenchmark(StepBenchmark):
         self.deterministic_episodes = deterministic_episodes
         self.control_mode = control_mode
         self.gripper_mode = gripper_mode
+        self.variant_kwargs = variant_kwargs or {}
 
         self._env: Any = None
         self._task_description: str = ""
@@ -109,6 +114,7 @@ class SimplerEnvBenchmark(StepBenchmark):
             make_kwargs["control_mode"] = self.control_mode
         if self.max_episode_steps is not None:
             make_kwargs["max_episode_steps"] = self.max_episode_steps
+        make_kwargs.update(self.variant_kwargs)
         self._env = simpler_env.make(self.task_name, **make_kwargs)
 
         # Reset — robot init is handled by prepackaged_config internally.
@@ -238,11 +244,14 @@ class SimplerEnvBenchmark(StepBenchmark):
         return {"success": step_result.done}
 
     def get_metadata(self) -> dict[str, Any]:
-        return {
+        meta: dict[str, Any] = {
             "task_name": self.task_name,
             "success_mode": self.success_mode,
             "max_steps": self.max_episode_steps,
         }
+        if self.variant_kwargs:
+            meta["variant_kwargs"] = self.variant_kwargs
+        return meta
 
     def get_action_spec(self) -> dict[str, DimSpec]:
         return {

--- a/tests/test_simpler_variants.py
+++ b/tests/test_simpler_variants.py
@@ -1,0 +1,238 @@
+"""Tests for SimplerEnvBenchmark variant_kwargs plumbing.
+
+Validates that ``variant_kwargs`` are stored, surfaced in metadata, and
+forwarded into ``simpler_env.make()`` on ``reset()`` -- all without
+importing the real SimplerEnv package.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from vla_eval.cli.config_loader import load_config
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+# -- Fake simpler_env module ------------------------------------------
+
+
+class _FakeGymEnv:
+    """Minimal stand-in for a ManiSkill env used in reset/step."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        self._make_kwargs = kwargs
+        self._closed = False
+
+    # Gymnasium wrapper interface
+    @property
+    def unwrapped(self) -> _FakeGymEnv:
+        return self
+
+    def get_wrapper_attr(self, name: str) -> Any:
+        return getattr(self, name)
+
+    def reset(self, **kwargs: Any) -> tuple[dict, dict]:
+        obs = {"agent": {"base_pose": np.zeros(7), "qpos": np.zeros(8)}, "extra": {"tcp_pose": np.zeros(7)}}
+        return obs, {}
+
+    def step(self, action: Any) -> tuple[dict, float, bool, bool, dict]:
+        return {}, 0.0, False, False, {}
+
+    def close(self) -> None:
+        self._closed = True
+
+    def get_language_instruction(self) -> str:
+        return "test task"
+
+
+def _fake_make(task_name: str, **kwargs: Any) -> _FakeGymEnv:
+    return _FakeGymEnv(task_name=task_name, **kwargs)
+
+
+@pytest.fixture()
+def fake_simpler_env(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
+    """Inject a fake ``simpler_env`` module into ``sys.modules``."""
+    mod = types.ModuleType("simpler_env")
+    setattr(mod, "make", _fake_make)
+    monkeypatch.setitem(sys.modules, "simpler_env", mod)
+    return mod
+
+
+# -- Unit tests (no env needed) --------------------------------------
+
+
+def test_variant_kwargs_default_is_empty():
+    from vla_eval.benchmarks.simpler.benchmark import SimplerEnvBenchmark
+
+    bench = SimplerEnvBenchmark(task_name="widowx_stack_cube")
+    assert bench.variant_kwargs == {}
+
+
+def test_variant_kwargs_stored():
+    from vla_eval.benchmarks.simpler.benchmark import SimplerEnvBenchmark
+
+    vk = {"lr_switch": True}
+    bench = SimplerEnvBenchmark(task_name="google_robot_pick_coke_can", variant_kwargs=vk)
+    assert bench.variant_kwargs == {"lr_switch": True}
+
+
+def test_variant_kwargs_none_gives_empty():
+    from vla_eval.benchmarks.simpler.benchmark import SimplerEnvBenchmark
+
+    bench = SimplerEnvBenchmark(task_name="widowx_stack_cube", variant_kwargs=None)
+    assert bench.variant_kwargs == {}
+
+
+def test_variant_kwargs_in_metadata_when_present():
+    from vla_eval.benchmarks.simpler.benchmark import SimplerEnvBenchmark
+
+    bench = SimplerEnvBenchmark(task_name="widowx_stack_cube")
+    assert "variant_kwargs" not in bench.get_metadata()
+
+    bench_va = SimplerEnvBenchmark(task_name="google_robot_pick_coke_can", variant_kwargs={"lr_switch": True})
+    meta = bench_va.get_metadata()
+    assert meta["variant_kwargs"] == {"lr_switch": True}
+
+
+def test_variant_kwargs_accepts_model_ids():
+    from vla_eval.benchmarks.simpler.benchmark import SimplerEnvBenchmark
+
+    vk = {"model_ids": "baked_apple_v2"}
+    bench = SimplerEnvBenchmark(task_name="google_robot_place_in_closed_top_drawer", variant_kwargs=vk)
+    assert bench.variant_kwargs["model_ids"] == "baked_apple_v2"
+
+
+# -- reset() forwards variant_kwargs to simpler_env.make() -----------
+
+
+def test_reset_forwards_variant_kwargs(fake_simpler_env: types.ModuleType):
+    """reset() must merge variant_kwargs into the make() call."""
+    from vla_eval.benchmarks.simpler.benchmark import SimplerEnvBenchmark
+
+    bench = SimplerEnvBenchmark(
+        task_name="google_robot_pick_coke_can",
+        variant_kwargs={"lr_switch": True, "obj_name": "coke_can"},
+    )
+    task: dict[str, Any] = {"name": "google_robot_pick_coke_can", "task_name": "google_robot_pick_coke_can"}
+    bench.reset(task)
+
+    assert bench._env is not None
+    assert bench._env._make_kwargs["task_name"] == "google_robot_pick_coke_can"
+    assert bench._env._make_kwargs["lr_switch"] is True
+    assert bench._env._make_kwargs["obj_name"] == "coke_can"
+
+
+def test_reset_merges_control_mode_with_variant_kwargs(fake_simpler_env: types.ModuleType):
+    """control_mode and variant_kwargs must both appear in make() kwargs."""
+    from vla_eval.benchmarks.simpler.benchmark import SimplerEnvBenchmark
+
+    bench = SimplerEnvBenchmark(
+        task_name="widowx_stack_cube",
+        control_mode="pd_ee_delta_pose",
+        variant_kwargs={"extra_key": 42},
+    )
+    task: dict[str, Any] = {"name": "widowx_stack_cube", "task_name": "widowx_stack_cube"}
+    bench.reset(task)
+
+    assert bench._env._make_kwargs["control_mode"] == "pd_ee_delta_pose"
+    assert bench._env._make_kwargs["extra_key"] == 42
+
+
+def test_reset_empty_variant_kwargs_omits_extra_keys(fake_simpler_env: types.ModuleType):
+    """With no variant_kwargs, make() receives only control_mode/max_episode_steps."""
+    from vla_eval.benchmarks.simpler.benchmark import SimplerEnvBenchmark
+
+    bench = SimplerEnvBenchmark(task_name="widowx_stack_cube")
+    task: dict[str, Any] = {"name": "widowx_stack_cube", "task_name": "widowx_stack_cube"}
+    bench.reset(task)
+
+    make_kw = bench._env._make_kwargs
+    assert "task_name" in make_kw
+    assert "lr_switch" not in make_kw
+    assert "model_ids" not in make_kw
+
+
+def test_reset_closes_previous_env(fake_simpler_env: types.ModuleType):
+    """Calling reset() twice must close the first env before creating a new one."""
+    from vla_eval.benchmarks.simpler.benchmark import SimplerEnvBenchmark
+
+    bench = SimplerEnvBenchmark(task_name="widowx_stack_cube")
+    task: dict[str, Any] = {"name": "widowx_stack_cube", "task_name": "widowx_stack_cube"}
+
+    bench.reset(task)
+    first_env = bench._env
+    assert first_env is not None
+
+    bench.reset(task)
+    assert first_env._closed is True
+    assert bench._env is not first_env
+
+
+# -- Config-level tests ----------------------------------------------
+
+
+def test_va_config_loads_and_has_benchmarks():
+    config_path = REPO_ROOT / "configs" / "simpler_google_robot_va_tasks.yaml"
+    assert config_path.exists(), f"VA config not found: {config_path}"
+
+    data = load_config(str(config_path))
+    assert "benchmarks" in data
+    assert len(data["benchmarks"]) > 0
+
+
+def test_va_config_import_strings_well_formed():
+    config_path = REPO_ROOT / "configs" / "simpler_google_robot_va_tasks.yaml"
+    data = load_config(str(config_path))
+
+    for bench in data["benchmarks"]:
+        import_path = bench.get("benchmark", "")
+        assert ":" in import_path, f"Bad import string: {import_path!r}"
+        module, _, cls_name = import_path.partition(":")
+        assert module
+        assert cls_name
+
+
+def test_va_config_uses_variant_task_names():
+    config_path = REPO_ROOT / "configs" / "simpler_google_robot_va_tasks.yaml"
+    data = load_config(str(config_path))
+
+    task_names = {b["params"]["task_name"] for b in data["benchmarks"]}
+
+    expected = {
+        # pick_coke_can_va (3)
+        "google_robot_pick_horizontal_coke_can",
+        "google_robot_pick_vertical_coke_can",
+        "google_robot_pick_standing_coke_can",
+        # move_near_va (2)
+        "google_robot_move_near_v0",
+        "google_robot_move_near_v1",
+        # open_close_drawer_va (6)
+        "google_robot_open_top_drawer",
+        "google_robot_open_middle_drawer",
+        "google_robot_open_bottom_drawer",
+        "google_robot_close_top_drawer",
+        "google_robot_close_middle_drawer",
+        "google_robot_close_bottom_drawer",
+        # place_apple_in_drawer_va (1, optional sub-score)
+        "google_robot_place_apple_in_closed_top_drawer",
+    }
+    assert task_names == expected, (
+        f"Unexpected task names: extra={task_names - expected}, missing={expected - task_names}"
+    )
+    assert len(task_names) == 12
+
+
+def test_va_config_subnames_end_with_va():
+    config_path = REPO_ROOT / "configs" / "simpler_google_robot_va_tasks.yaml"
+    data = load_config(str(config_path))
+
+    for bench in data["benchmarks"]:
+        subname = bench.get("subname", "")
+        assert subname.endswith("_va"), f"Subname {subname!r} should end with _va"


### PR DESCRIPTION
## Summary

Adds a first-pass Google Robot Variant Aggregation (VA) path for SimplerEnv.

`SimplerEnvBenchmark` already handles the visual-matching setup through `simpler_env.make(task_name, ...)`, but there was no way for benchmark configs to pass task-specific environment kwargs through the wrapper. This adds an optional `variant_kwargs` passthrough and a Google Robot VA config built from the task names exposed by the pinned SimplerEnv commit.

Addresses #49.

### What's in here

**`src/vla_eval/benchmarks/simpler/benchmark.py`**

Adds `variant_kwargs: dict[str, Any] | None` to `SimplerEnvBenchmark`.

The kwargs are merged into the `simpler_env.make()` call in `reset()`, alongside the existing `control_mode` and `max_episode_steps` overrides. They are also included in `get_metadata()` when non-empty, so existing configs keep unchanged metadata.

**`configs/simpler_google_robot_va_tasks.yaml`**

Adds a Google Robot VA config with 12 valid SimplerEnv task names from the pinned `ENVIRONMENT_MAP`:

- 3 pick-coke-can variants
- 2 move-near variants
- 6 open/close-drawer variants
- 1 optional place-apple-in-drawer sub-score

The header documents how these variant-level entries map back to the canonical reporting buckets: `pick_coke_can_va`, `move_near_va`, `open_close_drawer_va`, and optional `place_apple_in_drawer_va`.

**`tests/test_simpler_variants.py`**

Adds lightweight harness-level coverage without importing the real SimplerEnv package:

- constructor/default behavior for `variant_kwargs`
- `reset()` forwarding via a fake `simpler_env` module
- metadata behavior
- YAML loading through the harness config loader
- exact expected 12-task VA set
- `_va` subname suffix check

### Verification

```text
uv run --python D:\Dev\conda-envs\py313\python.exe pytest tests/test_simpler_variants.py -v
# 13 passed

uv run --python D:\Dev\conda-envs\py313\python.exe ruff check src/vla_eval/benchmarks/simpler/benchmark.py tests/test_simpler_variants.py
# All checks passed

uv run --python D:\Dev\conda-envs\py313\python.exe ruff format --check src/vla_eval/benchmarks/simpler/benchmark.py tests/test_simpler_variants.py
# 2 files already formatted

uv run --python D:\Dev\conda-envs\py313\python.exe ty check src/vla_eval/benchmarks/simpler/benchmark.py
# All checks passed

$env:PYTHONUTF8='1'; $env:HOME=$env:USERPROFILE; uv run --python D:\Dev\conda-envs\py313\python.exe vla-eval test --validate
# 75/75 configs valid

git diff --check
# clean
```

I did not run a full SimplerEnv Docker/simulation rollout. The validation here is intentionally lightweight: it checks the harness wiring and config structure without model downloads or GPU rendering. The VA task names were cross-checked against `simpler_env.ENVIRONMENT_MAP` at the pinned SimplerEnv commit used by `docker/Dockerfile.simpler`.

## Checklist

- [x] I have read the relevant contributing guide ([CONTRIBUTING.md](https://github.com/allenai/vla-evaluation-harness/blob/main/CONTRIBUTING.md))

**Code changes:**

- [x] Targeted pytest passes
- [x] Targeted ruff check passes
- [x] Touched Python files are formatted
- [x] Touched benchmark passes `ty check`
- [x] Config validation passes
- [x] `git diff --check` clean
- [ ] Full SimplerEnv Docker/simulation smoke test not run