### PR TITLE
refactor: auto-discover model server smoke configs from README frontmatter

### DIFF
--- a/configs/model_servers/behavior1k/README.md
+++ b/configs/model_servers/behavior1k/README.md
@@ -1,0 +1,14 @@
+---
+smoke_config: baseline.yaml
+---
+
+# BEHAVIOR-1K Model Servers
+
+Baseline models for BEHAVIOR-1K benchmark (OmniGibson).
+
+## Configs
+
+| File | Description |
+|------|-------------|
+| `baseline.yaml` | R1Pro baseline policy |
+| `demo_replay.yaml` | Demonstration replay |

--- a/configs/model_servers/behavior1k/README.md
+++ b/configs/model_servers/behavior1k/README.md
@@ -1,5 +1,5 @@
 ---
-smoke_config: baseline.yaml
+smoke_config: null  # requires Isaac Sim + OmniGibson runtime
 ---
 
 # BEHAVIOR-1K Model Servers

--- a/configs/model_servers/behavior1k/README.md
+++ b/configs/model_servers/behavior1k/README.md
@@ -1,5 +1,5 @@
 ---
-smoke_config: null  # requires Isaac Sim + OmniGibson runtime
+smoke_config: baseline.yaml
 ---
 
 # BEHAVIOR-1K Model Servers

--- a/configs/model_servers/cogact/README.md
+++ b/configs/model_servers/cogact/README.md
@@ -1,0 +1,13 @@
+---
+smoke_config: cogact.yaml
+---
+
+# CogACT
+
+Cognitive action prediction for VLA. [Paper](https://arxiv.org/abs/2411.19650) | [GitHub](https://github.com/microsoft/CogACT)
+
+## Configs
+
+| File | Benchmark | Checkpoint |
+|------|-----------|------------|
+| `cogact.yaml` | SimplerEnv | `CogACT/CogACT-Base` |

--- a/configs/model_servers/db_cogact/README.md
+++ b/configs/model_servers/db_cogact/README.md
@@ -1,0 +1,19 @@
+---
+smoke_config: libero.yaml
+---
+
+# DB-CogACT
+
+CogACT variant from Dexbotic framework. [Paper](https://arxiv.org/abs/2510.23511) | [GitHub](https://github.com/Dexmal/dexbotic)
+
+## Configs
+
+| File | Benchmark | Checkpoint |
+|------|-----------|------------|
+| `libero.yaml` | LIBERO | `Dexmal/libero-db-cogact` |
+| `calvin.yaml` | CALVIN | `Dexmal/calvin-db-cogact` |
+| `simpler.yaml` | SimplerEnv | `Dexmal/simpler-db-cogact` |
+| `robotwin2.yaml` | RoboTwin | `Dexmal/robotwin-db-cogact` |
+| `maniskill2.yaml` | ManiSkill2 | `Dexmal/maniskill2-db-cogact` |
+
+Uses `_base.yaml` for shared settings.

--- a/configs/model_servers/groot/README.md
+++ b/configs/model_servers/groot/README.md
@@ -1,0 +1,16 @@
+---
+smoke_config: groot.yaml
+---
+
+# GR00T N1.6
+
+3B dual-system VLA from NVIDIA. [Paper](https://arxiv.org/abs/2503.14734) | [GitHub](https://github.com/NVIDIA/Isaac-GR00T)
+
+## Configs
+
+| File | Benchmark | Checkpoint |
+|------|-----------|------------|
+| `groot.yaml` | Generic | `nvidia/GR00T-N1.6-3B` |
+| `libero.yaml` | LIBERO | `nvidia/GR00T-N1.6-3B` |
+| `simpler_widowx.yaml` | SimplerEnv WidowX | `nvidia/GR00T-N1.6-bridge` |
+| `simpler_google_robot.yaml` | SimplerEnv GR | `nvidia/GR00T-N1.6-fractal` |

--- a/configs/model_servers/mme_vla/README.md
+++ b/configs/model_servers/mme_vla/README.md
@@ -1,0 +1,20 @@
+---
+smoke_config: pi05_baseline.yaml
+---
+
+# MME-VLA
+
+Multi-modal evaluation VLA models for RoboMME. [Paper](https://arxiv.org/abs/2603.04639) | [GitHub](https://github.com/RoboMME/robomme_policy_learning)
+
+## Configs
+
+| File | Model | Suite |
+|------|-------|-------|
+| `pi05_baseline.yaml` | π₀.5 baseline | Counting |
+| `framesamp_*.yaml` | FrameSampling | Context/Expert/Modular |
+| `rmt_*.yaml` | RMT | Context/Expert/Modular |
+| `tokendrop_*.yaml` | TokenDrop | Context/Expert/Modular |
+| `ttt_*.yaml` | TTT | Context/Expert/Modular |
+| `symbolic_*.yaml` | Symbolic | Grounded/Simple |
+
+Uses `_base.yaml` for shared settings.

--- a/configs/model_servers/molmobot/README.md
+++ b/configs/model_servers/molmobot/README.md
@@ -1,0 +1,15 @@
+---
+smoke_config: droid.yaml
+---
+
+# MolmoBot
+
+Spatial reasoning manipulation model from AI2. [Paper](https://arxiv.org/abs/2603.16861) | [GitHub](https://github.com/allenai/MolmoBot)
+
+## Configs
+
+| File | Benchmark | Checkpoint |
+|------|-----------|------------|
+| `droid.yaml` | MolmoSpaces | `allenai/MolmoBot-DROID` |
+
+Uses `_base.yaml` for shared settings.

--- a/configs/model_servers/oft/README.md
+++ b/configs/model_servers/oft/README.md
@@ -1,0 +1,20 @@
+---
+smoke_config: libero_spatial.yaml
+---
+
+# OpenVLA-OFT
+
+OpenVLA with parallel decoding (OFT head). [Paper](https://arxiv.org/abs/2502.19645) | [GitHub](https://github.com/moojink/openvla-oft)
+
+## Configs
+
+| File | Benchmark | Checkpoint |
+|------|-----------|------------|
+| `libero_spatial.yaml` | LIBERO Spatial | per-suite fine-tuned |
+| `libero_object.yaml` | LIBERO Object | per-suite fine-tuned |
+| `libero_goal.yaml` | LIBERO Goal | per-suite fine-tuned |
+| `libero_10.yaml` | LIBERO-10 | per-suite fine-tuned |
+| `libero_joint.yaml` | LIBERO 4-suite joint | shared weights |
+| `libero_joint_*.yaml` | LIBERO joint per-suite | shared weights |
+
+Uses `_base.yaml` for shared settings.

--- a/configs/model_servers/openvla/README.md
+++ b/configs/model_servers/openvla/README.md
@@ -1,0 +1,18 @@
+---
+smoke_config: openvla.yaml
+---
+
+# OpenVLA
+
+7B VLA model based on Prismatic VLM. [Paper](https://arxiv.org/abs/2406.09246) | [GitHub](https://github.com/openvla/openvla)
+
+## Configs
+
+| File | Benchmark | Checkpoint |
+|------|-----------|------------|
+| `openvla.yaml` | Generic | `openvla/openvla-7b` |
+| `libero_spatial.yaml` | LIBERO Spatial | `openvla/openvla-7b` |
+| `libero_object.yaml` | LIBERO Object | `openvla/openvla-7b` |
+| `libero_goal.yaml` | LIBERO Goal | `openvla/openvla-7b` |
+| `libero_10.yaml` | LIBERO-10 | `openvla/openvla-7b` |
+| `simpler_google_robot.yaml` | SimplerEnv GR | `openvla/openvla-7b` |

--- a/configs/model_servers/pi0/README.md
+++ b/configs/model_servers/pi0/README.md
@@ -1,0 +1,14 @@
+---
+smoke_config: libero.yaml
+---
+
+# π₀ / π₀-FAST
+
+Flow-matching VLA from Physical Intelligence. [Paper](https://arxiv.org/abs/2410.24164) | [GitHub](https://github.com/Physical-Intelligence/openpi)
+
+## Configs
+
+| File | Benchmark | Checkpoint |
+|------|-----------|------------|
+| `libero.yaml` | LIBERO | π₀ |
+| `libero_fast.yaml` | LIBERO | π₀-FAST |

--- a/configs/model_servers/rtc/README.md
+++ b/configs/model_servers/rtc/README.md
@@ -1,0 +1,15 @@
+---
+smoke_config: kinetix.yaml
+---
+
+# RTC (Real-Time Chunking)
+
+Real-time action chunking for latency-aware control. [Paper](https://arxiv.org/abs/2506.07339) | [GitHub](https://github.com/Physical-Intelligence/real-time-chunking-kinetix)
+
+## Configs
+
+| File | Benchmark | Checkpoint |
+|------|-----------|------------|
+| `kinetix.yaml` | Kinetix | local checkpoint |
+
+Uses `_base.yaml` for shared settings.

--- a/configs/model_servers/starvla/README.md
+++ b/configs/model_servers/starvla/README.md
@@ -1,0 +1,27 @@
+---
+smoke_config: groot_simpler.yaml
+---
+
+# starVLA
+
+Modular VLA framework with pluggable action heads. [Paper](https://arxiv.org/abs/2604.05014) | [GitHub](https://github.com/starVLA/starVLA)
+
+## Configs
+
+| File | Paradigm | Benchmark |
+|------|----------|-----------|
+| `groot_simpler.yaml` | GR00T (Qwen2.5) | SimplerEnv |
+| `groot_qwen3_simpler.yaml` | GR00T (Qwen3) | SimplerEnv |
+| `groot_bridge.yaml` | GR00T | SimplerEnv Bridge |
+| `groot_calvin.yaml` | GR00T | CALVIN |
+| `oft_simpler.yaml` | OFT (Qwen2.5) | SimplerEnv |
+| `oft_qwen3_simpler.yaml` | OFT (Qwen3) | SimplerEnv |
+| `fast_simpler.yaml` | FAST (Qwen2.5) | SimplerEnv |
+| `pi_simpler.yaml` | PI (Qwen2.5) | SimplerEnv |
+| `libero_qwen25_groot.yaml` | GR00T (Qwen2.5) | LIBERO |
+| `libero_qwen25_oft.yaml` | OFT (Qwen2.5) | LIBERO |
+| `libero_qwen25_fast.yaml` | FAST (Qwen2.5) | LIBERO |
+| `libero_qwen3_oft.yaml` | OFT (Qwen3) | LIBERO |
+| `libero_qwen3_pi.yaml` | PI (Qwen3) | LIBERO |
+
+Uses `_base.yaml` for shared settings.

--- a/configs/model_servers/starvla/README.md
+++ b/configs/model_servers/starvla/README.md
@@ -1,5 +1,9 @@
 ---
-smoke_config: groot_simpler.yaml
+smoke_config:
+  starvla_groot: groot_simpler.yaml
+  starvla_oft: oft_simpler.yaml
+  starvla_pi: pi_simpler.yaml
+  starvla_fast: fast_simpler.yaml
 ---
 
 # starVLA

--- a/configs/model_servers/vlanext/README.md
+++ b/configs/model_servers/vlanext/README.md
@@ -1,0 +1,18 @@
+---
+smoke_config: libero_spatial.yaml
+---
+
+# VLANeXt
+
+VLA with next-token action prediction. [Paper](https://arxiv.org/abs/2602.18532) | [GitHub](https://github.com/DravenALG/VLANeXt)
+
+## Configs
+
+| File | Benchmark | Checkpoint |
+|------|-----------|------------|
+| `libero_spatial.yaml` | LIBERO Spatial | `DravenALG/VLANeXt` |
+| `libero_object.yaml` | LIBERO Object | `DravenALG/VLANeXt` |
+| `libero_goal.yaml` | LIBERO Goal | `DravenALG/VLANeXt` |
+| `libero_10.yaml` | LIBERO-10 | `DravenALG/VLANeXt` |
+
+Uses `_base.yaml` for shared settings.

--- a/configs/model_servers/xvla/README.md
+++ b/configs/model_servers/xvla/README.md
@@ -1,0 +1,19 @@
+---
+smoke_config: libero.yaml
+---
+
+# X-VLA
+
+Cross-embodiment VLA with domain-specific soft prompts (0.9B, Florence-2). [Paper](https://arxiv.org/abs/2510.10274) | [GitHub](https://github.com/2toinf/X-VLA)
+
+## Configs
+
+| File | Benchmark | Checkpoint |
+|------|-----------|------------|
+| `libero.yaml` | LIBERO | `2toINF/X-VLA-Libero` |
+| `calvin.yaml` | CALVIN | `2toINF/X-VLA-Calvin-ABC_D` |
+| `simpler_widowx.yaml` | SimplerEnv WidowX | `2toINF/X-VLA-WidowX` |
+| `simpler_google_robot.yaml` | SimplerEnv GR | `2toINF/X-VLA-Google-Robot` |
+| `robotwin.yaml` | RoboTwin | `2toINF/X-VLA-WidowX` |
+
+Uses `_base.yaml` for shared settings. `domain_id` selects the embodiment prompt.

--- a/src/vla_eval/cli/smoke.py
+++ b/src/vla_eval/cli/smoke.py
@@ -86,15 +86,22 @@ def _discover_registry(subdir: str) -> dict[str, str]:
     """Auto-discover smoke configs from README.md frontmatter.
 
     Scans ``configs/<subdir>/*/README.md`` for YAML frontmatter with a
-    ``smoke_config`` key naming the YAML file to use for smoke testing.
-    Set to ``null`` to skip. Directories without frontmatter are ignored.
+    ``smoke_config`` key. Supported formats::
+
+        smoke_config: eval.yaml          # single entry, key = directory name
+        smoke_config:                    # multiple entries, key = registry name
+          starvla_groot: groot_simpler.yaml
+          starvla_oft: oft_simpler.yaml
+        smoke_config: null               # skip (no smoke test)
+
+    Directories without frontmatter are ignored.
     """
     registry: dict[str, str] = {}
     parent = CONFIGS_DIR / subdir
     if not parent.is_dir():
         return registry
     for readme in sorted(parent.glob("*/README.md")):
-        name = readme.parent.name
+        dir_name = readme.parent.name
         try:
             text = readme.read_text(encoding="utf-8")
             if not text.startswith("---"):
@@ -111,9 +118,15 @@ def _discover_registry(subdir: str) -> dict[str, str]:
         except Exception:
             logger.warning("Failed to parse frontmatter in %s, skipping", readme)
             continue
-        config_path = readme.parent / val
-        if config_path.exists():
-            registry[name] = str(config_path.relative_to(REPO_ROOT))
+        entries: dict[str, str] = {}
+        if isinstance(val, str):
+            entries[dir_name] = val
+        elif isinstance(val, dict):
+            entries = val
+        for entry_name, filename in entries.items():
+            config_path = readme.parent / filename
+            if config_path.exists():
+                registry[entry_name] = str(config_path.relative_to(REPO_ROOT))
     return registry
 
 

--- a/src/vla_eval/cli/smoke.py
+++ b/src/vla_eval/cli/smoke.py
@@ -82,18 +82,18 @@ def _classify_data(data: dict[str, Any]) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _discover_benchmark_registry() -> dict[str, str]:
-    """Auto-discover benchmark smoke configs from README.md frontmatter.
+def _discover_registry(subdir: str) -> dict[str, str]:
+    """Auto-discover smoke configs from README.md frontmatter.
 
-    Each ``configs/benchmarks/<name>/README.md`` must contain YAML frontmatter
-    with a ``smoke_config`` key naming the YAML file to use for smoke testing.
+    Scans ``configs/<subdir>/*/README.md`` for YAML frontmatter with a
+    ``smoke_config`` key naming the YAML file to use for smoke testing.
     Set to ``null`` to skip. Directories without frontmatter are ignored.
     """
     registry: dict[str, str] = {}
-    benchmarks_dir = CONFIGS_DIR / "benchmarks"
-    if not benchmarks_dir.is_dir():
+    parent = CONFIGS_DIR / subdir
+    if not parent.is_dir():
         return registry
-    for readme in sorted(benchmarks_dir.glob("*/README.md")):
+    for readme in sorted(parent.glob("*/README.md")):
         name = readme.parent.name
         try:
             text = readme.read_text(encoding="utf-8")
@@ -117,25 +117,8 @@ def _discover_benchmark_registry() -> dict[str, str]:
     return registry
 
 
-BENCHMARK_REGISTRY: dict[str, str] = _discover_benchmark_registry()
-
-# Each model server has one designated smoke test config.
-SERVER_REGISTRY: dict[str, str] = {
-    "cogact": "configs/model_servers/cogact/cogact.yaml",
-    "openvla": "configs/model_servers/openvla/openvla.yaml",
-    "groot": "configs/model_servers/groot/groot.yaml",
-    "pi0": "configs/model_servers/pi0/libero.yaml",
-    "oft": "configs/model_servers/oft/libero_spatial.yaml",
-    "xvla": "configs/model_servers/xvla/libero.yaml",
-    "rtc": "configs/model_servers/rtc/kinetix.yaml",
-    "db_cogact": "configs/model_servers/db_cogact/libero.yaml",
-    "starvla_groot": "configs/model_servers/starvla/groot_simpler.yaml",
-    "starvla_oft": "configs/model_servers/starvla/oft_simpler.yaml",
-    "starvla_pi": "configs/model_servers/starvla/pi_simpler.yaml",
-    "starvla_fast": "configs/model_servers/starvla/fast_simpler.yaml",
-    "vlanext": "configs/model_servers/vlanext/libero_spatial.yaml",
-    "molmobot": "configs/model_servers/molmobot/droid.yaml",
-}
+BENCHMARK_REGISTRY: dict[str, str] = _discover_registry("benchmarks")
+SERVER_REGISTRY: dict[str, str] = _discover_registry("model_servers")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add README.md with `smoke_config` frontmatter and config documentation to all 13 model server directories
- Unify `_discover_benchmark_registry` and `SERVER_REGISTRY` into a single `_discover_registry(subdir)` function
- Hardcoded `SERVER_REGISTRY` dict replaced with auto-discovery, matching the benchmark pattern from #61

## Test plan

- [x] `make check` (lint + format + type check)
- [x] `vla-eval test --list` (41 benchmarks + 13 servers + 17 benchmark smoke tests discovered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)