### PR TITLE
fix: improve model server deps, smoke test reliability, and weight availability checks

### DIFF
--- a/configs/model_servers/molmobot/_base.yaml
+++ b/configs/model_servers/molmobot/_base.yaml
@@ -5,8 +5,6 @@
 
 script: "src/vla_eval/model_servers/molmobot.py"
 args:
-  primary_image_key: "exo_camera_1"
-  wrist_image_key: "wrist_camera"
   execute_horizon: 8            # Matches SynthVLAPolicyConfig.execute_horizon
   states_mode: "cross_attn"     # Matches SynthVLAPolicyConfig.states_mode
   max_joint_delta: 0.2          # Per-step safety clamp on arm joint deltas

--- a/docker/Dockerfile.robotwin
+++ b/docker/Dockerfile.robotwin
@@ -61,7 +61,7 @@ RUN git clone --depth 1 https://github.com/RoboTwin-Platform/RoboTwin.git /app/R
 ENV TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;8.9;9.0+PTX"
 RUN uv pip install --no-cache-dir wheel \
     && cd /app/RoboTwin/envs \
-    && git clone --depth 1 https://github.com/NVlabs/curobo.git \
+    && git clone --depth 1 --branch v0.7.8 https://github.com/NVlabs/curobo.git \
     && cd curobo \
     && uv pip install --no-cache-dir --no-build-isolation . \
     && rm -rf .git

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -20,6 +20,9 @@ while [[ $# -gt 0 ]]; do
     --tag)              TAG="$2"; shift 2 ;;
     --base-image)       BASE_IMAGE="$2"; shift 2 ;;
     --accept-license)   ACCEPTED_LICENSES+=("$2"); shift 2 ;;
+    -h|--help)
+      sed -n '2,/^[^#]/{ s/^# \?//p; }' "$0"
+      exit 0 ;;
     -*)                 echo "Unknown flag: $1"; exit 1 ;;
     *)                  TARGET="$1"; shift ;;
   esac

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -19,6 +19,9 @@ while [[ $# -gt 0 ]]; do
     --tag)       TAG="$2"; shift 2 ;;
     --no-latest) UPDATE_LATEST=false; shift ;;
     -y)          FORCE=true; shift ;;
+    -h|--help)
+      sed -n '2,/^[^#]/{ s/^# \?//p; }' "$0"
+      exit 0 ;;
     -*)          echo "Unknown flag: $1"; exit 1 ;;
     *)           TARGET="$1"; shift ;;
   esac

--- a/src/vla_eval/cli/main.py
+++ b/src/vla_eval/cli/main.py
@@ -858,7 +858,7 @@ examples:
     test_parser.add_argument(
         "--benchmark", nargs="?", const="*", default=None, metavar="NAME", help="Benchmark tests (exact registry name)"
     )
-    test_parser.add_argument("--timeout", type=int, default=300, help="Timeout in seconds for server/benchmark tests")
+    test_parser.add_argument("--timeout", type=int, default=600, help="Timeout in seconds for server/benchmark tests")
     test_parser.add_argument(
         "--parallel",
         nargs="?",

--- a/src/vla_eval/cli/smoke.py
+++ b/src/vla_eval/cli/smoke.py
@@ -415,7 +415,9 @@ def run_server_test(test: SmokeTest, timeout: int, *, gpu_id: str | None = None)
     captured_stderr: list[bytes] = []  # shared with _run() closure
 
     async def _run() -> dict:
-        env = {**os.environ, "CUDA_VISIBLE_DEVICES": gpu_id} if gpu_id is not None else None
+        env = {**os.environ, "TF_CPP_MIN_LOG_LEVEL": "3"}
+        if gpu_id is not None:
+            env["CUDA_VISIBLE_DEVICES"] = gpu_id
         proc = await anyio.open_process(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, env=env)
 
         async def _drain_stderr() -> None:

--- a/src/vla_eval/cli/smoke.py
+++ b/src/vla_eval/cli/smoke.py
@@ -415,7 +415,7 @@ def run_server_test(test: SmokeTest, timeout: int, *, gpu_id: str | None = None)
     captured_stderr: list[bytes] = []  # shared with _run() closure
 
     async def _run() -> dict:
-        env = {**os.environ, "TF_CPP_MIN_LOG_LEVEL": "3"}
+        env = {**os.environ, "TF_CPP_MIN_LOG_LEVEL": "2"}
         if gpu_id is not None:
             env["CUDA_VISIBLE_DEVICES"] = gpu_id
         proc = await anyio.open_process(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, env=env)

--- a/src/vla_eval/cli/smoke.py
+++ b/src/vla_eval/cli/smoke.py
@@ -415,9 +415,7 @@ def run_server_test(test: SmokeTest, timeout: int, *, gpu_id: str | None = None)
     captured_stderr: list[bytes] = []  # shared with _run() closure
 
     async def _run() -> dict:
-        env = {**os.environ, "TF_CPP_MIN_LOG_LEVEL": "2"}
-        if gpu_id is not None:
-            env["CUDA_VISIBLE_DEVICES"] = gpu_id
+        env = {**os.environ, "CUDA_VISIBLE_DEVICES": gpu_id} if gpu_id is not None else None
         proc = await anyio.open_process(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, env=env)
 
         async def _drain_stderr() -> None:

--- a/src/vla_eval/dirs.py
+++ b/src/vla_eval/dirs.py
@@ -51,15 +51,12 @@ def ensure_git_clone(name: str, repo: str, rev: str, *, shallow: bool = False) -
     return target
 
 
-def is_hf_cached(model_id: str, filename: str = "config.json") -> bool:
-    """Check if a HuggingFace model has a cached snapshot (no download).
+def is_hf_cached(model_id: str) -> bool:
+    """Check if a HuggingFace model has any cached snapshot (no download)."""
+    from huggingface_hub.constants import HF_HUB_CACHE
 
-    Uses ``huggingface_hub.try_to_load_from_cache`` (stable public API, v0.14+).
-    """
-    from huggingface_hub import try_to_load_from_cache
-
-    result = try_to_load_from_cache(model_id, filename)
-    return isinstance(result, str)
+    snapshots = Path(HF_HUB_CACHE) / f"models--{model_id.replace('/', '--')}" / "snapshots"
+    return snapshots.is_dir() and any(snapshots.iterdir())
 
 
 def _looks_like_hf_id(model_id: str) -> bool:

--- a/src/vla_eval/dirs.py
+++ b/src/vla_eval/dirs.py
@@ -1,4 +1,4 @@
-"""Host-side cache directory resolver and runtime licence helper.
+"""Host-side cache directory resolver, model availability checker, and runtime licence helper.
 
 Mirrors HuggingFace's ``HF_HOME`` / ``HF_ASSETS_CACHE`` precedence shape so consumers (benchmarks,
 model servers) put state in one canonical place.  See PR #58 for the full layout discussion.
@@ -49,6 +49,44 @@ def ensure_git_clone(name: str, repo: str, rev: str, *, shallow: bool = False) -
         subprocess.check_call(["git", "clone", repo, str(target)])
         subprocess.check_call(["git", "-C", str(target), "checkout", rev])
     return target
+
+
+def is_hf_cached(model_id: str, filename: str = "config.json") -> bool:
+    """Check if a HuggingFace model has a cached snapshot (no download).
+
+    Uses ``huggingface_hub.try_to_load_from_cache`` (stable public API, v0.14+).
+    """
+    from huggingface_hub import try_to_load_from_cache
+
+    result = try_to_load_from_cache(model_id, filename)
+    return isinstance(result, str)
+
+
+def _looks_like_hf_id(model_id: str) -> bool:
+    """Return True if *model_id* looks like a HuggingFace ``org/repo`` identifier."""
+    parts = model_id.split("/")
+    return len(parts) in (2, 3) and not model_id.startswith(("/", ".", "~"))
+
+
+def check_model_available(model_id: str) -> tuple[bool, str]:
+    """Check if model weights are locally available (no download).
+
+    Handles local filesystem paths and HuggingFace model IDs.
+    Returns ``(available, message)`` tuple.
+    """
+    if not model_id or model_id == "unknown":
+        return True, "no checkpoint configured"
+    if os.path.exists(model_id):
+        return True, "local path"
+    if _looks_like_hf_id(model_id):
+        try:
+            cached = is_hf_cached(model_id)
+        except ImportError:
+            return True, "unchecked (pip install huggingface_hub to verify)"
+        if cached:
+            return True, "cached"
+        return False, f"not cached (download: hf download {model_id})"
+    return False, f"not found: {model_id}"
 
 
 _LICENCE_BANNER = "=" * 70

--- a/src/vla_eval/dirs.py
+++ b/src/vla_eval/dirs.py
@@ -55,7 +55,8 @@ def is_hf_cached(model_id: str) -> bool:
     """Check if a HuggingFace model has any cached snapshot (no download)."""
     from huggingface_hub.constants import HF_HUB_CACHE
 
-    snapshots = Path(HF_HUB_CACHE) / f"models--{model_id.replace('/', '--')}" / "snapshots"
+    repo_id = "/".join(model_id.split("/")[:2])
+    snapshots = Path(HF_HUB_CACHE) / f"models--{repo_id.replace('/', '--')}" / "snapshots"
     return snapshots.is_dir() and any(snapshots.iterdir())
 
 
@@ -84,6 +85,13 @@ def check_model_available(model_id: str) -> tuple[bool, str]:
             return True, "cached"
         return False, f"not cached (download: hf download {model_id})"
     return False, f"not found: {model_id}"
+
+
+def require_model_available(model_id: str) -> None:
+    """Raise ``FileNotFoundError`` if *model_id* is not locally available."""
+    ok, msg = check_model_available(model_id)
+    if not ok:
+        raise FileNotFoundError(f"Model weights: {msg}")
 
 
 _LICENCE_BANNER = "=" * 70

--- a/src/vla_eval/model_servers/behavior1k_baseline.py
+++ b/src/vla_eval/model_servers/behavior1k_baseline.py
@@ -7,6 +7,9 @@
 #
 # [tool.uv.sources]
 # vla-eval = { path = "../../..", editable = true }
+#
+# [tool.uv]
+# exclude-newer = "2026-05-08T00:00:00Z"
 # ///
 """BEHAVIOR-1K zero-action baseline model server.
 

--- a/src/vla_eval/model_servers/behavior1k_demo_replay.py
+++ b/src/vla_eval/model_servers/behavior1k_demo_replay.py
@@ -9,6 +9,9 @@
 #
 # [tool.uv.sources]
 # vla-eval = { path = "../../..", editable = true }
+#
+# [tool.uv]
+# exclude-newer = "2026-05-08T00:00:00Z"
 # ///
 """BEHAVIOR-1K demo-replay model server.
 

--- a/src/vla_eval/model_servers/cogact.py
+++ b/src/vla_eval/model_servers/cogact.py
@@ -23,6 +23,10 @@
 # ///
 from __future__ import annotations
 
+import os
+
+os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "2")  # suppress TF GPU init noise (transitive dep)
+
 import logging
 from typing import Any
 

--- a/src/vla_eval/model_servers/cogact.py
+++ b/src/vla_eval/model_servers/cogact.py
@@ -23,10 +23,6 @@
 # ///
 from __future__ import annotations
 
-import os
-
-os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "2")  # suppress TF GPU init noise (transitive dep)
-
 import logging
 from typing import Any
 
@@ -82,6 +78,10 @@ class CogACTModelServer(PredictModelServer):
     def _load_model(self) -> None:
         if self._model is not None:
             return
+        import os
+
+        os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "2")  # suppress TF GPU init hang (transitive dep)
+
         import torch
         from vla import load_vla
 

--- a/src/vla_eval/model_servers/groot.py
+++ b/src/vla_eval/model_servers/groot.py
@@ -6,8 +6,6 @@
 #     "torch>=2.2,<2.8",
 #     "numpy>=1.24",
 #     "pillow>=9.0",
-#     "opencv-python-headless",
-#     "huggingface_hub",
 # ]
 #
 # [tool.uv.sources]

--- a/src/vla_eval/model_servers/groot.py
+++ b/src/vla_eval/model_servers/groot.py
@@ -134,11 +134,9 @@ class GR00TModelServer(PredictModelServer):
     def _load_model(self) -> None:
         if self._policy is not None:
             return
-        from vla_eval.dirs import check_model_available
+        from vla_eval.dirs import require_model_available
 
-        ok, msg = check_model_available(self.model_path)
-        if not ok:
-            raise FileNotFoundError(f"Model weights: {msg}")
+        require_model_available(self.model_path)
 
         import json
 

--- a/src/vla_eval/model_servers/groot.py
+++ b/src/vla_eval/model_servers/groot.py
@@ -134,6 +134,12 @@ class GR00TModelServer(PredictModelServer):
     def _load_model(self) -> None:
         if self._policy is not None:
             return
+        from vla_eval.dirs import check_model_available
+
+        ok, msg = check_model_available(self.model_path)
+        if not ok:
+            raise FileNotFoundError(f"Model weights: {msg}")
+
         import json
 
         from gr00t.data.embodiment_tags import EmbodimentTag

--- a/src/vla_eval/model_servers/groot.py
+++ b/src/vla_eval/model_servers/groot.py
@@ -6,6 +6,8 @@
 #     "torch>=2.2,<2.8",
 #     "numpy>=1.24",
 #     "pillow>=9.0",
+#     "opencv-python-headless",
+#     "huggingface_hub",
 # ]
 #
 # [tool.uv.sources]

--- a/src/vla_eval/model_servers/mme_vla.py
+++ b/src/vla_eval/model_servers/mme_vla.py
@@ -140,11 +140,9 @@ class MmeVlaModelServer(PredictModelServer):
         if os.path.isdir(self.checkpoint) and os.path.isdir(os.path.join(self.checkpoint, "params")):
             return self.checkpoint
 
-        from vla_eval.dirs import check_model_available
+        from vla_eval.dirs import require_model_available
 
-        ok, msg = check_model_available(self.checkpoint)
-        if not ok:
-            raise FileNotFoundError(f"Model weights: {msg}")
+        require_model_available(self.checkpoint)
 
         from huggingface_hub import snapshot_download
 

--- a/src/vla_eval/model_servers/mme_vla.py
+++ b/src/vla_eval/model_servers/mme_vla.py
@@ -140,6 +140,12 @@ class MmeVlaModelServer(PredictModelServer):
         if os.path.isdir(self.checkpoint) and os.path.isdir(os.path.join(self.checkpoint, "params")):
             return self.checkpoint
 
+        from vla_eval.dirs import check_model_available
+
+        ok, msg = check_model_available(self.checkpoint)
+        if not ok:
+            raise FileNotFoundError(f"Model weights: {msg}")
+
         from huggingface_hub import snapshot_download
 
         # Handle 3-segment paths: org/repo/subdir

--- a/src/vla_eval/model_servers/mme_vla.py
+++ b/src/vla_eval/model_servers/mme_vla.py
@@ -5,13 +5,11 @@
 #     "openpi",
 #     "numpy>=1.24",
 #     "huggingface_hub",
-#     "pytest",
-#     "chex",
 # ]
 #
 # [tool.uv.sources]
 # vla-eval = { path = "../../..", editable = true }
-# openpi = { git = "https://github.com/RoboMME/robomme_policy_learning.git", rev = "main" }
+# openpi = { git = "https://github.com/RoboMME/robomme_policy_learning.git", rev = "ecf086c3be7c2223167d9bb2f6ef1f0a6e24353b" }
 #
 # [tool.uv]
 # exclude-newer = "2026-04-06T00:00:00Z"

--- a/src/vla_eval/model_servers/mme_vla.py
+++ b/src/vla_eval/model_servers/mme_vla.py
@@ -5,8 +5,8 @@
 #     "openpi",
 #     "numpy>=1.24",
 #     "huggingface_hub",
-#     "pytest",
-#     "chex",
+#     "pytest",  # not declared in openpi's deps but imported by openpi.models_pytorch
+#     "chex",    # not declared in openpi's deps but imported by openpi.models
 # ]
 #
 # [tool.uv.sources]

--- a/src/vla_eval/model_servers/mme_vla.py
+++ b/src/vla_eval/model_servers/mme_vla.py
@@ -5,6 +5,8 @@
 #     "openpi",
 #     "numpy>=1.24",
 #     "huggingface_hub",
+#     "pytest",
+#     "chex",
 # ]
 #
 # [tool.uv.sources]

--- a/src/vla_eval/model_servers/molmobot.py
+++ b/src/vla_eval/model_servers/molmobot.py
@@ -89,6 +89,12 @@ class MolmoBotModelServer(ModelServer):
     def _load_model(self) -> None:
         if self._wrapper is not None:
             return
+        from vla_eval.dirs import check_model_available
+
+        ok, msg = check_model_available(self.hf_repo)
+        if not ok:
+            raise FileNotFoundError(f"Model weights: {msg}")
+
         from olmo.models.molmobot.inference_wrapper import SynthManipMolmoInferenceWrapper
 
         logger.info("Loading MolmoBot from %s (states_mode=%s)", self.hf_repo, self.states_mode)

--- a/src/vla_eval/model_servers/molmobot.py
+++ b/src/vla_eval/model_servers/molmobot.py
@@ -83,11 +83,9 @@ class MolmoBotModelServer(ModelServer):
     def _load_model(self) -> None:
         if self._wrapper is not None:
             return
-        from vla_eval.dirs import check_model_available
+        from vla_eval.dirs import require_model_available
 
-        ok, msg = check_model_available(self.hf_repo)
-        if not ok:
-            raise FileNotFoundError(f"Model weights: {msg}")
+        require_model_available(self.hf_repo)
 
         from huggingface_hub import snapshot_download
         from olmo.models.molmobot.inference_wrapper import SynthManipMolmoInferenceWrapper
@@ -111,9 +109,12 @@ class MolmoBotModelServer(ModelServer):
 
     async def on_episode_start(self, config: dict[str, Any], ctx: SessionContext) -> None:
         # Reset per-episode state.
+        from collections import deque
+
+        max_history = (self.n_obs_steps - 1) * self.obs_step_delta + 1
         self._sessions[ctx.session_id] = {
-            "obs_history": [],  # list[dict[cam_name, np.ndarray]]
-            "action_buffer": [],  # list[dict{"arm": (7,), "gripper": (1,)}]
+            "obs_history": deque(maxlen=max_history),
+            "action_buffer": [],
             "buffer_index": 0,
             "step_count": 0,
         }

--- a/src/vla_eval/model_servers/molmobot.py
+++ b/src/vla_eval/model_servers/molmobot.py
@@ -2,17 +2,16 @@
 # requires-python = "~=3.11"
 # dependencies = [
 #     "vla-eval",
-#     "molmobot @ git+https://github.com/allenai/MolmoBot.git@33c0ca77bf6062a23d60ffd4a6859334c4a46d30#subdirectory=MolmoBot",
-#     "molmo-spaces @ git+https://github.com/allenai/molmospaces.git",
-#     "torch>=2.3.1",
-#     "transformers>=4.37.1",
-#     "huggingface_hub",
-#     "torchmetrics",
-#     "numpy",
+#     "molmobot",
+#     "torchmetrics",  # not declared in molmobot's deps but imported by olmo.models.model
 # ]
 #
 # [tool.uv.sources]
 # vla-eval = { path = "../../..", editable = true }
+# molmobot = { git = "https://github.com/allenai/MolmoBot.git", rev = "33c0ca77bf6062a23d60ffd4a6859334c4a46d30", subdirectory = "MolmoBot" }
+#
+# [tool.uv]
+# exclude-newer = "2026-05-08T00:00:00Z"
 # ///
 """MolmoBot model server (Molmo2-4B + DiT flow-matching).
 

--- a/src/vla_eval/model_servers/molmobot.py
+++ b/src/vla_eval/model_servers/molmobot.py
@@ -54,8 +54,6 @@ class MolmoBotModelServer(ModelServer):
         execute_horizon: Actions executed before re-querying the model.
         states_mode: Model config override (paper uses ``cross_attn``).
         max_joint_delta: Per-step safety clamp on arm joint deltas.
-        primary_image_key: Primary camera key in obs["images"].
-        wrist_image_key: Wrist camera key in obs["images"].
     """
 
     def __init__(
@@ -64,16 +62,12 @@ class MolmoBotModelServer(ModelServer):
         execute_horizon: int = 8,
         states_mode: str = "cross_attn",
         max_joint_delta: float = 0.2,
-        primary_image_key: str = "exo_camera_1",
-        wrist_image_key: str = "wrist_camera",
     ) -> None:
         super().__init__()
         self.hf_repo = hf_repo
         self.execute_horizon = execute_horizon
         self.states_mode = states_mode
         self.max_joint_delta = float(max_joint_delta)
-        self.primary_image_key = primary_image_key
-        self.wrist_image_key = wrist_image_key
 
         self._wrapper: Any = None
         self.n_obs_steps: int = 1
@@ -95,11 +89,13 @@ class MolmoBotModelServer(ModelServer):
         if not ok:
             raise FileNotFoundError(f"Model weights: {msg}")
 
+        from huggingface_hub import snapshot_download
         from olmo.models.molmobot.inference_wrapper import SynthManipMolmoInferenceWrapper
 
         logger.info("Loading MolmoBot from %s (states_mode=%s)", self.hf_repo, self.states_mode)
+        local_dir = snapshot_download(self.hf_repo)
         self._wrapper = SynthManipMolmoInferenceWrapper(
-            checkpoint_path=self.hf_repo,
+            checkpoint_path=local_dir,
             states_mode=self.states_mode,
         )
         mc = self._wrapper.model_config
@@ -153,15 +149,17 @@ class MolmoBotModelServer(ModelServer):
         )
 
         # Extract per-camera images from this step's observation.
+        # After spec mapping, images arrive in spec order (primary, wrist).
         images_dict = obs.get("images", {})
-        cam_obs: dict[str, np.ndarray] = {}
-        for cam_key in (self.primary_image_key, self.wrist_image_key):
-            img = images_dict.get(cam_key)
-            if img is None:
-                raise KeyError(
-                    f"MolmoBotModelServer: missing camera '{cam_key}' in obs. Available: {list(images_dict.keys())}"
-                )
-            cam_obs[cam_key] = np.asarray(img, dtype=np.uint8)
+        img_list = list(images_dict.values())
+        if len(img_list) < 2:
+            raise KeyError(
+                f"MolmoBotModelServer: expected 2 images, got {len(img_list)} (keys: {list(images_dict.keys())})"
+            )
+        cam_obs = {
+            "primary": np.asarray(img_list[0], dtype=np.uint8),
+            "wrist": np.asarray(img_list[1], dtype=np.uint8),
+        }
         state["obs_history"].append(cam_obs)
 
         # Refill action buffer if exhausted.
@@ -209,8 +207,8 @@ class MolmoBotModelServer(ModelServer):
         for i in range(self.n_obs_steps):
             frame_idx = current_step - (self.n_obs_steps - 1 - i) * self.obs_step_delta
             if 0 <= frame_idx < len(history):
-                primary_frames.append(history[frame_idx][self.primary_image_key])
-                wrist_frames.append(history[frame_idx][self.wrist_image_key])
+                primary_frames.append(history[frame_idx]["primary"])
+                wrist_frames.append(history[frame_idx]["wrist"])
 
         assert primary_frames, "No frames available for inference"
         images: list[np.ndarray] = [*primary_frames, *wrist_frames]

--- a/src/vla_eval/model_servers/pi0.py
+++ b/src/vla_eval/model_servers/pi0.py
@@ -4,8 +4,8 @@
 #     "vla-eval",
 #     "openpi",
 #     "numpy>=1.24",
-#     "pytest",
-#     "chex",
+#     "pytest",  # not declared in openpi's deps but imported by openpi.models_pytorch
+#     "chex",    # not declared in openpi's deps but imported by openpi.models
 # ]
 #
 # [tool.uv.sources]

--- a/src/vla_eval/model_servers/pi0.py
+++ b/src/vla_eval/model_servers/pi0.py
@@ -4,6 +4,8 @@
 #     "vla-eval",
 #     "openpi",
 #     "numpy>=1.24",
+#     "pytest",
+#     "chex",
 # ]
 #
 # [tool.uv.sources]

--- a/src/vla_eval/model_servers/pi0.py
+++ b/src/vla_eval/model_servers/pi0.py
@@ -4,8 +4,6 @@
 #     "vla-eval",
 #     "openpi",
 #     "numpy>=1.24",
-#     "pytest",
-#     "chex",
 # ]
 #
 # [tool.uv.sources]

--- a/src/vla_eval/model_servers/rtc.py
+++ b/src/vla_eval/model_servers/rtc.py
@@ -324,11 +324,6 @@ class RTCModelServer(PredictModelServer):
             raise RuntimeError("No model selected — on_episode_start must be called first")
 
         obs_vec = self._get_obs_with_history(obs, ctx)
-        if obs_vec.shape[-1] != self.obs_dim:
-            logger.warning("obs dim %d != expected %d, zero-padding", obs_vec.shape[-1], self.obs_dim)
-            padded = np.zeros(self.obs_dim, dtype=np.float32)
-            padded[: min(obs_vec.shape[-1], self.obs_dim)] = obs_vec[: self.obs_dim]
-            obs_vec = padded
 
         # Split the per-episode RNG so each step gets a unique key.
         # This makes the diffusion policy stochastic across episodes.

--- a/src/vla_eval/model_servers/rtc.py
+++ b/src/vla_eval/model_servers/rtc.py
@@ -268,6 +268,7 @@ class RTCModelServer(PredictModelServer):
         level = task.get("level")
         if level is None:
             level = next(iter(self._models))
+            logger.warning("No level in task config; falling back to %r", level)
 
         if level not in self._models:
             raise ValueError(f"No RTC model loaded for level={level!r}. Available: {list(self._models.keys())}")

--- a/src/vla_eval/model_servers/rtc.py
+++ b/src/vla_eval/model_servers/rtc.py
@@ -267,7 +267,7 @@ class RTCModelServer(PredictModelServer):
         task = config.get("task", {})
         level = task.get("level")
         if level is None:
-            raise ValueError("Task must have a 'level' field for RTC model selection")
+            level = next(iter(self._models))
 
         if level not in self._models:
             raise ValueError(f"No RTC model loaded for level={level!r}. Available: {list(self._models.keys())}")
@@ -324,6 +324,11 @@ class RTCModelServer(PredictModelServer):
             raise RuntimeError("No model selected — on_episode_start must be called first")
 
         obs_vec = self._get_obs_with_history(obs, ctx)
+        if obs_vec.shape[-1] != self.obs_dim:
+            logger.warning("obs dim %d != expected %d, zero-padding", obs_vec.shape[-1], self.obs_dim)
+            padded = np.zeros(self.obs_dim, dtype=np.float32)
+            padded[: min(obs_vec.shape[-1], self.obs_dim)] = obs_vec[: self.obs_dim]
+            obs_vec = padded
 
         # Split the per-episode RNG so each step gets a unique key.
         # This makes the diffusion policy stochastic across episodes.

--- a/src/vla_eval/model_servers/starvla.py
+++ b/src/vla_eval/model_servers/starvla.py
@@ -182,11 +182,9 @@ class StarVLAModelServer(PredictModelServer):
         via ``huggingface_hub.snapshot_download``.  The first checkpoint
         file found under the ``checkpoints/`` sub-directory is returned.
         """
-        from vla_eval.dirs import check_model_available
+        from vla_eval.dirs import require_model_available
 
-        ok, msg = check_model_available(checkpoint)
-        if not ok:
-            raise FileNotFoundError(f"Model weights: {msg}")
+        require_model_available(checkpoint)
 
         path = Path(checkpoint)
         if path.is_file() and path.suffix in (".pt", ".safetensors"):

--- a/src/vla_eval/model_servers/starvla.py
+++ b/src/vla_eval/model_servers/starvla.py
@@ -182,6 +182,12 @@ class StarVLAModelServer(PredictModelServer):
         via ``huggingface_hub.snapshot_download``.  The first checkpoint
         file found under the ``checkpoints/`` sub-directory is returned.
         """
+        from vla_eval.dirs import check_model_available
+
+        ok, msg = check_model_available(checkpoint)
+        if not ok:
+            raise FileNotFoundError(f"Model weights: {msg}")
+
         path = Path(checkpoint)
         if path.is_file() and path.suffix in (".pt", ".safetensors"):
             return str(path)

--- a/src/vla_eval/model_servers/starvla.py
+++ b/src/vla_eval/model_servers/starvla.py
@@ -27,7 +27,7 @@
 # starvla = { git = "https://github.com/starVLA/starVLA.git", rev = "eaa51c4c2f4012d42f1036ee318d41942e8f97a3" }
 #
 # [tool.uv]
-# exclude-newer = "2026-02-24T00:00:00Z"
+# exclude-newer = "2026-05-08T00:00:00Z"
 # ///
 """starVLA model server — supports all Qwen* frameworks.
 

--- a/src/vla_eval/model_servers/vlanext.py
+++ b/src/vla_eval/model_servers/vlanext.py
@@ -204,11 +204,9 @@ class VLANeXtModelServer(PredictModelServer):
         via ``huggingface_hub.snapshot_download``.  The checkpoint file
         matching *suite* is returned.
         """
-        from vla_eval.dirs import check_model_available
+        from vla_eval.dirs import require_model_available
 
-        ok, msg = check_model_available(checkpoint)
-        if not ok:
-            raise FileNotFoundError(f"Model weights: {msg}")
+        require_model_available(checkpoint)
 
         path = Path(checkpoint)
         if path.is_file() and path.suffix == ".pt":

--- a/src/vla_eval/model_servers/vlanext.py
+++ b/src/vla_eval/model_servers/vlanext.py
@@ -204,6 +204,12 @@ class VLANeXtModelServer(PredictModelServer):
         via ``huggingface_hub.snapshot_download``.  The checkpoint file
         matching *suite* is returned.
         """
+        from vla_eval.dirs import check_model_available
+
+        ok, msg = check_model_available(checkpoint)
+        if not ok:
+            raise FileNotFoundError(f"Model weights: {msg}")
+
         path = Path(checkpoint)
         if path.is_file() and path.suffix == ".pt":
             return str(path)

--- a/src/vla_eval/orchestrator.py
+++ b/src/vla_eval/orchestrator.py
@@ -72,7 +72,7 @@ class Orchestrator:
 
     @property
     def _output_dir(self) -> Path:
-        d = Path(self.config.get("output_dir", "./results"))
+        d = Path(self.config.get("output_dir", "./results")).resolve()
         d.mkdir(parents=True, exist_ok=True)
         return d
 


### PR DESCRIPTION
## Summary

Improve model server dependency management, smoke test reliability, and add model weight availability checking infrastructure.

### Dependency improvements
- **molmobot**: move git dep from PEP 508 direct URL to `[tool.uv.sources]` (fixes uv cache corruption with `#subdirectory=`), remove unused deps, add `exclude-newer`, use `snapshot_download` for path resolution, access images by position (spec order) instead of benchmark-specific keys
- **pi0/mme_vla**: annotate `pytest`/`chex` as missing upstream openpi deps
- **mme_vla**: pin openpi `rev` to commit hash instead of `\"main\"`
- **behavior1k_baseline/demo_replay**: add `exclude-newer`
- **starvla**: update `exclude-newer` to `2026-05-08` (fixes CUDA driver compat)
- **cogact**: set `TF_CPP_MIN_LOG_LEVEL=2` to prevent TF GPU init hang (transitive dep)

### Model weight availability check (`dirs.py`)
- Add `is_hf_cached()` and `check_model_available()` utilities — same pattern as `ensure_license()`
- Model servers call `check_model_available()` in `_load_model()` / `_resolve_checkpoint()` for fast fail with download instructions
- Applied to: molmobot, groot, starvla, vlanext, mme_vla

### Smoke test infrastructure
- **rtc**: default level selection for smoke test compat
- **cli**: increase smoke test timeout 300s -> 600s
- **orchestrator**: resolve `output_dir` to absolute path (Docker fix)
- **Dockerfile.robotwin**: pin curobo to `v0.7.8`

### Other
- **docker/build.sh, push.sh**: add `--help` / `-h` flag

## Smoke test results

`CUDA_VISIBLE_DEVICES=1 UV_CACHE_DIR=/tmp/cache/uv uv run vla-eval test --all --timeout 600`

### Server (15 pass / 1 fail)

| Server | Status | Time | Notes |
|--------|--------|------|-------|
| behavior1k | Pass | 1s | |
| cogact | Pass | 518s | |
| db_cogact | Pass | 240s | |
| groot | Pass | 108s | |
| mme_vla | Pass | 136s | |
| molmobot | Pass | 42s | |
| oft | Pass | 229s | |
| openvla | Pass | 219s | |
| pi0 | Pass | 142s | |
| rtc | **Fail** | 1s | local checkpoint not available (no public weights) |
| starvla_groot | Pass | 256s | |
| starvla_oft | Pass | 233s | |
| starvla_pi | Pass | 180s | |
| starvla_fast | Pass | 142s | |
| vlanext | Pass | 326s | |
| xvla | Pass | 77s | |

### Benchmark (17 pass / 0 fail)

| Benchmark | Status | Time |
|-----------|--------|------|
| calvin | Pass | 24s |
| kinetix | Pass | 41s |
| libero | Pass | 27s |
| libero_mem | Pass | 26s |
| libero_plus | Pass | 33s |
| libero_pro | Pass | 29s |
| maniskill2 | Pass | 17s |
| mikasa | Pass | 20s |
| molmospaces | Pass | 18s |
| rlbench | Pass | 5s |
| robocasa | Pass | 34s |
| robocerebra | Pass | 22s |
| robomme | Pass | 48s |
| robotwin | Pass | 56s |
| simpler | Pass | 64s |
| vlabench | Pass | 39s |
| vlanext | Pass | 28s |

### Validate
- Pass: 155/155 configs valid

Generated with [Claude Code](https://claude.com/claude-code)