### PR TITLE
fix(docker): add pip/wheel deps, extract inline patches, support derived images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,5 @@
 !docker/*.patch
 
 !docker/apply_eef_pos_patch.py
+!docker/xvla_sink_camera.py
+!docker/xvla_google_robot_patch.py

--- a/docker/Dockerfile.behavior1k
+++ b/docker/Dockerfile.behavior1k
@@ -34,7 +34,7 @@ ENV OMNIGIBSON_HEADLESS=1 \
     PRIVACY_CONSENT=Y
 
 # ── Conda environment (Python 3.10 — required by Isaac Sim 4.5.0) ──
-RUN conda create -n behavior python=3.10 -y && conda clean -afy
+RUN conda create -n behavior python=3.10 pip -y && conda clean -afy
 SHELL ["conda", "run", "-n", "behavior", "/bin/bash", "-c"]
 
 # ── Pre-reqs the v3.7.2 setup.sh enforces before installing OmniGibson ─

--- a/docker/Dockerfile.calvin
+++ b/docker/Dockerfile.calvin
@@ -21,8 +21,8 @@ RUN git clone --recurse-submodules --depth 1 \
 # CALVIN has legacy deps (pyhash needs use_2to3 / multicoretsne needs old cmake).
 # Pin setuptools <=57 and use pip (not uv) with --no-build-isolation to avoid
 # uv's build-isolation injecting newer setuptools.
-RUN pip install --no-cache-dir "setuptools==57.5.0" \
-    && conda install -n calvin cmake=3.18 -y && conda clean -afy
+RUN conda install -n calvin cmake=3.18 -y && conda clean -afy
+RUN pip install --no-cache-dir "setuptools==57.5.0" wheel \
 RUN cd /app/calvin/calvin_env   && pip install --no-cache-dir --no-build-isolation -e . \
     && cd /app/calvin/calvin_models && pip install --no-cache-dir --no-build-isolation -e .
 

--- a/docker/Dockerfile.calvin
+++ b/docker/Dockerfile.calvin
@@ -22,8 +22,8 @@ RUN git clone --recurse-submodules --depth 1 \
 # Pin setuptools <=57 and use pip (not uv) with --no-build-isolation to avoid
 # uv's build-isolation injecting newer setuptools.
 RUN conda install -n calvin cmake=3.18 -y && conda clean -afy
-RUN pip install --no-cache-dir "setuptools==57.5.0" wheel
-RUN cd /app/calvin/calvin_env   && pip install --no-cache-dir --no-build-isolation -e . \
+RUN pip install --no-cache-dir "setuptools==57.5.0" wheel \
+    && cd /app/calvin/calvin_env   && pip install --no-cache-dir --no-build-isolation -e . \
     && cd /app/calvin/calvin_models && pip install --no-cache-dir --no-build-isolation -e .
 
 # Patch: catch pybullet.error on double-disconnect during GC teardown

--- a/docker/Dockerfile.calvin
+++ b/docker/Dockerfile.calvin
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Create Python 3.8 conda env via miniforge
-RUN conda create -y -n calvin python=3.8 && conda clean -afy
+RUN conda create -y -n calvin python=3.8 pip && conda clean -afy
 SHELL ["conda", "run", "-n", "calvin", "/bin/bash", "-c"]
 
 # Clone CALVIN with submodules (shallow)
@@ -22,7 +22,7 @@ RUN git clone --recurse-submodules --depth 1 \
 # Pin setuptools <=57 and use pip (not uv) with --no-build-isolation to avoid
 # uv's build-isolation injecting newer setuptools.
 RUN conda install -n calvin cmake=3.18 -y && conda clean -afy
-RUN pip install --no-cache-dir "setuptools==57.5.0" wheel \
+RUN pip install --no-cache-dir "setuptools==57.5.0" wheel
 RUN cd /app/calvin/calvin_env   && pip install --no-cache-dir --no-build-isolation -e . \
     && cd /app/calvin/calvin_models && pip install --no-cache-dir --no-build-isolation -e .
 

--- a/docker/Dockerfile.mikasa_robo
+++ b/docker/Dockerfile.mikasa_robo
@@ -21,7 +21,7 @@ RUN uv pip install --no-cache-dir --prerelease=allow mani_skill==3.0.0b15 gymnas
 # Clone and install MIKASA-Robo
 # MIKASA-Robo's setup.py imports pkg_resources, which was removed from
 # setuptools >=70 on conda-forge. Pin setuptools <70 to restore it.
-RUN uv pip install --no-cache-dir "setuptools<70" \
+RUN uv pip install --no-cache-dir "setuptools<70" wheel \
     && git clone --depth 1 https://github.com/CognitiveAISystems/MIKASA-Robo.git /opt/MIKASA-Robo \
     && cd /opt/MIKASA-Robo \
     && uv pip install --no-cache-dir --no-build-isolation . \

--- a/docker/Dockerfile.robotwin
+++ b/docker/Dockerfile.robotwin
@@ -59,7 +59,8 @@ RUN git clone --depth 1 https://github.com/RoboTwin-Platform/RoboTwin.git /app/R
 # ── Install CuRobo (motion planner, built from source) ──────────────
 # No GPU visible during build → must specify arch explicitly.
 ENV TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;8.9;9.0+PTX"
-RUN cd /app/RoboTwin/envs \
+RUN uv pip install --no-cache-dir wheel \
+    && cd /app/RoboTwin/envs \
     && git clone --depth 1 https://github.com/NVlabs/curobo.git \
     && cd curobo \
     && uv pip install --no-cache-dir --no-build-isolation . \

--- a/docker/Dockerfile.simpler_xvla
+++ b/docker/Dockerfile.simpler_xvla
@@ -17,55 +17,13 @@ RUN cd /app/ManiSkill2_real2sim \
 
 # 2. Align sink camera + robot init with Bridge dataset (eggplant task).
 #    X-VLA was trained on BridgeData which uses a specific camera viewpoint.
-RUN cd /app/ManiSkill2_real2sim && python3 -c "\
-import pathlib; \
-p = pathlib.Path('mani_skill2_real2sim/agents/configs/widowx/defaults.py'); \
-s = p.read_text(); \
-# Replace sink camera position/rotation with Bridge dataset camera \
-s = s.replace(\"p=[-0.00300001, -0.21, 0.39]\", \"p=[0.00, -0.16, 0.336]\"); \
-s = s.replace(\"q=[-0.907313, 0.0782, -0.36434, -0.194741]\", \"q=[0.909182, -0.0819809, 0.347277, 0.214629]\"); \
-# Remove fov/near/far (use intrinsic instead) \
-s = s.replace(\"                fov=1.5,  # ignored if intrinsic is passed\\n\", \"\"); \
-s = s.replace(\"                near=0.01,\\n\", \"\"); \
-s = s.replace(\"                far=10,\\n\", \"\"); \
-p.write_text(s); \
-print('Patched sink camera config'); \
-# Also align sink robot init with standard widowx \
-p2 = pathlib.Path('mani_skill2_real2sim/envs/custom_scenes/base_env.py'); \
-s2 = p2.read_text(); \
-s2 = s2.replace(\"qpos = np.array([-0.2600599, -0.12875618, 0.04461369, -0.00652761, 1.7033415, -0.26983038, 0.037,\\n                                 0.037])\", \
-                \"qpos = np.array([-0.01840777,  0.0398835,   0.22242722,  -0.00460194,  1.36524296,  0.00153398, 0.037, 0.037])\"); \
-s2 = s2.replace(\"robot_init_height = 0.85\", \"robot_init_height = 0.870\"); \
-s2 = s2.replace(\"init_y = 0.070\", \"init_y = 0.028\"); \
-p2.write_text(s2); \
-print('Patched sink robot init');"
+COPY docker/xvla_sink_camera.py /tmp/
+RUN cd /app/ManiSkill2_real2sim && python3 /tmp/xvla_sink_camera.py && rm /tmp/xvla_sink_camera.py
 
 # 3. Add absolute EE controller to Google Robot config (same pattern as WidowX).
 #    X-VLA Google Robot eval requires base_pose (use_delta=False) with planner.
-RUN cd /app/ManiSkill2_real2sim && python3 -c "\
-import pathlib; \
-p = pathlib.Path('mani_skill2_real2sim/agents/configs/google_robot/defaults.py'); \
-s = p.read_text(); \
-# Add base_pose controller definition after target_delta_pose_align_interpolate_by_planner \
-old = '        _C[\"arm\"] = dict('; \
-new_ctrl = '''        arm_pd_ee_base_pose_align_interpolate_by_planner = PDEEPoseControllerConfig(\n\
-            *arm_common_args,\n\
-            frame=\"base\",\n\
-            interpolate=True,\n\
-            use_delta=False,\n\
-            interpolate_by_planner=True,\n\
-            interpolate_planner_vlim=self.arm_vel_limit,\n\
-            interpolate_planner_alim=self.arm_acc_limit,\n\
-            interpolate_planner_jerklim=self.arm_jerk_limit,\n\
-            **arm_common_kwargs,\n\
-        )\n        _C[\"arm\"] = dict('; \
-s = s.replace(old, new_ctrl); \
-# Register in arm_controllers dict \
-s = s.replace(\
-    'arm_pd_ee_target_delta_pose_align_interpolate_by_planner=arm_pd_ee_target_delta_pose_align_interpolate_by_planner,', \
-    'arm_pd_ee_target_delta_pose_align_interpolate_by_planner=arm_pd_ee_target_delta_pose_align_interpolate_by_planner,\n            arm_pd_ee_base_pose_align_interpolate_by_planner=arm_pd_ee_base_pose_align_interpolate_by_planner,'); \
-p.write_text(s); \
-print('Patched Google Robot base_pose controller');"
+COPY docker/xvla_google_robot_patch.py /tmp/
+RUN cd /app/ManiSkill2_real2sim && python3 /tmp/xvla_google_robot_patch.py && rm /tmp/xvla_google_robot_patch.py
 
 # 4. Change prepackaged defaults to base_pose controller (matches X-VLA fork).
 RUN cd /app/ManiSkill2_real2sim && \

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -27,6 +27,9 @@ done
 
 BENCHMARKS=(simpler libero libero_pro libero_plus libero_mem robocerebra maniskill2 calvin mikasa_robo vlabench rlbench robotwin robocasa kinetix robomme molmospaces behavior1k)
 
+# Derived images that extend a benchmark image instead of base
+DERIVED_BENCHMARKS=(simpler_groot simpler_xvla)
+
 # Images whose Dockerfile gates the build behind an ``ARG ACCEPT_*=YES``
 # build-arg.  Map: image-name → "<arg-name> <licence-url>".  Adding a new
 # gated image means one line here — no CLI flag changes required.
@@ -51,6 +54,14 @@ is_license_accepted() {
   return 1
 }
 
+is_derived() {
+  local n="$1"
+  for d in "${DERIVED_BENCHMARKS[@]}"; do
+    [[ "$d" == "$n" ]] && return 0
+  done
+  return 1
+}
+
 build_image() {
   local name="$1"
   local image_name="${name//_/-}"
@@ -58,7 +69,10 @@ build_image() {
   local image_tag="${REGISTRY}/${image_name}:${TAG}"
   local build_args=()
 
-  if [[ "$name" != "base" ]]; then
+  if is_derived "$name"; then
+    # Derived images use the Dockerfile's default BASE_IMAGE (e.g. simpler:latest)
+    build_args=(--build-arg "HARNESS_VERSION=${HARNESS_VERSION}")
+  elif [[ "$name" != "base" ]]; then
     build_args=(--build-arg "BASE_IMAGE=${BASE_IMAGE}" --build-arg "HARNESS_VERSION=${HARNESS_VERSION}")
   fi
 
@@ -81,20 +95,27 @@ build_image() {
 if [[ -n "$TARGET" ]]; then
   if [[ "$TARGET" != "base" ]]; then
     found=false
+    is_derived=false
     for b in "${BENCHMARKS[@]}"; do
       [[ "$b" == "$TARGET" ]] && found=true && break
     done
+    for b in "${DERIVED_BENCHMARKS[@]}"; do
+      [[ "$b" == "$TARGET" ]] && found=true && is_derived=true && break
+    done
     if ! $found; then
-      echo "ERROR: Unknown image '${TARGET}'. Available: base ${BENCHMARKS[*]}"
+      echo "ERROR: Unknown image '${TARGET}'. Available: base ${BENCHMARKS[*]} ${DERIVED_BENCHMARKS[*]}"
       exit 1
     fi
-    # Build base first
+    # Build base first (and parent benchmark for derived images)
     build_image base
   fi
   build_image "$TARGET"
 else
   build_image base
   for b in "${BENCHMARKS[@]}"; do
+    build_image "$b"
+  done
+  for b in "${DERIVED_BENCHMARKS[@]}"; do
     build_image "$b"
   done
 fi

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -95,19 +95,22 @@ build_image() {
 if [[ -n "$TARGET" ]]; then
   if [[ "$TARGET" != "base" ]]; then
     found=false
-    is_derived=false
+    target_is_derived=false
     for b in "${BENCHMARKS[@]}"; do
       [[ "$b" == "$TARGET" ]] && found=true && break
     done
     for b in "${DERIVED_BENCHMARKS[@]}"; do
-      [[ "$b" == "$TARGET" ]] && found=true && is_derived=true && break
+      [[ "$b" == "$TARGET" ]] && found=true && target_is_derived=true && break
     done
     if ! $found; then
       echo "ERROR: Unknown image '${TARGET}'. Available: base ${BENCHMARKS[*]} ${DERIVED_BENCHMARKS[*]}"
       exit 1
     fi
-    # Build base first (and parent benchmark for derived images)
     build_image base
+    if $target_is_derived; then
+      parent="${TARGET%%_*}"
+      build_image "$parent"
+    fi
   fi
   build_image "$TARGET"
 else

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -31,8 +31,6 @@ if [[ "$TAG" == "latest" && "$FORCE" != true ]]; then
 fi
 
 IMAGES=(base simpler simpler_groot simpler_xvla libero libero_pro libero_plus libero_mem robocerebra maniskill2 calvin mikasa_robo vlabench rlbench robotwin robocasa kinetix robomme molmospaces behavior1k)
-
-
 # Images excluded from registry pushes — build locally only.
 NO_REDIST=(rlbench behavior1k)
 

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -30,7 +30,8 @@ if [[ "$TAG" == "latest" && "$FORCE" != true ]]; then
   UPDATE_LATEST=false  # already pushing as latest, no need to double-tag
 fi
 
-IMAGES=(base simpler libero libero_pro libero_plus libero_mem robocerebra maniskill2 calvin mikasa_robo vlabench rlbench robotwin robocasa kinetix robomme molmospaces behavior1k)
+IMAGES=(base simpler simpler_groot simpler_xvla libero libero_pro libero_plus libero_mem robocerebra maniskill2 calvin mikasa_robo vlabench rlbench robotwin robocasa kinetix robomme molmospaces behavior1k)
+
 
 # Images excluded from registry pushes — build locally only.
 NO_REDIST=(rlbench behavior1k)

--- a/docker/xvla_google_robot_patch.py
+++ b/docker/xvla_google_robot_patch.py
@@ -1,11 +1,11 @@
 """Add absolute EE (base_pose) controller to Google Robot config for X-VLA."""
 
 import pathlib
+import sys
 
 p = pathlib.Path("mani_skill2_real2sim/agents/configs/google_robot/defaults.py")
 s = p.read_text()
 
-# Add base_pose controller definition before _C["arm"] = dict(
 old = '        _C["arm"] = dict('
 new_ctrl = (
     "        arm_pd_ee_base_pose_align_interpolate_by_planner = PDEEPoseControllerConfig(\n"
@@ -21,13 +21,21 @@ new_ctrl = (
     "        )\n"
     '        _C["arm"] = dict('
 )
+
+if old not in s:
+    print(f"ERROR: patch target not found in {p}: {old!r}", file=sys.stderr)
+    sys.exit(1)
 s = s.replace(old, new_ctrl)
 
-# Register in arm_controllers dict
+register_old = "arm_pd_ee_target_delta_pose_align_interpolate_by_planner=arm_pd_ee_target_delta_pose_align_interpolate_by_planner,"
+if register_old not in s:
+    print(f"ERROR: patch target not found in {p}: {register_old[:80]!r}", file=sys.stderr)
+    sys.exit(1)
 s = s.replace(
-    "arm_pd_ee_target_delta_pose_align_interpolate_by_planner=arm_pd_ee_target_delta_pose_align_interpolate_by_planner,",
-    "arm_pd_ee_target_delta_pose_align_interpolate_by_planner=arm_pd_ee_target_delta_pose_align_interpolate_by_planner,\n"
+    register_old,
+    register_old + "\n"
     "            arm_pd_ee_base_pose_align_interpolate_by_planner=arm_pd_ee_base_pose_align_interpolate_by_planner,",
 )
+
 p.write_text(s)
 print("Patched Google Robot base_pose controller")

--- a/docker/xvla_google_robot_patch.py
+++ b/docker/xvla_google_robot_patch.py
@@ -1,0 +1,33 @@
+"""Add absolute EE (base_pose) controller to Google Robot config for X-VLA."""
+
+import pathlib
+
+p = pathlib.Path("mani_skill2_real2sim/agents/configs/google_robot/defaults.py")
+s = p.read_text()
+
+# Add base_pose controller definition before _C["arm"] = dict(
+old = '        _C["arm"] = dict('
+new_ctrl = (
+    "        arm_pd_ee_base_pose_align_interpolate_by_planner = PDEEPoseControllerConfig(\n"
+    "            *arm_common_args,\n"
+    '            frame="base",\n'
+    "            interpolate=True,\n"
+    "            use_delta=False,\n"
+    "            interpolate_by_planner=True,\n"
+    "            interpolate_planner_vlim=self.arm_vel_limit,\n"
+    "            interpolate_planner_alim=self.arm_acc_limit,\n"
+    "            interpolate_planner_jerklim=self.arm_jerk_limit,\n"
+    "            **arm_common_kwargs,\n"
+    "        )\n"
+    '        _C["arm"] = dict('
+)
+s = s.replace(old, new_ctrl)
+
+# Register in arm_controllers dict
+s = s.replace(
+    "arm_pd_ee_target_delta_pose_align_interpolate_by_planner=arm_pd_ee_target_delta_pose_align_interpolate_by_planner,",
+    "arm_pd_ee_target_delta_pose_align_interpolate_by_planner=arm_pd_ee_target_delta_pose_align_interpolate_by_planner,\n"
+    "            arm_pd_ee_base_pose_align_interpolate_by_planner=arm_pd_ee_base_pose_align_interpolate_by_planner,",
+)
+p.write_text(s)
+print("Patched Google Robot base_pose controller")

--- a/docker/xvla_sink_camera.py
+++ b/docker/xvla_sink_camera.py
@@ -1,0 +1,26 @@
+"""Align SimplerEnv sink camera + robot init with Bridge dataset for X-VLA."""
+
+import pathlib
+
+# Patch WidowX sink camera to match Bridge dataset camera viewpoint
+p = pathlib.Path("mani_skill2_real2sim/agents/configs/widowx/defaults.py")
+s = p.read_text()
+s = s.replace("p=[-0.00300001, -0.21, 0.39]", "p=[0.00, -0.16, 0.336]")
+s = s.replace("q=[-0.907313, 0.0782, -0.36434, -0.194741]", "q=[0.909182, -0.0819809, 0.347277, 0.214629]")
+s = s.replace("                fov=1.5,  # ignored if intrinsic is passed\n", "")
+s = s.replace("                near=0.01,\n", "")
+s = s.replace("                far=10,\n", "")
+p.write_text(s)
+print("Patched sink camera config")
+
+# Align sink robot init with standard widowx
+p2 = pathlib.Path("mani_skill2_real2sim/envs/custom_scenes/base_env.py")
+s2 = p2.read_text()
+s2 = s2.replace(
+    "qpos = np.array([-0.2600599, -0.12875618, 0.04461369, -0.00652761, 1.7033415, -0.26983038, 0.037,\n                                 0.037])",
+    "qpos = np.array([-0.01840777,  0.0398835,   0.22242722,  -0.00460194,  1.36524296,  0.00153398, 0.037, 0.037])",
+)
+s2 = s2.replace("robot_init_height = 0.85", "robot_init_height = 0.870")
+s2 = s2.replace("init_y = 0.070", "init_y = 0.028")
+p2.write_text(s2)
+print("Patched sink robot init")

--- a/docker/xvla_sink_camera.py
+++ b/docker/xvla_sink_camera.py
@@ -1,11 +1,21 @@
 """Align SimplerEnv sink camera + robot init with Bridge dataset for X-VLA."""
 
 import pathlib
+import sys
 
-# Patch WidowX sink camera to match Bridge dataset camera viewpoint
+
+def _patch(path: pathlib.Path, old: str, new: str) -> str:
+    text = path.read_text()
+    patched = text.replace(old, new)
+    if patched == text:
+        print(f"ERROR: patch target not found in {path}: {old[:80]!r}", file=sys.stderr)
+        sys.exit(1)
+    return patched
+
+
 p = pathlib.Path("mani_skill2_real2sim/agents/configs/widowx/defaults.py")
 s = p.read_text()
-s = s.replace("p=[-0.00300001, -0.21, 0.39]", "p=[0.00, -0.16, 0.336]")
+s = _patch(p, "p=[-0.00300001, -0.21, 0.39]", "p=[0.00, -0.16, 0.336]")
 s = s.replace("q=[-0.907313, 0.0782, -0.36434, -0.194741]", "q=[0.909182, -0.0819809, 0.347277, 0.214629]")
 s = s.replace("                fov=1.5,  # ignored if intrinsic is passed\n", "")
 s = s.replace("                near=0.01,\n", "")
@@ -13,11 +23,11 @@ s = s.replace("                far=10,\n", "")
 p.write_text(s)
 print("Patched sink camera config")
 
-# Align sink robot init with standard widowx
 p2 = pathlib.Path("mani_skill2_real2sim/envs/custom_scenes/base_env.py")
-s2 = p2.read_text()
-s2 = s2.replace(
-    "qpos = np.array([-0.2600599, -0.12875618, 0.04461369, -0.00652761, 1.7033415, -0.26983038, 0.037,\n                                 0.037])",
+s2 = _patch(
+    p2,
+    "qpos = np.array([-0.2600599, -0.12875618, 0.04461369, -0.00652761, 1.7033415, -0.26983038, 0.037,\n"
+    "                                 0.037])",
     "qpos = np.array([-0.01840777,  0.0398835,   0.22242722,  -0.00460194,  1.36524296,  0.00153398, 0.037, 0.037])",
 )
 s2 = s2.replace("robot_init_height = 0.85", "robot_init_height = 0.870")


### PR DESCRIPTION
## Summary

- Add explicit `pip` to `conda create` commands (conda-forge no longer bundles it with python by default)
- Add explicit `wheel` where needed (conda-forge [removed it from pip's dependencies](https://conda-forge.org/news/2024/08/21/sunsetting-pip-deps/) as of 2024-08)
- Extract inline Python patches from `Dockerfile.simpler_xvla` into separate files (`xvla_sink_camera.py`, `xvla_google_robot_patch.py`) for readability
- Add `DERIVED_BENCHMARKS` support in `build.sh` for images that extend a benchmark image instead of base (`simpler_groot`, `simpler_xvla`)
- Add `simpler_groot` and `simpler_xvla` to `push.sh` IMAGES array

Affected Dockerfiles: `behavior1k`, `calvin`, `mikasa_robo`, `robotwin`, `simpler_xvla`

## Test plan

- [x] `make check` (lint + format + type check)
- [x] `uv run pytest tests/` (272 passed)
- [ ] `docker/build.sh simpler_xvla` (verify extracted patches still work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)