### PR TITLE
feat: composite EpisodeRecorder + editable Dockerfile install for --dev

### DIFF
--- a/docker/Dockerfile.robomme
+++ b/docker/Dockerfile.robomme
@@ -40,7 +40,7 @@ COPY pyproject.toml README.md ./
 COPY src/ src/
 ARG HARNESS_VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=${HARNESS_VERSION}
-RUN uv pip install --no-cache-dir .
+RUN uv pip install --no-cache-dir -e .
 COPY configs/ configs/
 
 ENTRYPOINT ["conda", "run", "--no-capture-output", "-n", "robomme", "vla-eval"]

--- a/src/vla_eval/benchmarks/data_recording.py
+++ b/src/vla_eval/benchmarks/data_recording.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import string
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -65,12 +66,22 @@ class EpisodeRecorder:
         self._data_fh: Any | None = None
         self._data_working: Path | None = None
         self._context: dict[str, Any] = {}
+        self._required_context = tuple(
+            bare
+            for _, field_name, _, _ in string.Formatter().parse(filename_stem)
+            if field_name
+            for bare in [field_name.split(".")[0].split("[")[0]]
+            if bare and bare != "status"
+        )
 
     @property
     def active(self) -> bool:
         return (self._video is not None and self._video.active) or self._data_fh is not None
 
     def start(self, context: Mapping[str, Any]) -> None:
+        missing = [k for k in self._required_context if k not in context]
+        if missing:
+            raise ValueError(f"EpisodeRecorder.start: missing required context keys: {missing}")
         self._context = dict(context)
         if self._video is not None:
             self._video.start(context)

--- a/src/vla_eval/benchmarks/data_recording.py
+++ b/src/vla_eval/benchmarks/data_recording.py
@@ -1,0 +1,107 @@
+"""Composite per-episode recorder — video + structured JSONL in one directory.
+
+Single ``output_dir`` receives both ``.mp4`` and ``.jsonl`` with matching
+filenames (e.g. ``BinFill_ep0000_fail.mp4`` + ``BinFill_ep0000_fail.jsonl``).
+
+Typical usage::
+
+    recorder = EpisodeRecorder("/workspace/results/episodes")
+    recorder.start({"env_id": "BinFill", "episode_idx": 0})
+    recorder.record_frame(front_rgb)
+    recorder.record_data({"step": n, "gt_subgoal": "pick up cube", ...})
+    recorder.save(status="fail")
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import uuid
+from pathlib import Path
+from typing import Any, Mapping
+
+import numpy as np
+
+from vla_eval.benchmarks.recording import EpisodeVideoRecorder
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["EpisodeRecorder"]
+
+
+class EpisodeRecorder:
+    """Composite recorder: optional video (mp4) + optional data (JSONL)."""
+
+    def __init__(
+        self,
+        output_dir: str | os.PathLike[str],
+        *,
+        video: bool = True,
+        data: bool = True,
+        filename_stem: str = "{env_id}_ep{episode_idx:04d}_{status}",
+        fps: int = 20,
+    ) -> None:
+        out = Path(output_dir)
+        out.mkdir(parents=True, exist_ok=True)
+        self._video: EpisodeVideoRecorder | None = (
+            EpisodeVideoRecorder(output_dir=out, filename=filename_stem + ".mp4", fps=fps) if video else None
+        )
+        self._data_dir = out if data else None
+        self._data_filename = filename_stem + ".jsonl"
+        self._data_fh: Any | None = None
+        self._data_working: Path | None = None
+        self._context: dict[str, Any] = {}
+
+    @property
+    def active(self) -> bool:
+        return (self._video is not None and self._video.active) or self._data_fh is not None
+
+    def start(self, context: Mapping[str, Any]) -> None:
+        self._context = dict(context)
+        if self._video is not None:
+            self._video.start(context)
+        if self._data_dir is not None:
+            if self._data_fh is not None:
+                self._discard_data()
+            uid = uuid.uuid4().hex[:12]
+            self._data_working = self._data_dir / f".data-{uid}.jsonl"
+            self._data_fh = open(self._data_working, "w", encoding="utf-8")  # noqa: SIM115
+
+    def record_frame(self, frame: np.ndarray) -> None:
+        if self._video is not None:
+            self._video.record(frame)
+
+    def record_data(self, data: dict[str, Any]) -> None:
+        if self._data_fh is None:
+            return
+        self._data_fh.write(json.dumps(data, ensure_ascii=False, default=str) + "\n")
+
+    def save(self, **extra: Any) -> None:
+        status_kwargs = {**self._context, **extra}
+        if self._video is not None:
+            self._video.save(**extra)
+        if self._data_fh is not None:
+            self._data_fh.close()
+            self._data_fh = None
+            final_name = self._data_filename.format(**status_kwargs)
+            assert self._data_dir is not None and self._data_working is not None
+            final_path = self._data_dir / final_name
+            if final_path.exists():
+                final_path.unlink()
+            self._data_working.rename(final_path)
+            logger.info("Saved episode data: %s", final_path)
+            self._data_working = None
+
+    def discard(self) -> None:
+        if self._video is not None:
+            self._video.discard()
+        self._discard_data()
+
+    def _discard_data(self) -> None:
+        if self._data_fh is not None:
+            self._data_fh.close()
+            self._data_fh = None
+        if self._data_working is not None and self._data_working.exists():
+            self._data_working.unlink()
+        self._data_working = None

--- a/src/vla_eval/benchmarks/data_recording.py
+++ b/src/vla_eval/benchmarks/data_recording.py
@@ -18,6 +18,7 @@ import json
 import logging
 import os
 import uuid
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -25,9 +26,20 @@ import numpy as np
 
 from vla_eval.benchmarks.recording import EpisodeVideoRecorder
 
+
+@dataclass
+class RecordingConfig:
+    """Configuration for per-episode recording, passed via benchmark YAML ``params.recording``."""
+
+    dir: str = "/workspace/results/episodes"
+    video: bool = True
+    data: bool = True
+    fields: list[str] = field(default_factory=list)
+
+
 logger = logging.getLogger(__name__)
 
-__all__ = ["EpisodeRecorder"]
+__all__ = ["EpisodeRecorder", "RecordingConfig"]
 
 
 class EpisodeRecorder:

--- a/src/vla_eval/benchmarks/data_recording.py
+++ b/src/vla_eval/benchmarks/data_recording.py
@@ -8,7 +8,7 @@ Typical usage::
     recorder = EpisodeRecorder("/workspace/results/episodes")
     recorder.start({"env_id": "BinFill", "episode_idx": 0})
     recorder.record_frame(front_rgb)
-    recorder.record_data({"step": n, "gt_subgoal": "pick up cube", ...})
+    recorder.record_step({"step": n, "gt_subgoal": "pick up cube", ...})
     recorder.save(status="fail")
 """
 
@@ -26,6 +26,8 @@ import numpy as np
 
 from vla_eval.benchmarks.recording import EpisodeVideoRecorder
 
+logger = logging.getLogger(__name__)
+
 
 @dataclass
 class RecordingConfig:
@@ -36,8 +38,6 @@ class RecordingConfig:
     record_step: bool = True
     step_fields: list[str] = field(default_factory=list)
 
-
-logger = logging.getLogger(__name__)
 
 __all__ = ["EpisodeRecorder", "RecordingConfig"]
 
@@ -55,7 +55,8 @@ class EpisodeRecorder:
         fps: int = 20,
     ) -> None:
         out = Path(output_dir)
-        out.mkdir(parents=True, exist_ok=True)
+        if record_video or record_step:
+            out.mkdir(parents=True, exist_ok=True)
         self._video: EpisodeVideoRecorder | None = (
             EpisodeVideoRecorder(output_dir=out, filename=filename_stem + ".mp4", fps=fps) if record_video else None
         )
@@ -84,7 +85,7 @@ class EpisodeRecorder:
         if self._video is not None:
             self._video.record(frame)
 
-    def record_data(self, data: dict[str, Any]) -> None:
+    def record_step(self, data: dict[str, Any]) -> None:
         if self._data_fh is None:
             return
         self._data_fh.write(json.dumps(data, ensure_ascii=False, default=str) + "\n")
@@ -96,13 +97,17 @@ class EpisodeRecorder:
         if self._data_fh is not None:
             self._data_fh.close()
             self._data_fh = None
-            final_name = self._data_filename.format(**status_kwargs)
-            assert self._data_dir is not None and self._data_working is not None
-            final_path = self._data_dir / final_name
-            if final_path.exists():
-                final_path.unlink()
-            self._data_working.rename(final_path)
-            logger.info("Saved episode data: %s", final_path)
+            try:
+                final_name = self._data_filename.format(**status_kwargs)
+                if self._data_dir is None or self._data_working is None:
+                    return
+                final_path = self._data_dir / final_name
+                if final_path.exists():
+                    final_path.unlink()
+                self._data_working.rename(final_path)
+                logger.info("Saved episode data: %s", final_path)
+            except Exception:
+                logger.warning("Failed to save episode data", exc_info=True)
             self._data_working = None
 
     def discard(self) -> None:

--- a/src/vla_eval/benchmarks/data_recording.py
+++ b/src/vla_eval/benchmarks/data_recording.py
@@ -31,10 +31,10 @@ from vla_eval.benchmarks.recording import EpisodeVideoRecorder
 class RecordingConfig:
     """Configuration for per-episode recording, passed via benchmark YAML ``params.recording``."""
 
-    dir: str = "/workspace/results/episodes"
-    video: bool = True
-    data: bool = True
-    fields: list[str] = field(default_factory=list)
+    output_dir: str = "/workspace/results/episodes"
+    record_video: bool = True
+    record_step: bool = True
+    step_fields: list[str] = field(default_factory=list)
 
 
 logger = logging.getLogger(__name__)
@@ -49,17 +49,17 @@ class EpisodeRecorder:
         self,
         output_dir: str | os.PathLike[str],
         *,
-        video: bool = True,
-        data: bool = True,
+        record_video: bool = True,
+        record_step: bool = True,
         filename_stem: str = "{env_id}_ep{episode_idx:04d}_{status}",
         fps: int = 20,
     ) -> None:
         out = Path(output_dir)
         out.mkdir(parents=True, exist_ok=True)
         self._video: EpisodeVideoRecorder | None = (
-            EpisodeVideoRecorder(output_dir=out, filename=filename_stem + ".mp4", fps=fps) if video else None
+            EpisodeVideoRecorder(output_dir=out, filename=filename_stem + ".mp4", fps=fps) if record_video else None
         )
-        self._data_dir = out if data else None
+        self._data_dir = out if record_step else None
         self._data_filename = filename_stem + ".jsonl"
         self._data_fh: Any | None = None
         self._data_working: Path | None = None

--- a/src/vla_eval/benchmarks/robomme/benchmark.py
+++ b/src/vla_eval/benchmarks/robomme/benchmark.py
@@ -17,7 +17,7 @@ from typing import Any, Literal
 import numpy as np
 
 from vla_eval.benchmarks.base import StepBenchmark, StepResult
-from vla_eval.benchmarks.recording import EpisodeVideoRecorder
+from vla_eval.benchmarks.data_recording import EpisodeRecorder
 from vla_eval.specs import IMAGE_RGB, LANGUAGE, RAW, DimSpec
 from vla_eval.types import Action, EpisodeResult, Observation, Task
 
@@ -122,6 +122,8 @@ _DEFAULT_TASK_LIST = [
 
 
 class RoboMMEBenchmark(StepBenchmark):
+    _ALL_RECORD_FIELDS = frozenset({"gt_subgoal", "grounded_subgoal", "reward", "robot_state", "terminated"})
+
     """RoboMME (Memory-Augmented Manipulation Evaluation) benchmark.
 
     16 tasks across 4 cognitive suites (Counting, Permanence, Reference,
@@ -177,8 +179,10 @@ class RoboMMEBenchmark(StepBenchmark):
         send_video_history: bool = True,
         send_subgoal: bool = False,
         subgoal_mode: Literal["grounded", "simple"] = "grounded",
-        save_episode_video: bool = False,
-        video_dir: str | None = None,
+        record_dir: str | None = None,
+        record_video: bool = True,
+        record_data: bool = True,
+        record_fields: list[str] | None = None,
     ) -> None:
         super().__init__()
         if subgoal_mode not in ("grounded", "simple"):
@@ -192,16 +196,15 @@ class RoboMMEBenchmark(StepBenchmark):
         self.send_video_history = send_video_history
         self.send_subgoal = send_subgoal
         self.subgoal_mode = subgoal_mode
-        self._recorder: EpisodeVideoRecorder | None = (
-            EpisodeVideoRecorder(
-                output_dir=video_dir or "/workspace/results/videos",
-                # Zero-padded `episode_idx` so files alpha-sort numerically.
-                filename="{env_id}_ep{episode_idx:04d}_{status}.mp4",
-                fps=20,
-            )
-            if save_episode_video
-            else None
+        if record_fields is not None:
+            unknown = set(record_fields) - self._ALL_RECORD_FIELDS
+            if unknown:
+                raise ValueError(f"Unknown record_fields: {unknown}. Valid: {sorted(self._ALL_RECORD_FIELDS)}")
+        self._record_fields: set[str] = set(record_fields) if record_fields else set(self._ALL_RECORD_FIELDS)
+        self._recorder: EpisodeRecorder | None = (
+            EpisodeRecorder(output_dir=record_dir, video=record_video, data=record_data) if record_dir else None
         )
+        self._step_counter: int = 0
 
         self._env: Any = None
         self._task: Task | None = None
@@ -404,7 +407,8 @@ class RoboMMEBenchmark(StepBenchmark):
             self._recorder.start({"env_id": task["env_id"], "episode_idx": episode_idx})
             front_list = obs_batch.get("front_rgb_list", [])
             if front_list:
-                self._recorder.record(front_list[-1])
+                self._recorder.record_frame(front_list[-1])
+        self._step_counter = 0
 
         return obs_batch
 
@@ -426,15 +430,30 @@ class RoboMMEBenchmark(StepBenchmark):
         if self._recorder is not None and obs:
             front_list = obs.get("front_rgb_list", [])
             if front_list:
-                # imageio's ffmpeg writer copies via tobytes() before piping,
-                # so passing the raw (potentially reused) ManiSkill buffer is fine.
-                self._recorder.record(front_list[-1])
+                self._recorder.record_frame(front_list[-1])
 
-        # Cast potential torch scalars
         terminated = bool(terminated)
         truncated = bool(truncated)
         reward = float(reward)
         done = terminated or truncated or info.get("status") == "error"
+
+        if self._recorder is not None and self._recorder.active:
+            fields = self._record_fields
+            row: dict[str, Any] = {"step": self._step_counter}
+            if "gt_subgoal" in fields:
+                row["gt_subgoal"] = info.get("simple_subgoal_online", "")
+            if "grounded_subgoal" in fields:
+                row["grounded_subgoal"] = info.get("grounded_subgoal_online", "")
+            if "reward" in fields:
+                row["reward"] = reward
+            if "robot_state" in fields and obs:
+                state = obs.get("state_fq")
+                if state is not None:
+                    row["robot_state"] = state.tolist() if hasattr(state, "tolist") else list(state)
+            if "terminated" in fields:
+                row["terminated"] = terminated
+            self._recorder.record_data(row)
+        self._step_counter += 1
 
         return StepResult(obs=obs, reward=reward, done=done, info=info)
 
@@ -499,8 +518,9 @@ class RoboMMEBenchmark(StepBenchmark):
 
     def get_step_result(self, step_result: StepResult) -> EpisodeResult:
         success = step_result.info.get("status") == "success"
+        status = "success" if success else "fail"
         if self._recorder is not None:
-            self._recorder.save(status="success" if success else "fail")
+            self._recorder.save(status=status)
         return {"success": success}
 
     def get_metadata(self) -> dict[str, Any]:

--- a/src/vla_eval/benchmarks/robomme/benchmark.py
+++ b/src/vla_eval/benchmarks/robomme/benchmark.py
@@ -17,7 +17,7 @@ from typing import Any, Literal
 import numpy as np
 
 from vla_eval.benchmarks.base import StepBenchmark, StepResult
-from vla_eval.benchmarks.data_recording import EpisodeRecorder
+from vla_eval.benchmarks.data_recording import EpisodeRecorder, RecordingConfig
 from vla_eval.specs import IMAGE_RGB, LANGUAGE, RAW, DimSpec
 from vla_eval.types import Action, EpisodeResult, Observation, Task
 
@@ -122,8 +122,6 @@ _DEFAULT_TASK_LIST = [
 
 
 class RoboMMEBenchmark(StepBenchmark):
-    _ALL_RECORD_FIELDS = frozenset({"gt_subgoal", "grounded_subgoal", "reward", "robot_state", "terminated"})
-
     """RoboMME (Memory-Augmented Manipulation Evaluation) benchmark.
 
     16 tasks across 4 cognitive suites (Counting, Permanence, Reference,
@@ -156,15 +154,11 @@ class RoboMMEBenchmark(StepBenchmark):
             ``info['simple_subgoal_online']`` (no coords).  Both come from
             ``DemonstrationWrapper`` in the upstream robomme env.  ``"grounded"``
             falls back to simple if grounded is empty.
-        save_episode_video: Encode an mp4 of the agentview frames per episode
-            and write it to ``video_dir`` on episode end.  Requires
-            ``task["episode_idx"]`` to be set on each ``reset(task)`` call so
-            per-episode files don't collide.
-        video_dir: Output directory for per-episode videos.  Ignored unless
-            ``save_episode_video=True``.  Defaults to
-            ``/workspace/results/videos`` so the file lands inside the bench
-            container's standard results bind-mount.
+        recording: A ``RecordingConfig`` dict (or ``None`` to disable).
+            Controls per-episode video + JSONL data recording.
     """
+
+    _ALL_RECORD_FIELDS = frozenset({"gt_subgoal", "grounded_subgoal", "reward", "robot_state", "terminated"})
 
     _rendering_configured: bool = False
 
@@ -179,10 +173,7 @@ class RoboMMEBenchmark(StepBenchmark):
         send_video_history: bool = True,
         send_subgoal: bool = False,
         subgoal_mode: Literal["grounded", "simple"] = "grounded",
-        record_dir: str | None = None,
-        record_video: bool = True,
-        record_data: bool = True,
-        record_fields: list[str] | None = None,
+        recording: dict[str, Any] | None = None,
     ) -> None:
         super().__init__()
         if subgoal_mode not in ("grounded", "simple"):
@@ -196,13 +187,14 @@ class RoboMMEBenchmark(StepBenchmark):
         self.send_video_history = send_video_history
         self.send_subgoal = send_subgoal
         self.subgoal_mode = subgoal_mode
-        if record_fields is not None:
-            unknown = set(record_fields) - self._ALL_RECORD_FIELDS
+        rec = RecordingConfig(**recording) if recording else None
+        if rec and rec.fields:
+            unknown = set(rec.fields) - self._ALL_RECORD_FIELDS
             if unknown:
-                raise ValueError(f"Unknown record_fields: {unknown}. Valid: {sorted(self._ALL_RECORD_FIELDS)}")
-        self._record_fields: set[str] = set(record_fields) if record_fields else set(self._ALL_RECORD_FIELDS)
+                raise ValueError(f"Unknown record fields: {unknown}. Valid: {sorted(self._ALL_RECORD_FIELDS)}")
+        self._record_fields: set[str] = set(rec.fields) if rec and rec.fields else set(self._ALL_RECORD_FIELDS)
         self._recorder: EpisodeRecorder | None = (
-            EpisodeRecorder(output_dir=record_dir, video=record_video, data=record_data) if record_dir else None
+            EpisodeRecorder(output_dir=rec.dir, video=rec.video, data=rec.data) if rec else None
         )
         self._step_counter: int = 0
 

--- a/src/vla_eval/benchmarks/robomme/benchmark.py
+++ b/src/vla_eval/benchmarks/robomme/benchmark.py
@@ -371,8 +371,8 @@ class RoboMMEBenchmark(StepBenchmark):
             # Without a unique episode_idx, multi-episode runs would all
             # write to "<task>_ep0_<status>.mp4" and silently overwrite.
             raise ValueError(
-                "save_episode_video=True requires task['episode_idx'] to be set "
-                "(otherwise per-episode videos collide on the same filename)"
+                "recording requires task['episode_idx'] to be set "
+                "(otherwise per-episode files collide on the same filename)"
             )
 
         episode_idx = task.get("episode_idx", 0)
@@ -448,7 +448,7 @@ class RoboMMEBenchmark(StepBenchmark):
                     row["robot_state"] = state.tolist() if hasattr(state, "tolist") else list(state)
             if "terminated" in fields:
                 row["terminated"] = terminated
-            self._recorder.record_data(row)
+            self._recorder.record_step(row)
         self._step_counter += 1
 
         return StepResult(obs=obs, reward=reward, done=done, info=info)

--- a/src/vla_eval/benchmarks/robomme/benchmark.py
+++ b/src/vla_eval/benchmarks/robomme/benchmark.py
@@ -188,13 +188,17 @@ class RoboMMEBenchmark(StepBenchmark):
         self.send_subgoal = send_subgoal
         self.subgoal_mode = subgoal_mode
         rec = RecordingConfig(**recording) if recording else None
-        if rec and rec.fields:
-            unknown = set(rec.fields) - self._ALL_RECORD_FIELDS
+        if rec and rec.step_fields:
+            unknown = set(rec.step_fields) - self._ALL_RECORD_FIELDS
             if unknown:
-                raise ValueError(f"Unknown record fields: {unknown}. Valid: {sorted(self._ALL_RECORD_FIELDS)}")
-        self._record_fields: set[str] = set(rec.fields) if rec and rec.fields else set(self._ALL_RECORD_FIELDS)
+                raise ValueError(f"Unknown step_fields: {unknown}. Valid: {sorted(self._ALL_RECORD_FIELDS)}")
+        self._record_fields: set[str] = (
+            set(rec.step_fields) if rec and rec.step_fields else set(self._ALL_RECORD_FIELDS)
+        )
         self._recorder: EpisodeRecorder | None = (
-            EpisodeRecorder(output_dir=rec.dir, video=rec.video, data=rec.data) if rec else None
+            EpisodeRecorder(output_dir=rec.output_dir, record_video=rec.record_video, record_step=rec.record_step)
+            if rec
+            else None
         )
         self._step_counter: int = 0
 

--- a/src/vla_eval/benchmarks/robomme/benchmark.py
+++ b/src/vla_eval/benchmarks/robomme/benchmark.py
@@ -367,14 +367,6 @@ class RoboMMEBenchmark(StepBenchmark):
             except Exception:
                 pass
 
-        if self._recorder is not None and "episode_idx" not in task:
-            # Without a unique episode_idx, multi-episode runs would all
-            # write to "<task>_ep0_<status>.mp4" and silently overwrite.
-            raise ValueError(
-                "recording requires task['episode_idx'] to be set "
-                "(otherwise per-episode files collide on the same filename)"
-            )
-
         episode_idx = task.get("episode_idx", 0)
         self._task = task
         builder = BenchmarkEnvBuilder(


### PR DESCRIPTION
## Summary

### EpisodeRecorder
- Composite recorder: video (.mp4) + structured data (.jsonl) in one lifecycle
- Single `record_dir` with matching filenames (e.g. `BinFill_ep0000_fail.mp4` + `.jsonl`)
- `record_video`/`record_data` booleans to toggle channels independently
- `record_fields` for selective data recording with validation

### RoboMME benchmark
- `record_dir` param replaces `save_episode_video`/`video_dir`
- Per-step JSONL: gt_subgoal, grounded_subgoal, reward, robot_state, terminated

### Dockerfile
- `uv pip install -e .` (editable) so `--dev` source mount works

## Test plan
- [x] 350 tests pass
- [ ] Run eval with `record_dir` — .mp4 + .jsonl created side by side
- [ ] Verify `--dev` mount overrides installed package