### PR TITLE
feat(docker): add ROCm GPU runtime support

### DIFF
--- a/experiments/bench_demand.py
+++ b/experiments/bench_demand.py
@@ -40,6 +40,7 @@ import numpy as np
 import yaml
 from tqdm import tqdm
 
+from vla_eval.docker_resources import _detect_runtime
 from vla_eval.model_servers.base import SessionContext
 from vla_eval.model_servers.predict import PredictModelServer
 from vla_eval.model_servers.serve import serve_async
@@ -135,8 +136,6 @@ class ResourceMonitor:
 
     @staticmethod
     def _gpu_stats() -> dict[str, float]:
-        from vla_eval.docker_resources import _detect_runtime
-
         if _detect_runtime() == "rocm":
             return ResourceMonitor._rocm_gpu_stats()
         return ResourceMonitor._nvidia_gpu_stats()

--- a/experiments/bench_demand.py
+++ b/experiments/bench_demand.py
@@ -24,7 +24,9 @@ from __future__ import annotations
 
 import argparse
 import copy
+import json
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -133,6 +135,18 @@ class ResourceMonitor:
 
     @staticmethod
     def _gpu_stats() -> dict[str, float]:
+        from vla_eval.docker_resources import _detect_runtime
+
+        if _detect_runtime() == "rocm":
+            return ResourceMonitor._rocm_gpu_stats()
+        return ResourceMonitor._nvidia_gpu_stats()
+
+    @staticmethod
+    def _zero_gpu_stats() -> dict[str, float]:
+        return {"gpu_util_pct": 0.0, "gpu_mem_used_gb": 0.0, "gpu_mem_total_gb": 0.0}
+
+    @staticmethod
+    def _nvidia_gpu_stats() -> dict[str, float]:
         try:
             out = subprocess.check_output(
                 [
@@ -157,7 +171,72 @@ class ResourceMonitor:
                 "gpu_mem_total_gb": round(total_mem / 1024, 1),
             }
         except Exception:
-            return {"gpu_util_pct": 0.0, "gpu_mem_used_gb": 0.0, "gpu_mem_total_gb": 0.0}
+            return ResourceMonitor._zero_gpu_stats()
+
+    @staticmethod
+    def _rocm_gpu_stats() -> dict[str, float]:
+        try:
+            out = subprocess.check_output(
+                [
+                    "rocm-smi",
+                    "--showuse",
+                    "--showmemuse",
+                    "--showmeminfo",
+                    "vram",
+                    "--json",
+                ],
+                text=True,
+                timeout=5,
+            )
+            data = json.loads(out)
+            max_util = 0.0
+            total_mem_used = 0.0
+            total_mem = 0.0
+            for stats in data.values():
+                if not isinstance(stats, dict):
+                    continue
+                util, mem_used, mem_total = ResourceMonitor._parse_rocm_card_stats(stats)
+                max_util = max(max_util, util)
+                total_mem_used += mem_used
+                total_mem += mem_total
+            return {
+                "gpu_util_pct": round(max_util, 1),
+                "gpu_mem_used_gb": round(total_mem_used, 1),
+                "gpu_mem_total_gb": round(total_mem, 1),
+            }
+        except Exception:
+            return ResourceMonitor._zero_gpu_stats()
+
+    @staticmethod
+    def _parse_rocm_card_stats(stats: dict[str, Any]) -> tuple[float, float, float]:
+        util = 0.0
+        mem_used_gb = 0.0
+        mem_total_gb = 0.0
+        for key, value in stats.items():
+            key_lower = key.lower()
+            if "gpu use" in key_lower:
+                util = ResourceMonitor._parse_float(value)
+            elif "vram" in key_lower and "memory" in key_lower and "used" in key_lower and "%" not in key_lower:
+                mem_used_gb = ResourceMonitor._memory_value_to_gb(value, key_lower)
+            elif "vram" in key_lower and "memory" in key_lower and "total" in key_lower and "%" not in key_lower:
+                mem_total_gb = ResourceMonitor._memory_value_to_gb(value, key_lower)
+        return util, mem_used_gb, mem_total_gb
+
+    @staticmethod
+    def _parse_float(value: Any) -> float:
+        match = re.search(r"-?\d+(?:\.\d+)?", str(value).replace(",", ""))
+        if match is None:
+            return 0.0
+        return float(match.group(0))
+
+    @staticmethod
+    def _memory_value_to_gb(value: Any, key_lower: str) -> float:
+        amount = ResourceMonitor._parse_float(value)
+        if "(b)" in key_lower or key_lower.endswith(" b"):
+            return amount / 1073741824
+        if "mib" in key_lower or "mb" in key_lower:
+            return amount / 1024
+        return amount
 
 
 # ---------------------------------------------------------------------------

--- a/experiments/bench_demand.py
+++ b/experiments/bench_demand.py
@@ -224,7 +224,7 @@ class ResourceMonitor:
 
     @staticmethod
     def _parse_float(value: Any) -> float:
-        match = re.search(r"-?\d+(?:\.\d+)?", str(value).replace(",", ""))
+        match = re.search(r"-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?", str(value).replace(",", ""))
         if match is None:
             return 0.0
         return float(match.group(0))

--- a/src/vla_eval/cli/main.py
+++ b/src/vla_eval/cli/main.py
@@ -526,7 +526,7 @@ def cmd_test(args: argparse.Namespace) -> None:
     # --- resolve parallelism ---
     gpu_queue: queue.Queue[str] | None = None
     if args.parallel is not None:
-        gpu_ids = parse_gpus(None)  # auto-detect via nvidia-smi
+        gpu_ids = parse_gpus(None)  # auto-detect via the active GPU runtime
         if args.parallel == "auto":
             workers = len(gpu_ids)
         else:

--- a/src/vla_eval/cli/smoke.py
+++ b/src/vla_eval/cli/smoke.py
@@ -415,7 +415,10 @@ def run_server_test(test: SmokeTest, timeout: int, *, gpu_id: str | None = None)
     captured_stderr: list[bytes] = []  # shared with _run() closure
 
     async def _run() -> dict:
-        env = {**os.environ, "CUDA_VISIBLE_DEVICES": gpu_id} if gpu_id is not None else None
+        from vla_eval.docker_resources import gpu_visibility_env
+
+        visibility = gpu_visibility_env(gpu_id)
+        env = {**os.environ, **visibility} if visibility else None
         proc = await anyio.open_process(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, env=env)
 
         async def _drain_stderr() -> None:

--- a/src/vla_eval/docker_resources.py
+++ b/src/vla_eval/docker_resources.py
@@ -58,6 +58,8 @@ def parse_cpus(spec: str | None) -> list[int]:
 @lru_cache(maxsize=1)
 def _detect_runtime() -> GpuRuntime:
     """Detect the host GPU runtime used for Docker device forwarding."""
+    if not os.path.exists("/dev/kfd"):
+        return "nvidia"
     try:
         subprocess.check_output(["rocm-smi", "--showid"], text=True, stderr=subprocess.DEVNULL, timeout=5)
         return "rocm"
@@ -74,7 +76,7 @@ def _detect_gpu_ids_nvidia() -> list[str]:
             stderr=subprocess.DEVNULL,
         )
         return [idx.strip() for idx in out.strip().splitlines() if idx.strip()]
-    except (FileNotFoundError, subprocess.CalledProcessError):
+    except (OSError, subprocess.CalledProcessError):
         return ["0"]
 
 
@@ -171,14 +173,9 @@ def shard_docker_flags(
     flags: list[str] = []
 
     # GPU: round-robin across available devices
-    runtime = _detect_runtime()
     gpu_list = parse_gpus(gpus)
     device = gpu_list[shard_id % len(gpu_list)]
-    if runtime == "rocm":
-        flags.extend(_ROCM_DEVICE_FLAGS)
-        flags.extend(["-e", f"HIP_VISIBLE_DEVICES={device}"])
-    else:
-        flags.extend(["--gpus", f"device={device}"])
+    flags.extend(gpu_docker_flag(device))
 
     # CPU: partition available cores across shards
     cpu_ids = parse_cpus(cpus)

--- a/src/vla_eval/docker_resources.py
+++ b/src/vla_eval/docker_resources.py
@@ -16,7 +16,7 @@ from typing import Literal
 
 GpuRuntime = Literal["nvidia", "rocm"]
 
-_ROCM_DEVICE_FLAGS = ["--device=/dev/kfd", "--device=/dev/dri", "--group-add", "video"]
+_ROCM_DEVICE_FLAGS = ("--device=/dev/kfd", "--device=/dev/dri", "--group-add", "video")
 
 
 def _format_cpuset(cpu_ids: list[int]) -> str:
@@ -166,9 +166,8 @@ def shard_docker_flags(
         gpus: GPU spec (e.g. ``"0,1"`` or ``"all"``).  ``None`` = ``"all"``.
 
     Returns:
-        Flag list to extend a ``docker run`` command, e.g.
-        ``["--gpus", "device=0", "--cpuset-cpus", "0-5",
-          "-e", "OMP_NUM_THREADS=1", "-e", "MKL_NUM_THREADS=1"]``.
+        Flag list to extend a ``docker run`` command.  GPU flags are
+        runtime-dependent (delegated to :func:`gpu_docker_flag`).
     """
     flags: list[str] = []
 

--- a/src/vla_eval/docker_resources.py
+++ b/src/vla_eval/docker_resources.py
@@ -8,7 +8,15 @@ and CPU resources across parallel shard containers.
 from __future__ import annotations
 
 import os
+import re
 import subprocess
+from functools import lru_cache
+from glob import glob
+from typing import Literal
+
+GpuRuntime = Literal["nvidia", "rocm"]
+
+_ROCM_DEVICE_FLAGS = ["--device=/dev/kfd", "--device=/dev/dri", "--group-add", "video"]
 
 
 def _format_cpuset(cpu_ids: list[int]) -> str:
@@ -47,7 +55,17 @@ def parse_cpus(spec: str | None) -> list[int]:
     return sorted(set(cpus))
 
 
-def _detect_gpu_ids() -> list[str]:
+@lru_cache(maxsize=1)
+def _detect_runtime() -> GpuRuntime:
+    """Detect the host GPU runtime used for Docker device forwarding."""
+    try:
+        subprocess.check_output(["rocm-smi", "--showid"], text=True, stderr=subprocess.DEVNULL, timeout=5)
+        return "rocm"
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return "nvidia"
+
+
+def _detect_gpu_ids_nvidia() -> list[str]:
     """Query nvidia-smi for available GPU indices."""
     try:
         out = subprocess.check_output(
@@ -60,10 +78,31 @@ def _detect_gpu_ids() -> list[str]:
         return ["0"]
 
 
+def _detect_gpu_ids_rocm() -> list[str]:
+    """Query rocm-smi for GPU indices, falling back to render-node count."""
+    try:
+        out = subprocess.check_output(["rocm-smi", "--showid"], text=True, stderr=subprocess.DEVNULL, timeout=5)
+        ids = list(dict.fromkeys(m.group(1) for m in re.finditer(r"GPU\[(\d+)\]", out)))
+        if ids:
+            return ids
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        pass
+
+    render_nodes = sorted(glob("/dev/dri/renderD*"))
+    return [str(i) for i, _ in enumerate(render_nodes)] or ["0"]
+
+
+def _detect_gpu_ids() -> list[str]:
+    """Query the active GPU runtime for available GPU indices."""
+    if _detect_runtime() == "rocm":
+        return _detect_gpu_ids_rocm()
+    return _detect_gpu_ids_nvidia()
+
+
 def parse_gpus(spec: str | None) -> list[str]:
     """Parse GPU spec into list of device IDs.
 
-    ``None`` or ``"all"`` enumerates GPUs via nvidia-smi.
+    ``None`` or ``"all"`` enumerates GPUs via the active runtime.
     ``"0,1"`` returns ``["0", "1"]``.
     """
     if spec is None or spec.strip().lower() == "all":
@@ -72,10 +111,26 @@ def parse_gpus(spec: str | None) -> list[str]:
 
 
 def gpu_docker_flag(spec: str | None) -> list[str]:
-    """Return ``--gpus`` flag pair for a single (non-sharded) container."""
+    """Return GPU device flags for a single (non-sharded) container."""
+    runtime = _detect_runtime()
+    if runtime == "rocm":
+        flags = list(_ROCM_DEVICE_FLAGS)
+        if spec is None or spec.strip().lower() == "all":
+            # ROCm treats missing HIP_VISIBLE_DEVICES as "all visible devices".
+            return flags
+        flags.extend(["-e", f"HIP_VISIBLE_DEVICES={spec}"])
+        return flags
     if spec is None or spec.strip().lower() == "all":
         return ["--gpus", "all"]
     return ["--gpus", f"device={spec}"]
+
+
+def gpu_visibility_env(gpu_id: str | None) -> dict[str, str]:
+    """Return host-side GPU visibility env vars for one worker."""
+    if gpu_id is None:
+        return {}
+    key = "HIP_VISIBLE_DEVICES" if _detect_runtime() == "rocm" else "CUDA_VISIBLE_DEVICES"
+    return {key: gpu_id}
 
 
 def tty_docker_flags() -> list[str]:
@@ -116,9 +171,14 @@ def shard_docker_flags(
     flags: list[str] = []
 
     # GPU: round-robin across available devices
+    runtime = _detect_runtime()
     gpu_list = parse_gpus(gpus)
     device = gpu_list[shard_id % len(gpu_list)]
-    flags.extend(["--gpus", f"device={device}"])
+    if runtime == "rocm":
+        flags.extend(_ROCM_DEVICE_FLAGS)
+        flags.extend(["-e", f"HIP_VISIBLE_DEVICES={device}"])
+    else:
+        flags.extend(["--gpus", f"device={device}"])
 
     # CPU: partition available cores across shards
     cpu_ids = parse_cpus(cpus)

--- a/tests/test_bench_demand.py
+++ b/tests/test_bench_demand.py
@@ -7,7 +7,7 @@ from experiments.bench_demand import ResourceMonitor
 
 
 class TestResourceMonitorGpuStats:
-    @patch("vla_eval.docker_resources._detect_runtime", return_value="nvidia")
+    @patch("experiments.bench_demand._detect_runtime", return_value="nvidia")
     @patch(
         "experiments.bench_demand.subprocess.check_output",
         return_value="10, 1024, 8192\n75, 2048, 8192\n",
@@ -19,7 +19,7 @@ class TestResourceMonitorGpuStats:
             "gpu_mem_total_gb": 16.0,
         }
 
-    @patch("vla_eval.docker_resources._detect_runtime", return_value="rocm")
+    @patch("experiments.bench_demand._detect_runtime", return_value="rocm")
     @patch(
         "experiments.bench_demand.subprocess.check_output",
         return_value=json.dumps(
@@ -44,7 +44,7 @@ class TestResourceMonitorGpuStats:
             "gpu_mem_total_gb": 48.0,
         }
 
-    @patch("vla_eval.docker_resources._detect_runtime", return_value="rocm")
+    @patch("experiments.bench_demand._detect_runtime", return_value="rocm")
     @patch("experiments.bench_demand.subprocess.check_output", side_effect=FileNotFoundError)
     def test_rocm_gpu_stats_falls_back_to_zero(self, _check_output_mock, _runtime_mock):
         assert ResourceMonitor._gpu_stats() == {

--- a/tests/test_bench_demand.py
+++ b/tests/test_bench_demand.py
@@ -1,0 +1,63 @@
+"""Tests for demand-benchmark resource monitoring helpers."""
+
+import json
+from unittest.mock import patch
+
+from experiments.bench_demand import ResourceMonitor
+
+
+class TestResourceMonitorGpuStats:
+    @patch("vla_eval.docker_resources._detect_runtime", return_value="nvidia")
+    @patch(
+        "experiments.bench_demand.subprocess.check_output",
+        return_value="10, 1024, 8192\n75, 2048, 8192\n",
+    )
+    def test_nvidia_gpu_stats(self, _check_output_mock, _runtime_mock):
+        assert ResourceMonitor._gpu_stats() == {
+            "gpu_util_pct": 75.0,
+            "gpu_mem_used_gb": 3.0,
+            "gpu_mem_total_gb": 16.0,
+        }
+
+    @patch("vla_eval.docker_resources._detect_runtime", return_value="rocm")
+    @patch(
+        "experiments.bench_demand.subprocess.check_output",
+        return_value=json.dumps(
+            {
+                "card0": {
+                    "GPU use (%)": "15%",
+                    "VRAM Total Memory (B)": str(16 * 1024**3),
+                    "VRAM Total Used Memory (B)": str(2 * 1024**3),
+                },
+                "card1": {
+                    "GPU use (%)": "80%",
+                    "VRAM Total Memory (B)": str(32 * 1024**3),
+                    "VRAM Total Used Memory (B)": str(int(3.5 * 1024**3)),
+                },
+            }
+        ),
+    )
+    def test_rocm_gpu_stats(self, _check_output_mock, _runtime_mock):
+        assert ResourceMonitor._gpu_stats() == {
+            "gpu_util_pct": 80.0,
+            "gpu_mem_used_gb": 5.5,
+            "gpu_mem_total_gb": 48.0,
+        }
+
+    @patch("vla_eval.docker_resources._detect_runtime", return_value="rocm")
+    @patch("experiments.bench_demand.subprocess.check_output", side_effect=FileNotFoundError)
+    def test_rocm_gpu_stats_falls_back_to_zero(self, _check_output_mock, _runtime_mock):
+        assert ResourceMonitor._gpu_stats() == {
+            "gpu_util_pct": 0.0,
+            "gpu_mem_used_gb": 0.0,
+            "gpu_mem_total_gb": 0.0,
+        }
+
+    def test_rocm_parser_handles_mib_values(self):
+        assert ResourceMonitor._parse_rocm_card_stats(
+            {
+                "GPU use (%)": "42%",
+                "VRAM Total Memory (MiB)": "65536",
+                "VRAM Total Used Memory (MiB)": "12288",
+            }
+        ) == (42.0, 12.0, 64.0)

--- a/tests/test_docker_resources.py
+++ b/tests/test_docker_resources.py
@@ -104,13 +104,15 @@ class TestDetectRuntime:
         assert _detect_runtime() == "rocm"
         assert mock_check_output.call_count == 1
 
+    @patch("vla_eval.docker_resources.os.path.exists", return_value=True)
     @patch("vla_eval.docker_resources.subprocess.check_output", side_effect=FileNotFoundError)
-    def test_defaults_to_nvidia_when_rocm_smi_missing(self, _mock):
+    def test_defaults_to_nvidia_when_rocm_smi_missing(self, _mock, _exists_mock):
         _detect_runtime.cache_clear()
         assert _detect_runtime() == "nvidia"
 
+    @patch("vla_eval.docker_resources.os.path.exists", return_value=True)
     @patch("vla_eval.docker_resources.subprocess.check_output", side_effect=PermissionError)
-    def test_defaults_to_nvidia_when_rocm_smi_is_not_executable(self, _mock):
+    def test_defaults_to_nvidia_when_rocm_smi_is_not_executable(self, _mock, _exists_mock):
         _detect_runtime.cache_clear()
         assert _detect_runtime() == "nvidia"
 

--- a/tests/test_docker_resources.py
+++ b/tests/test_docker_resources.py
@@ -90,13 +90,15 @@ class TestDetectRuntime:
     def teardown_method(self):
         _detect_runtime.cache_clear()
 
+    @patch("vla_eval.docker_resources.os.path.exists", return_value=True)
     @patch("vla_eval.docker_resources.subprocess.check_output", return_value="")
-    def test_detects_rocm_when_rocm_smi_succeeds(self, _mock):
+    def test_detects_rocm_when_rocm_smi_succeeds(self, _mock, _exists_mock):
         _detect_runtime.cache_clear()
         assert _detect_runtime() == "rocm"
 
+    @patch("vla_eval.docker_resources.os.path.exists", return_value=True)
     @patch("vla_eval.docker_resources.subprocess.check_output", return_value="")
-    def test_detection_is_cached(self, mock_check_output):
+    def test_detection_is_cached(self, mock_check_output, _exists_mock):
         _detect_runtime.cache_clear()
         assert _detect_runtime() == "rocm"
         assert _detect_runtime() == "rocm"
@@ -109,6 +111,11 @@ class TestDetectRuntime:
 
     @patch("vla_eval.docker_resources.subprocess.check_output", side_effect=PermissionError)
     def test_defaults_to_nvidia_when_rocm_smi_is_not_executable(self, _mock):
+        _detect_runtime.cache_clear()
+        assert _detect_runtime() == "nvidia"
+
+    @patch("vla_eval.docker_resources.os.path.exists", return_value=False)
+    def test_defaults_to_nvidia_when_dev_kfd_missing(self, _exists_mock):
         _detect_runtime.cache_clear()
         assert _detect_runtime() == "nvidia"
 

--- a/tests/test_docker_resources.py
+++ b/tests/test_docker_resources.py
@@ -3,8 +3,11 @@
 from unittest.mock import patch
 
 from vla_eval.docker_resources import (
+    _detect_gpu_ids_rocm,
+    _detect_runtime,
     _format_cpuset,
     gpu_docker_flag,
+    gpu_visibility_env,
     parse_cpus,
     parse_gpus,
     shard_docker_flags,
@@ -79,22 +82,123 @@ class TestParseGpus:
 
 
 # ---------------------------------------------------------------------------
+# runtime detection
+# ---------------------------------------------------------------------------
+
+
+class TestDetectRuntime:
+    def teardown_method(self):
+        _detect_runtime.cache_clear()
+
+    @patch("vla_eval.docker_resources.subprocess.check_output", return_value="")
+    def test_detects_rocm_when_rocm_smi_succeeds(self, _mock):
+        _detect_runtime.cache_clear()
+        assert _detect_runtime() == "rocm"
+
+    @patch("vla_eval.docker_resources.subprocess.check_output", return_value="")
+    def test_detection_is_cached(self, mock_check_output):
+        _detect_runtime.cache_clear()
+        assert _detect_runtime() == "rocm"
+        assert _detect_runtime() == "rocm"
+        assert mock_check_output.call_count == 1
+
+    @patch("vla_eval.docker_resources.subprocess.check_output", side_effect=FileNotFoundError)
+    def test_defaults_to_nvidia_when_rocm_smi_missing(self, _mock):
+        _detect_runtime.cache_clear()
+        assert _detect_runtime() == "nvidia"
+
+    @patch("vla_eval.docker_resources.subprocess.check_output", side_effect=PermissionError)
+    def test_defaults_to_nvidia_when_rocm_smi_is_not_executable(self, _mock):
+        _detect_runtime.cache_clear()
+        assert _detect_runtime() == "nvidia"
+
+
+class TestDetectRocmGpuIds:
+    @patch(
+        "vla_eval.docker_resources.subprocess.check_output",
+        return_value="GPU[0] : GPU ID: 0x740f\nGPU[1] : GPU ID: 0x740f\n",
+    )
+    def test_parses_rocm_smi_gpu_indices(self, _mock):
+        assert _detect_gpu_ids_rocm() == ["0", "1"]
+
+    @patch(
+        "vla_eval.docker_resources.subprocess.check_output",
+        return_value="GPU[0] : GPU ID: 0x740f\nGPU[0] : Unique ID: 0xabc\nGPU[1] : GPU ID: 0x740f\n",
+    )
+    def test_deduplicates_rocm_smi_gpu_indices(self, _mock):
+        assert _detect_gpu_ids_rocm() == ["0", "1"]
+
+    @patch("vla_eval.docker_resources.glob", return_value=["/dev/dri/renderD128", "/dev/dri/renderD129"])
+    @patch("vla_eval.docker_resources.subprocess.check_output", side_effect=FileNotFoundError)
+    def test_falls_back_to_render_node_count(self, _subprocess_mock, _glob_mock):
+        assert _detect_gpu_ids_rocm() == ["0", "1"]
+
+    @patch("vla_eval.docker_resources.glob", return_value=[])
+    @patch("vla_eval.docker_resources.subprocess.check_output", side_effect=FileNotFoundError)
+    def test_falls_back_to_zero_when_no_rocm_query_works(self, _subprocess_mock, _glob_mock):
+        assert _detect_gpu_ids_rocm() == ["0"]
+
+
+# ---------------------------------------------------------------------------
 # gpu_docker_flag
 # ---------------------------------------------------------------------------
 
 
 class TestGpuDockerFlag:
-    def test_none(self):
+    @patch("vla_eval.docker_resources._detect_runtime", return_value="nvidia")
+    def test_none(self, _runtime_mock):
         assert gpu_docker_flag(None) == ["--gpus", "all"]
 
-    def test_all(self):
+    @patch("vla_eval.docker_resources._detect_runtime", return_value="nvidia")
+    def test_all(self, _runtime_mock):
         assert gpu_docker_flag("all") == ["--gpus", "all"]
 
-    def test_specific(self):
+    @patch("vla_eval.docker_resources._detect_runtime", return_value="nvidia")
+    def test_specific(self, _runtime_mock):
         assert gpu_docker_flag("0") == ["--gpus", "device=0"]
 
-    def test_multi(self):
+    @patch("vla_eval.docker_resources._detect_runtime", return_value="nvidia")
+    def test_multi(self, _runtime_mock):
         assert gpu_docker_flag("0,1") == ["--gpus", "device=0,1"]
+
+
+class TestRocmGpuDockerFlag:
+    @patch("vla_eval.docker_resources._detect_runtime", return_value="rocm")
+    def test_none_leaves_all_rocm_devices_visible(self, _runtime_mock):
+        flags = gpu_docker_flag(None)
+        assert flags == ["--device=/dev/kfd", "--device=/dev/dri", "--group-add", "video"]
+        assert "--ipc=host" not in flags
+        assert "--security-opt" not in flags
+
+    @patch("vla_eval.docker_resources._detect_runtime", return_value="rocm")
+    def test_all_leaves_all_rocm_devices_visible(self, _runtime_mock):
+        flags = gpu_docker_flag("all")
+        assert flags == ["--device=/dev/kfd", "--device=/dev/dri", "--group-add", "video"]
+
+    @patch("vla_eval.docker_resources._detect_runtime", return_value="rocm")
+    def test_specific_sets_hip_visible_devices(self, _runtime_mock):
+        flags = gpu_docker_flag("0,1")
+        assert flags == [
+            "--device=/dev/kfd",
+            "--device=/dev/dri",
+            "--group-add",
+            "video",
+            "-e",
+            "HIP_VISIBLE_DEVICES=0,1",
+        ]
+
+
+class TestGpuVisibilityEnv:
+    def test_none(self):
+        assert gpu_visibility_env(None) == {}
+
+    @patch("vla_eval.docker_resources._detect_runtime", return_value="nvidia")
+    def test_nvidia_uses_cuda_visible_devices(self, _runtime_mock):
+        assert gpu_visibility_env("1") == {"CUDA_VISIBLE_DEVICES": "1"}
+
+    @patch("vla_eval.docker_resources._detect_runtime", return_value="rocm")
+    def test_rocm_uses_hip_visible_devices(self, _runtime_mock):
+        assert gpu_visibility_env("1") == {"HIP_VISIBLE_DEVICES": "1"}
 
 
 # ---------------------------------------------------------------------------
@@ -103,8 +207,9 @@ class TestGpuDockerFlag:
 
 
 class TestShardDockerFlags:
+    @patch("vla_eval.docker_resources._detect_runtime", return_value="nvidia")
     @patch("vla_eval.docker_resources._detect_gpu_ids", return_value=["0", "1"])
-    def test_single_shard_all_gpus(self, _mock):
+    def test_single_shard_all_gpus(self, _gpu_mock, _runtime_mock):
         flags = shard_docker_flags(0, 1, gpus="all")
         assert "--gpus" in flags
         idx = flags.index("--gpus")
@@ -115,9 +220,10 @@ class TestShardDockerFlags:
         assert "OMP_NUM_THREADS=1" in flags
         assert "MKL_NUM_THREADS=1" in flags
 
+    @patch("vla_eval.docker_resources._detect_runtime", return_value="nvidia")
     @patch("vla_eval.docker_resources._detect_gpu_ids", return_value=["0"])
     @patch("vla_eval.docker_resources.os.cpu_count", return_value=16)
-    def test_multi_shard_cpu_partition(self, _cpu_mock, _gpu_mock):
+    def test_multi_shard_cpu_partition(self, _cpu_mock, _gpu_mock, _runtime_mock):
         flags = shard_docker_flags(0, 4)
         assert "--cpuset-cpus" in flags
         idx = flags.index("--cpuset-cpus")
@@ -131,7 +237,8 @@ class TestShardDockerFlags:
         idx = flags3.index("--cpuset-cpus")
         assert flags3[idx + 1] == "12-15"
 
-    def test_gpu_round_robin(self):
+    @patch("vla_eval.docker_resources._detect_runtime", return_value="nvidia")
+    def test_gpu_round_robin(self, _runtime_mock):
         flags0 = shard_docker_flags(0, 4, gpus="0,1")
         flags1 = shard_docker_flags(1, 4, gpus="0,1")
         flags2 = shard_docker_flags(2, 4, gpus="0,1")
@@ -145,7 +252,9 @@ class TestShardDockerFlags:
         assert _gpu(flags2) == "device=0"
         assert _gpu(flags3) == "device=1"
 
-    def test_explicit_cpu_range(self):
+    @patch("vla_eval.docker_resources._detect_runtime", return_value="nvidia")
+    @patch("vla_eval.docker_resources._detect_gpu_ids", return_value=["0"])
+    def test_explicit_cpu_range(self, _gpu_mock, _runtime_mock):
         flags = shard_docker_flags(0, 2, cpus="8-15")
         idx = flags.index("--cpuset-cpus")
         assert flags[idx + 1] == "8-11"
@@ -154,7 +263,9 @@ class TestShardDockerFlags:
         idx = flags1.index("--cpuset-cpus")
         assert flags1[idx + 1] == "12-15"
 
-    def test_non_contiguous_cpu_range(self):
+    @patch("vla_eval.docker_resources._detect_runtime", return_value="nvidia")
+    @patch("vla_eval.docker_resources._detect_gpu_ids", return_value=["0"])
+    def test_non_contiguous_cpu_range(self, _gpu_mock, _runtime_mock):
         flags = shard_docker_flags(0, 2, cpus="0-2,12-14")
         idx = flags.index("--cpuset-cpus")
         assert flags[idx + 1] == "0-2"
@@ -163,10 +274,38 @@ class TestShardDockerFlags:
         idx = flags1.index("--cpuset-cpus")
         assert flags1[idx + 1] == "12-14"
 
+    @patch("vla_eval.docker_resources._detect_runtime", return_value="nvidia")
     @patch("vla_eval.docker_resources._detect_gpu_ids", return_value=["0"])
     @patch("vla_eval.docker_resources.os.cpu_count", return_value=4)
-    def test_more_shards_than_cpus_skips_cpuset(self, _cpu_mock, _gpu_mock):
+    def test_more_shards_than_cpus_skips_cpuset(self, _cpu_mock, _gpu_mock, _runtime_mock):
         flags = shard_docker_flags(0, 8)
         assert "--cpuset-cpus" not in flags
         # OMP still set
         assert "OMP_NUM_THREADS=1" in flags
+
+
+class TestRocmShardDockerFlags:
+    @patch("vla_eval.docker_resources._detect_runtime", return_value="rocm")
+    @patch("vla_eval.docker_resources._detect_gpu_ids", return_value=["0", "1"])
+    def test_rocm_shards_round_robin_with_hip_visible_devices(self, _gpu_mock, _runtime_mock):
+        flags0 = shard_docker_flags(0, 2, gpus="all", cpus="0-7")
+        flags1 = shard_docker_flags(1, 2, gpus="all", cpus="0-7")
+
+        assert "--gpus" not in flags0
+        assert "--device=/dev/kfd" in flags0
+        assert "--device=/dev/dri" in flags0
+        assert flags0[flags0.index("--group-add") + 1] == "video"
+        assert "--ipc=host" not in flags0
+        assert "--security-opt" not in flags0
+        assert "HIP_VISIBLE_DEVICES=0" in flags0
+        assert "HIP_VISIBLE_DEVICES=1" in flags1
+
+        assert flags0[flags0.index("--cpuset-cpus") + 1] == "0-3"
+        assert flags1[flags1.index("--cpuset-cpus") + 1] == "4-7"
+        assert "OMP_NUM_THREADS=1" in flags0
+        assert "MKL_NUM_THREADS=1" in flags0
+
+    @patch("vla_eval.docker_resources._detect_runtime", return_value="rocm")
+    def test_rocm_explicit_gpu_round_robin(self, _runtime_mock):
+        flags = shard_docker_flags(2, 4, gpus="2,3")
+        assert "HIP_VISIBLE_DEVICES=2" in flags


### PR DESCRIPTION
## Summary

Adds ROCm-aware GPU runtime support for Docker execution while preserving the existing NVIDIA `--gpus` behavior.

This addresses the ROCm follow-up discussed in #44:

- detects ROCm with cached `rocm-smi --showid`, defaulting to NVIDIA behavior when ROCm is unavailable
- discovers ROCm GPU indices from `rocm-smi --showid`, with `/dev/dri/renderD*` as a fallback
- adds ROCm Docker device forwarding for `/dev/kfd` and `/dev/dri`, plus `--group-add video`
- sets `HIP_VISIBLE_DEVICES` for explicit GPU selections and sharded execution
- intentionally leaves `HIP_VISIBLE_DEVICES` unset for ROCm `all`, matching ROCm's all-visible behavior
- keeps the existing NVIDIA Docker flag behavior unchanged
- makes server smoke execution use `HIP_VISIBLE_DEVICES` on ROCm and `CUDA_VISIBLE_DEVICES` on NVIDIA
- makes demand-benchmark GPU resource monitoring choose `rocm-smi` JSON stats on ROCm and `nvidia-smi` on NVIDIA
- adds ROCm mirror coverage while pinning existing NVIDIA tests to the NVIDIA runtime path

## Checklist

- [x] I have read the relevant contributing guide ([CONTRIBUTING.md](https://github.com/allenai/vla-evaluation-harness/blob/main/CONTRIBUTING.md) or [leaderboard/CONTRIBUTING.md](https://github.com/allenai/vla-evaluation-harness/blob/main/leaderboard/CONTRIBUTING.md))

**Code changes:**
- [x] `make check` passes (ruff + ty)
- [x] `make test` passes (pytest)
- [ ] Smoke-tested affected configs (Docker benchmark execution was not run locally; Docker daemon is unavailable in this environment)
- [x] I have updated relevant documentation (not applicable; no user-facing docs or config changes)

Smoke test commands run:
```bash
make check
make test
uv run vla-eval test --validate
```

Results:
- `make check`: passed
- `make test`: 298 passed, 2 skipped
- `uv run vla-eval test --validate`: 155/155 configs valid

Environment:
- Ubuntu 22.04 on WSL
- Python 3.11.15

Notes:
- ROCm behavior is covered with mocked unit tests.
- No local ROCm hardware was available for a live ROCm run.
