### PR TITLE
docs: revise em dash usage in README and core docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ CLI (cli/main.py)
 
 `vla-eval run` writes raw rows to `<output_dir>/recording-<eval_id>.sqlite`:
 
-- Recording is configured at the **benchmark config's top-level `recording:` key** (sibling of `params`). The orchestrator reads this dict — `output_dir`, `filename_stem`, `record_video`, `record_step`, `video_fps` — and builds the recorder. Benchmarks are not involved in recording policy; they only decide *what* to record (which obs frame, which step fields).
+- Recording is configured at the **benchmark config's top-level `recording:` key** (sibling of `params`). The orchestrator reads this dict (`output_dir`, `filename_stem`, `record_video`, `record_step`, `video_fps`) and builds the recorder. Benchmarks are not involved in recording policy; they only decide *what* to record (which obs frame, which step fields).
 - Benchmark calls `recorder.record_video(frame)` / `recorder.record_step(row)`; the recorder buffers per-episode and flushes in one transaction at episode end.
 - `filename_stem` (default `"ep{episode_idx:04d}_{status}"`) is a `str.format` template against the task dict's serializable fields + `{status}`. The orchestrator validates it against the first task at startup so a typo fails fast.
 - Model server (optional, used by external callers like reflex-train) receives `(sid, eid, eval_id, db_path)` in the `EPISODE_START` WS payload and opens a `vla_eval.recording.StepRecorder` to push its own step rows. Field-union with the benchmark's rows is automatic via SQLite `json_patch`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,19 +2,19 @@
 
 ## Ways to Contribute
 
-We'd love your help — especially with reproducibility, which we care about most.
+We'd love your help, especially with reproducibility, which we care about most.
 
-1. **Reproduction reports** — If you've run an evaluation and can compare against published scores, we'd appreciate a report. See [db-cogact.md](docs/reproductions/db-cogact.md) for an example.
+1. **Reproduction reports**: If you've run an evaluation and can compare against published scores, we'd appreciate a report. See [db-cogact.md](docs/reproductions/db-cogact.md) for an example.
 
-2. **Bug reports and fixes** — If something doesn't look right during evaluation, please let us know. Filing an issue or opening a PR helps a lot.
+2. **Bug reports and fixes**: If something doesn't look right during evaluation, please let us know. Filing an issue or opening a PR helps a lot.
 
-3. **New benchmark integrations** — Adding a benchmark lets everyone reproduce results on it. See [Adding a Benchmark](#adding-a-benchmark) for the step-by-step guide.
+3. **New benchmark integrations**: Adding a benchmark lets everyone reproduce results on it. See [Adding a Benchmark](#adding-a-benchmark) for the step-by-step guide.
 
-4. **New model server integrations** — Adding a model server opens up new evaluation combinations. See [Adding a Model Server](#adding-a-model-server) for the guide.
+4. **New model server integrations**: Adding a model server opens up new evaluation combinations. See [Adding a Model Server](#adding-a-model-server) for the guide.
 
-5. **Leaderboard data** — Missing scores, corrections, or protocol notes are all helpful. See [leaderboard/CONTRIBUTING.md](leaderboard/CONTRIBUTING.md).
+5. **Leaderboard data**: Missing scores, corrections, or protocol notes are all helpful. See [leaderboard/CONTRIBUTING.md](leaderboard/CONTRIBUTING.md).
 
-We're also open to contributions that improve the harness itself — new evaluation metrics, video recording, visualization tools, and similar enhancements are all welcome.
+We're also open to contributions that improve the harness itself, including new evaluation metrics, video recording, visualization tools, and similar enhancements.
 
 ---
 
@@ -58,7 +58,7 @@ make format            # ruff format only
 make check             # lint + format + ty check (no auto-fix, CI-style)
 ```
 
-Ruff and ty config are in `pyproject.toml` — line length is **119**.
+Ruff and ty config are in `pyproject.toml`; line length is **119**.
 
 ## CI
 
@@ -90,7 +90,7 @@ src/vla_eval/
 6. Add a config YAML in `configs/`
 7. Add a Dockerfile in `docker/Dockerfile.<name>`
 8. Register the name in the `BENCHMARKS` array in `docker/build.sh` and the `IMAGES` array in `docker/push.sh`
-9. Smoke-test: `vla-eval test -c configs/<name>.yaml` (runs 1 episode with an EchoModelServer — no real model or GPU needed, but requires Docker + the benchmark image)
+9. Smoke-test: `vla-eval test -c configs/<name>.yaml` (runs 1 episode with an EchoModelServer; no real model or GPU needed, but requires Docker + the benchmark image)
 
 See `benchmarks/libero/` for a complete reference implementation.
 
@@ -99,7 +99,7 @@ See `benchmarks/libero/` for a complete reference implementation.
 1. Create `src/vla_eval/model_servers/<name>.py` as a **uv script** with [PEP 723](https://peps.python.org/pep-0723/) inline metadata
 2. Subclass `PredictModelServer` from `model_servers/predict.py` (or `ModelServer` from `model_servers/base.py` for advanced async use cases)
 3. Implement `predict(obs, ctx) -> dict`. Load the model inside `__init__` (no lazy-load hook)
-4. Use `run_server()` for the CLI entrypoint — **do not write manual argparse**:
+4. Use `run_server()` for the CLI entrypoint. **Do not write manual argparse**:
    ```python
    if __name__ == "__main__":
        from vla_eval.model_servers.serve import run_server
@@ -116,7 +116,7 @@ YAML configs are parsed into typed dataclasses in `config.py`. When adding confi
 
 - Add the field to the appropriate dataclass with a default value
 - Update `from_dict()` if the field needs special handling
-- Keep `params` as `dict[str, Any]` — it's benchmark-specific and passed through as-is
+- Keep `params` as `dict[str, Any]`; it is benchmark-specific and passed through as-is
 
 ## PR Workflow
 
@@ -124,4 +124,4 @@ YAML configs are parsed into typed dataclasses in `config.py`. When adding confi
 2. Make changes, add tests if applicable
 3. Update relevant documentation (`README.md` badges, `docs/reproductions/`, etc.)
 4. Run `make check && make test`
-5. Open a PR — CI will run automatically
+5. Open a PR. CI will run automatically

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@
 ### Latest News
 
 - [2026/06] [v0.3.0](https://github.com/allenai/vla-evaluation-harness/releases/tag/v0.3.0) released. SQLite recording + `vla-eval merge`, wandb/trackio tracking, and a watchdog for wedged benchmarks.
-- [2026/05] [v0.2.0](https://github.com/allenai/vla-evaluation-harness/releases/tag/v0.2.0) released. 18 benchmarks x 13 model servers — the largest open VLA evaluation matrix. Browse [`configs/`](configs/) to get started.
-- [2026/05] [Leaderboard](https://allenai.github.io/vla-evaluation-harness/leaderboard/) rebuilt: 1,885 models x 18 benchmarks, schema-validated pipeline, updated monthly.
+- [2026/05] [v0.2.0](https://github.com/allenai/vla-evaluation-harness/releases/tag/v0.2.0) released. 18 benchmarks x 13 model servers, the largest open VLA evaluation matrix. Browse [`configs/`](configs/) to get started.
+- [2026/05] [Leaderboard](https://allenai.github.io/vla-evaluation-harness/leaderboard/) rebuilt: 2,456 models x 18 benchmarks, schema-validated pipeline, updated monthly.
 - [2026/04] [v0.1.0](https://github.com/allenai/vla-evaluation-harness/releases/tag/v0.1.0) released. 6 VLA models [reproduced](docs/reproductions/) within 2pp of published scores.
 - [2026/04] Batch parallel eval: 2,000 LIBERO episodes in 18 min on 1x H100 ([details](#batch-parallel-evaluation)).
 
@@ -31,22 +31,22 @@
 | | |
 |:--|:--|
 | **Batch Parallel Evaluation** | Episode sharding + batched GPU inference → **47× throughput** (2 000 LIBERO episodes in 18 min on 1× H100). [Details](#batch-parallel-evaluation) |
-| **Zero Setup** | Benchmarks in Docker, model servers as single-file [uv scripts](https://docs.astral.sh/uv/guides/scripts/) — no dependency conflicts. |
-| **AI-Assisted Integration** | Built-in [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skills for [adding benchmarks](.claude/skills/add-benchmark/) and [model servers](.claude/skills/add-model-server/) — scaffold new integrations in minutes, not hours. |
-| **[Leaderboard](https://allenai.github.io/vla-evaluation-harness/leaderboard/)** | The largest unified VLA comparison — 1,885 models × 18 benchmarks, aggregated from 1,755 papers. |
+| **Zero Setup** | Benchmarks in Docker and model servers as single-file [uv scripts](https://docs.astral.sh/uv/guides/scripts/), avoiding dependency conflicts. |
+| **AI-Assisted Integration** | Built-in [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skills for [adding benchmarks](.claude/skills/add-benchmark/) and [model servers](.claude/skills/add-model-server/) help scaffold new integrations in minutes, not hours. |
+| **[Leaderboard](https://allenai.github.io/vla-evaluation-harness/leaderboard/)** | The largest unified VLA comparison: 2,456 models × 18 benchmarks, aggregated from 2,087 papers. |
 
 ---
 
 ## Motivation
 
-VLA models are evaluated on LIBERO, CALVIN, SimplerEnv, ManiSkill, and others — but each benchmark has its own dependencies, observation format, and evaluation protocol. In practice, every research team ends up maintaining private eval forks per benchmark. Results diverge. Bug fixes don't propagate. No one tests under real-time conditions where the environment keeps moving during inference.
+VLA models are evaluated on LIBERO, CALVIN, SimplerEnv, ManiSkill, and others, but each benchmark has its own dependencies, observation format, and evaluation protocol. In practice, every research team ends up maintaining private eval forks per benchmark. Results diverge. Bug fixes don't propagate. No one tests under real-time conditions where the environment keeps moving during inference.
 
 **vla-evaluation-harness** integrates the model once, integrates the benchmark once, and the full cross-evaluation matrix fills itself.
 
 **How**: our abstraction layer fully decouples models from benchmarks.
 
-- Benchmarks run inside **Docker** — no dependency hell, exact reproducibility.
-- Model servers are standalone **[uv scripts](https://docs.astral.sh/uv/guides/scripts/)** with inline dependency declarations — zero manual setup.
+- Benchmarks run inside **Docker**, giving exact reproducibility without dependency conflicts.
+- Model servers are standalone **[uv scripts](https://docs.astral.sh/uv/guides/scripts/)** with inline dependency declarations and no manual setup.
 
 See [Architecture](docs/architecture.md) for how the pieces connect.
 
@@ -73,11 +73,11 @@ uv sync --python 3.11 --all-extras --dev
 Two terminals: one for the model server (GPU), one for the benchmark client.
 
 ```bash
-# Terminal 1 — model server (runs on host with GPU)
+# Terminal 1: model server (runs on host with GPU)
 vla-eval serve --config configs/model_servers/db_cogact/libero.yaml
 
-# Terminal 2 — run evaluation (benchmark runs in Docker by default).
-# Wait for the model server to finish loading first — ``GET /health`` returning HTTP 200 is the ready signal.
+# Terminal 2: run evaluation (benchmark runs in Docker by default).
+# Wait for the model server to finish loading first; ``GET /health`` returning HTTP 200 is the ready signal.
 vla-eval run --config configs/benchmarks/libero/smoke_test.yaml
 ```
 
@@ -131,7 +131,7 @@ wait
 vla-eval merge -c configs/benchmarks/libero/spatial.yaml -o results/libero_spatial.json
 ```
 
-Each shard gets a deterministic slice via round-robin. Results merge with episode-level deduplication — if a shard fails, re-run only that shard.
+Each shard gets a deterministic slice via round-robin. Results merge with episode-level deduplication; if a shard fails, re-run only that shard.
 
 ### Batch Model Server (GPU parallelism)
 
@@ -212,7 +212,7 @@ Two opt-in systems capture eval data. Both key on `eval_id` so recordings and tr
 
 ### Recording
 
-Every `vla-eval run` persists raw data to `<output_dir>/recording-<eval_id>.sqlite` — per-step rows, episode results, and eval metadata. Configure via each benchmark's `recording:` key:
+Every `vla-eval run` persists raw data to `<output_dir>/recording-<eval_id>.sqlite`: per-step rows, episode results, and eval metadata. Configure via each benchmark's `recording:` key:
 
 ```yaml
 benchmarks:
@@ -234,7 +234,7 @@ tracking:
   report_to: wandb           # "wandb" | ["wandb", "trackio"] | "all" | "none"
 ```
 
-The harness injects `id=<eval_id>` + `resume="allow"` so live (`vla-eval run`) and merge (`vla-eval merge`) paths converge on the same run. All other settings — project, entity, API key — come from the backend's native env vars (`WANDB_*`, `TRACKIO_*`). See the [W&B env reference](https://docs.wandb.ai/guides/track/environment-variables) for details. Install the backend yourself: `pip install wandb` / `pip install trackio`.
+The harness injects `id=<eval_id>` + `resume="allow"` so live (`vla-eval run`) and merge (`vla-eval merge`) paths converge on the same run. All other settings, including project, entity, and API key, come from the backend's native env vars (`WANDB_*`, `TRACKIO_*`). See the [W&B env reference](https://docs.wandb.ai/guides/track/environment-variables) for details. Install the backend yourself: `pip install wandb` / `pip install trackio`.
 
 Under sharding, aggregate emission defers to `vla-eval merge`; per-episode tracking is live-path only.
 

--- a/configs/benchmarks/duobench/README.md
+++ b/configs/benchmarks/duobench/README.md
@@ -17,6 +17,5 @@ Tasks: `ball_maze`, `bin_sort`, `block_balance`, `carry_pot`, `hinge_chest`,
 
 | File | Description | Tasks | Episodes/task |
 |------|-------------|:-----:|:-------------:|
-| `eval.yaml` | Canonical evaluation — all 11 tasks | 11 | 100 |
+| `eval.yaml` | Canonical evaluation across all 11 tasks | 11 | 100 |
 | `smoke_test.yaml` | Minimal pipeline check (`ball_maze`, 1 episode) | 1 | 1 |
-

--- a/docker/README.md
+++ b/docker/README.md
@@ -29,5 +29,5 @@ Images are published to `ghcr.io/allenai/vla-evaluation-harness/<name>:<tag>`.
 
 ## Adding a New Benchmark
 
-1. Create `Dockerfile.<name>` — use `ARG BASE_IMAGE` and install benchmark-specific deps.
+1. Create `Dockerfile.<name>`, use `ARG BASE_IMAGE`, and install benchmark-specific deps.
 2. Add `<name>` to the `BENCHMARKS` array in `build.sh` and `IMAGES` array in `push.sh`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -106,7 +106,7 @@ numpy arrays are encoded inline within msgpack:
 
 ### Payload convention
 
-Observations and actions are `dict[str, Any]` — the framework imposes **no fixed schema**. Each benchmark defines its own observation structure via `make_obs()`. The recommended (not enforced) convention:
+Observations and actions are `dict[str, Any]`; the framework imposes **no fixed schema**. Each benchmark defines its own observation structure via `make_obs()`. The recommended (not enforced) convention:
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -150,7 +150,7 @@ The full config is saved alongside results for reproducibility.
 
 ## Import Resolution
 
-Benchmarks are referenced by full import path (`"module.path:ClassName"`) in config files. No registry or short-name mapping — explicit is better than implicit.
+Benchmarks are referenced by full import path (`"module.path:ClassName"`) in config files. No registry or short-name mapping; explicit is better than implicit.
 
 ```python
 from vla_eval.registry import resolve_import_string
@@ -192,14 +192,14 @@ All failures are recorded in structured results with `failure_reason`.
 
 ## Planned Features
 
-- **Video / trajectory recording** — Per-episode video via `Benchmark.render()` and trajectory logs in msgpack format.
-- **Reference score comparison** — Regression testing against known model+benchmark scores.
+- **Video / trajectory recording**: Per-episode video via `Benchmark.render()` and trajectory logs in msgpack format.
+- **Reference score comparison**: Regression testing against known model+benchmark scores.
 
 ## Design Background
 
 The design philosophy and detailed design outline were written before implementation:
 
-- [Design Philosophy](design-philosophy.md) — Core principles: freshness, convenience, layered abstraction, quality, reproducibility, openness.
-- [RFCs](rfcs/README.md) — Detailed component specifications, protocol design, and technical decisions.
+- [Design Philosophy](design-philosophy.md): Core principles: freshness, convenience, layered abstraction, quality, reproducibility, openness.
+- [RFCs](rfcs/README.md): Detailed component specifications, protocol design, and technical decisions.
 
 These documents reflect the intended direction. The implementation follows them closely.

--- a/docs/design-philosophy.md
+++ b/docs/design-philosophy.md
@@ -1,42 +1,42 @@
 # Design Philosophy
 
-## Freshness — Keep benchmarks meaningful
+## Freshness: Keep benchmarks meaningful
 
 Benchmarks are living things. As the community advances, existing benchmarks saturate and lose the ability to discriminate between models. This project does not fall behind.
 
-- LIBERO is already saturated — many models converge to high success rates, and multiple studies have exposed its limitations. We actively include improved successors like LIBERO-Pro.
+- LIBERO is already saturated; many models converge to high success rates, and multiple studies have exposed its limitations. We actively include improved successors like LIBERO-Pro.
 - When a new benchmark gains traction in the community, we add an adapter promptly. Conversely, benchmarks that lose discriminative value are deprecated.
 - The default benchmark suite is periodically updated to reflect "what constitutes a meaningful evaluation right now."
 
-## Convenience — Zero-friction evaluation
+## Convenience: Zero-friction evaluation
 
 Researchers' time should go to model development, not environment setup.
 
 - Evaluate a model across diverse robot benchmarks without manually reconciling complex environment configurations or interface mismatches between benchmarks.
 - Docker-based environment isolation eliminates dependency conflicts at the root. A single CLI command starts evaluation.
-- The model server interface is kept minimal — a few lines of modification to existing model code is all it takes to integrate.
+- The model server interface is kept minimal: a few lines of modification to existing model code is all it takes to integrate.
 
-## Layered Abstraction — Generality and convenience coexist
+## Layered Abstraction: Generality and convenience coexist
 
 Two goals:
 
 1. **Generality**: Define a framework that accommodates future research paradigms and techniques without major changes.
 2. **Convenience**: High generality means few constraints, which in turn means less convenience for researchers who "just want to get it running quickly."
 
-These cannot coexist in a single layer. The solution is multiple layers — from a low-level layer with minimal constraints (high generality) to a high-level layer with more constraints but easier usage (high convenience).
+These cannot coexist in a single layer. The solution is multiple layers, from a low-level layer with minimal constraints (high generality) to a high-level layer with more constraints but easier usage (high convenience).
 
-This principle applies across the entire project — server interface, client interface, benchmark adapters, and execution tools all follow the same philosophy. At every layer, the lower layer imposes only minimal constraints so that "this framework can't support my use case" never happens.
+This principle applies across the entire project: server interface, client interface, benchmark adapters, and execution tools all follow the same philosophy. At every layer, the lower layer imposes only minimal constraints so that "this framework can't support my use case" never happens.
 
-## Quality — Verify both code and results
+## Quality: Verify both code and results
 
 To trust the harness's results, the harness itself must be trustworthy.
 
 - Code quality: strict type checking, linting, and formatting.
-- Testing: tests for critical paths — protocol serialization, adapter correctness, metric computation.
+- Testing: tests for critical paths, including protocol serialization, adapter correctness, and metric computation.
 - CI/CD: automated validation pipeline on every PR. Integration tests required when adding benchmark adapters.
 - Result verification: maintain reference scores for known model+benchmark combinations and regression-test that framework changes don't affect results.
 
-## Reproducibility — Same conditions, same results
+## Reproducibility: Same conditions, same results
 
 If evaluation results vary by environment, the benchmark is meaningless.
 
@@ -44,10 +44,10 @@ If evaluation results vary by environment, the benchmark is meaningless.
 - Explicitly record seed management, episode composition, and evaluation protocol so that anyone, anywhere, can reproduce identical results.
 - Automatically record the configuration used for each evaluation run (benchmark version, seeds, episode list, etc.) alongside the results.
 
-## Openness — Grow with the community
+## Openness: Grow with the community
 
 The framework's value is proportional to the breadth of benchmarks it supports. Expanding that breadth is not the maintainers' job alone.
 
 - Aim for a structure where external contributors can easily add new benchmarks and model adapters.
 - Clearly document the interfaces required for adding benchmark adapters, and provide contribution guides and templates to lower the barrier to entry.
-- Provide example model servers and adapters as reference implementations — a clear starting point that says "follow this."
+- Provide example model servers and adapters as reference implementations, giving contributors a clear starting point.

--- a/docs/reproductions/README.md
+++ b/docs/reproductions/README.md
@@ -54,7 +54,7 @@ SE = SimplerEnv. SE GR = Google Robot VM.
 
 ## Benchmarks with No Model Coverage Yet
 
-Integrated in vla-eval: RLBench, RoboCasa, Mikasa, RoboCerebra, LIBERO-90, LIBERO-Pro, BEHAVIOR-1K ([details](behavior1k.md) — needs an R1Pro-compatible model server).
+Integrated in vla-eval: RLBench, RoboCasa, Mikasa, RoboCerebra, LIBERO-90, LIBERO-Pro, BEHAVIOR-1K ([details](behavior1k.md); needs an R1Pro-compatible model server).
 
 ## Per-Codebase Details
 

--- a/docs/rfcs/0001-realtime-evaluation.md
+++ b/docs/rfcs/0001-realtime-evaluation.md
@@ -9,7 +9,7 @@
 
 ## Summary
 
-This project exists because **no existing VLA evaluation framework measures what actually matters for deployment: whether a model can control a robot in real time.** Sync-only evaluation freezes the world while the model thinks — real robots cannot do this. Real-time evaluation, where the simulation clock is tied to wall-clock time and the environment keeps advancing whether or not the model has returned an action, is therefore not a feature but the core architectural requirement. Every major design decision in vla-evaluation-harness — client-server separation, async model interfaces, the Benchmark/EpisodeRunner split — traces back to this requirement.
+This project exists because **no existing VLA evaluation framework measures what actually matters for deployment: whether a model can control a robot in real time.** Sync-only evaluation freezes the world while the model thinks, but real robots cannot do this. Real-time evaluation, where the simulation clock is tied to wall-clock time and the environment keeps advancing whether or not the model has returned an action, is therefore not a feature but the core architectural requirement. Every major design decision in vla-evaluation-harness, including client-server separation, async model interfaces, and the Benchmark/EpisodeRunner split, traces back to this requirement.
 
 ## Motivation
 
@@ -17,16 +17,16 @@ Standard evaluation frameworks (e.g. `model.predict(obs)` inside a `gym.step()` 
 
 1. **Time stops during inference.** A model taking 500ms per action gets the same score as one taking 5ms, even though the slow model would fail on a real robot where objects keep moving.
 2. **Sync scores are misleading.** A model scoring 90% success in sync evaluation might score 60% under real-time constraints because half its actions arrive too late. Without measuring this gap, researchers cannot assess deployment readiness.
-3. **gymnasium's `step()` makes real-time structurally impossible.** The blocking `action = model(obs); obs, reward, done, info = env.step(action)` loop couples environment time to inference time. You cannot simply "add a timer" — the architecture must decouple them from the start.
+3. **gymnasium's `step()` makes real-time structurally impossible.** The blocking `action = model(obs); obs, reward, done, info = env.step(action)` loop couples environment time to inference time. You cannot simply "add a timer"; the architecture must decouple them from the start.
 
 These are not hypothetical problems. VLA models vary in inference latency from 5ms (small diffusion policies) to 500ms+ (large autoregressive models). This 100× range means real-time performance is a first-class evaluation axis, not an afterthought.
 
 ## What is Real-time Evaluation?
 
-Real-time evaluation **ties the simulation clock to wall-clock time** — the environment keeps advancing whether or not the model has returned an action:
+Real-time evaluation **ties the simulation clock to wall-clock time**. The environment keeps advancing whether or not the model has returned an action:
 
 - If inference is still running when a step occurs, a **hold policy** fills the gap (repeat last action, output zeros, or a custom callable).
-- The same `Benchmark` implementation works with both sync and real-time runners — the benchmark defines *what* to evaluate, not *how fast*.
+- The same `Benchmark` implementation works with both sync and real-time runners. The benchmark defines *what* to evaluate, not *how fast*.
 
 This is exactly what happens on a real robot: the control loop keeps running, and the policy must keep up or the robot acts on stale commands.
 
@@ -36,11 +36,11 @@ Real-time evaluation requires decoupling inference from environment stepping. Th
 
 ### Client-Server Separation (→ RFC-0002)
 
-The model and environment must run in **separate processes** (typically separate machines). This is not just for deployment convenience — it is necessary so that the environment loop and inference loop can advance on independent clocks. A single-process `model.predict()` call inside `env.step()` makes decoupling impossible.
+The model and environment must run in **separate processes** (typically separate machines). This is not just for deployment convenience; it is necessary so that the environment loop and inference loop can advance on independent clocks. A single-process `model.predict()` call inside `env.step()` makes decoupling impossible.
 
 ### Model Server is Async by Default (→ RFC-0003)
 
-The base `ModelServer` interface is `async` because in real-time mode, observations arrive while inference is still running. The server must be able to receive new observations, decide which to process, and manage its own inference pipeline — none of which is possible with a blocking `predict(obs) → action` signature. (A blocking `PredictModelServer` convenience class is provided for the common case, but it builds on the async foundation.)
+The base `ModelServer` interface is `async` because in real-time mode, observations arrive while inference is still running. The server must be able to receive new observations, decide which to process, and manage its own inference pipeline. None of that is possible with a blocking `predict(obs) → action` signature. (A blocking `PredictModelServer` convenience class is provided for the common case, but it builds on the async foundation.)
 
 ### Benchmark ≠ EpisodeRunner (→ RFC-0004)
 
@@ -52,10 +52,10 @@ The `Connection` class exposes two calling conventions on the same WebSocket:
 
 ```python
 class Connection:
-    # Sync mode — blocks until action arrives
+    # Sync mode: blocks until action arrives
     async def act(self, obs: dict[str, Any]) -> dict[str, Any]: ...
 
-    # Real-time mode — non-blocking send + action callback
+    # Real-time mode: non-blocking send + action callback
     async def send_observation(self, obs: dict[str, Any]) -> None: ...
     def on_action(self, callback: Callable[[dict[str, Any]], None]) -> None: ...
 ```
@@ -92,10 +92,10 @@ class AsyncEpisodeRunner(EpisodeRunner):
 
 **Key mechanics:**
 
-1. **Fixed Hz via `asyncio.sleep(1/hz)`** — the environment advances on a wall-clock schedule. Model inference runs concurrently and does not block stepping.
+1. **Fixed Hz via `asyncio.sleep(1/hz)`**: the environment advances on a wall-clock schedule. Model inference runs concurrently and does not block stepping.
 2. **ActionBuffer** stores the latest action received from `on_action`. Each step reads from the buffer, not from a blocking call.
 3. **Hold policy** determines behavior when the buffer has no new action: `repeat_last` replays the previous action, `zero` outputs a zero action, or a custom callable computes a fallback.
-4. **Non-blocking observation sending** — `send_observation()` returns immediately. The model server may skip observations it cannot process in time.
+4. **Non-blocking observation sending**: `send_observation()` returns immediately. The model server may skip observations it cannot process in time.
 
 ## Real-time Metrics
 
@@ -109,18 +109,16 @@ Real-time evaluation introduces metrics that sync evaluation cannot capture:
 | **Stale Action Ratio** | Fraction of environment steps using a repeated (hold-policy) action |
 | **Latency Distribution** | Inference latency percentiles: p50, p95, p99 |
 
-**RT Degradation** is the headline metric. A model with 90% sync / 85% real-time has 5% degradation — likely deployment-ready. A model with 90% sync / 40% real-time has 50% degradation — fast inference or architectural changes are needed regardless of the sync score.
+**RT Degradation** is the headline metric. A model with 90% sync / 85% real-time has 5% degradation and is likely deployment-ready. A model with 90% sync / 40% real-time has 50% degradation, so fast inference or architectural changes are needed regardless of the sync score.
 
 ## Implementation Status
 
-- ✅ `SyncEpisodeRunner` — fully implemented and tested across LIBERO, CALVIN, SimplerEnv
-- ✅ Client-server architecture — WebSocket + msgpack protocol operational
-- ✅ Protocol timestamps — `seq` and `timestamp` fields on every message
+- ✅ `SyncEpisodeRunner`: fully implemented and tested across LIBERO, CALVIN, SimplerEnv
+- ✅ Client-server architecture: WebSocket + msgpack protocol operational
+- ✅ Protocol timestamps: `seq` and `timestamp` fields on every message
 - ✅ `Connection.send_observation()` / `on_action()` / `start_listener()` / `stop_listener()`
-- ✅ `AsyncEpisodeRunner` — fully implemented (`runners/async_runner.py`)
-- ✅ `ActionBuffer` + hold policies (`repeat_last`, `zero`, callable) — (`runners/action_buffer.py`)
-- ✅ Real-time metrics collection — effective control Hz, step timing, stale action ratio
+- ✅ `AsyncEpisodeRunner`: fully implemented (`runners/async_runner.py`)
+- ✅ `ActionBuffer` + hold policies (`repeat_last`, `zero`, callable): `runners/action_buffer.py`
+- ✅ Real-time metrics collection: effective control Hz, step timing, stale action ratio
 - ✅ `Clock` abstraction for pace control (`runners/clock.py`)
-
-
 

--- a/docs/rfcs/0002-communication-protocol.md
+++ b/docs/rfcs/0002-communication-protocol.md
@@ -14,9 +14,9 @@ Defines the wire protocol between benchmark clients and model servers: transport
 ## Transport
 
 - **WebSocket + msgpack** async communication.
-- **Single WebSocket connection** (`ws://server:port`). Message `type` field multiplexes logical channels — no need for multiple connections or HTTP endpoints.
+- **Single WebSocket connection** (`ws://server:port`). Message `type` field multiplexes logical channels, so no multiple connections or HTTP endpoints are needed.
 - **Serialization**: msgpack with a custom numpy codec (see below). Arbitrary `dict[str, Any]` payloads including numpy arrays are serialized transparently.
-- **Image encoding**: Configurable per deployment — raw numpy (default), JPEG, or PNG.
+- **Image encoding**: Configurable per deployment: raw numpy (default), JPEG, or PNG.
 - **Compression**: Default `None`. On LAN the compression CPU overhead exceeds network savings. WAN deployments can enable compression via configuration.
 
 ## Message Schema
@@ -53,13 +53,13 @@ numpy arrays are encoded inline as msgpack dicts by the custom codec in `protoco
 - `dtype`: numpy dtype string (e.g. `"float32"`, `"uint8"`).
 - `shape`: integer tuple.
 
-**Security**: On deserialization the codec rejects `Void`, `Object`, and `Complex` dtypes — these can trigger arbitrary code execution via pickle. Only `bool`, `int*`, `uint*`, and `float*` kinds are allowed.
+**Security**: On deserialization the codec rejects `Void`, `Object`, and `Complex` dtypes because these can trigger arbitrary code execution via pickle. Only `bool`, `int*`, `uint*`, and `float*` kinds are allowed.
 
 Scalar numpy types (`np.integer`, `np.floating`, `np.bool_`) are converted to Python builtins during encoding so they survive msgpack round-trips.
 
 ## Payload Convention
 
-Observations and actions are `dict[str, Any]` — the framework imposes **no fixed schema**. Each benchmark defines its own structure via `Benchmark.make_obs()`.
+Observations and actions are `dict[str, Any]`; the framework imposes **no fixed schema**. Each benchmark defines its own structure via `Benchmark.make_obs()`.
 
 The recommended (not enforced) convention, based on the [RLinf](../proposal/03_REFERENCE_SURVEY/rlinf.md) field set adopted by starVLA / InternVLA-M1 / dexbotic:
 
@@ -69,12 +69,12 @@ The recommended (not enforced) convention, based on the [RLinf](../proposal/03_R
 | `states` | `np.ndarray` | Proprioception (joint angles, end-effector pose, etc.) |
 | `task_description` | `str` | Natural-language task instruction |
 
-Following the convention enables a single model server implementation to work across multiple benchmarks without per-benchmark key mapping. Not following it is fine — the protocol layer only requires `dict[str, Any]`.
+Following the convention enables a single model server implementation to work across multiple benchmarks without per-benchmark key mapping. Not following it is fine; the protocol layer only requires `dict[str, Any]`.
 
 
 ## Connection Client API
 
-The framework provides `Connection` — a client library used by benchmarks and episode runners to communicate with the model server. No user-side ABC implementation is needed.
+The framework provides `Connection`, a client library used by benchmarks and episode runners to communicate with the model server. No user-side ABC implementation is needed.
 
 ```python
 conn = vla_eval.connect("ws://model-server:8000")
@@ -86,17 +86,17 @@ class Connection:
     async def start_episode(self, config: dict[str, Any]) -> None: ...
     async def end_episode(self, result: dict[str, Any]) -> None: ...
 
-    # Sync mode — send observation, await action
+    # Sync mode: send observation, await action
     async def act(self, obs: dict[str, Any]) -> dict[str, Any]: ...
 
-    # Real-time mode — non-blocking send + action callback
+    # Real-time mode: non-blocking send + action callback
     async def send_observation(self, obs: dict[str, Any]) -> None: ...
     def on_action(self, callback: Callable[[dict[str, Any]], None]) -> None: ...
 ```
 
 Key design points:
 
-- **`act()` uses `asyncio.Future`** internally — it awaits the server's action response without busy-polling.
+- **`act()` uses `asyncio.Future`** internally; it awaits the server's action response without busy-polling.
 - **Sync mode**: `act()` sends an observation and returns the matching action (matched by `seq`).
 - **Real-time mode**: `send_observation()` fires and forgets; incoming actions are dispatched to the registered `on_action` callback. The `AsyncEpisodeRunner` uses this with an `ActionBuffer` and a hold policy.
 - **Sequence numbering** is managed internally; callers never set `seq` manually.
@@ -114,6 +114,4 @@ Implemented in `connection.py`.
 | Server-side WebSocket handler | `model_servers/serve.py` | ✅ Implemented |
 | Image encoding (JPEG/PNG/raw) | `protocol/image_codec.py` | ✅ Implemented |
 | WAN compression option | — | 🔜 Not yet implemented |
-
-
 

--- a/docs/rfcs/0003-model-server-hierarchy.md
+++ b/docs/rfcs/0003-model-server-hierarchy.md
@@ -19,7 +19,7 @@ ModelServer (ABC, async)
 └── BatchPredictModelServer (dynamic batching)
 ```
 
-## ModelServer (Base — Async)
+## ModelServer (Base, Async)
 
 ```python
 class ModelServer(ABC):
@@ -52,7 +52,7 @@ class PredictModelServer(ModelServer):
         Shape (action_dim,) for chunk_size=1, (chunk_size, action_dim) otherwise."""
 ```
 
-The framework wraps `predict()` in `asyncio.run_in_executor` — the researcher never touches async. When `chunk_size > 1`, the framework manages a per-session `ActionChunkBuffer`: it pops buffered actions on each observation and only calls `predict()` when the buffer is exhausted (or every step for `"average"` ensemble).
+The framework wraps `predict()` in `asyncio.run_in_executor`, so the researcher never touches async. When `chunk_size > 1`, the framework manages a per-session `ActionChunkBuffer`: it pops buffered actions on each observation and only calls `predict()` when the buffer is exhausted (or every step for `"average"` ensemble).
 
 ## Action Chunking
 
@@ -65,7 +65,7 @@ Action chunking is entirely the server's responsibility. The benchmark client al
 | `"ema"` | Exponential moving average with `ema_alpha`. Newer chunk weighted higher. |
 | `callable` | User function: `(old_actions, new_actions) → ensembled`. |
 
-Callable example — cosine-similarity adaptive ensemble (used in starVLA, dexbotic):
+Callable example: cosine-similarity adaptive ensemble (used in starVLA, dexbotic):
 
 ```python
 def adaptive_ensemble(old: np.ndarray, new: np.ndarray) -> np.ndarray:
@@ -100,7 +100,7 @@ class BatchPredictModelServer(ModelServer):
         """Batched blocking inference. len(result) == len(obs_batch)."""
 ```
 
-The framework queues observations across sessions and dispatches `predict_batch()` when `max_batch_size` is reached or `max_wait_time` elapses — whichever comes first. Per-session chunk buffers are managed identically to `PredictModelServer`.
+The framework queues observations across sessions and dispatches `predict_batch()` when `max_batch_size` is reached or `max_wait_time` elapses, whichever comes first. Per-session chunk buffers are managed identically to `PredictModelServer`.
 
 ## SessionContext
 
@@ -135,17 +135,16 @@ In `PredictModelServer`, `send_action` is called automatically from the return v
 
 ## When to Use Which
 
-- **`PredictModelServer`** — default choice. Covers single-step and chunk models in both sync and real-time evaluation.
-- **`BatchPredictModelServer`** — multiple environments evaluated concurrently to maximize GPU utilization.
-- **`ModelServer`** — only when you need direct async control (custom observation filtering, streaming inference, etc.).
+- **`PredictModelServer`**: default choice. Covers single-step and chunk models in both sync and real-time evaluation.
+- **`BatchPredictModelServer`**: multiple environments evaluated concurrently to maximize GPU utilization.
+- **`ModelServer`**: only when you need direct async control (custom observation filtering, streaming inference, etc.).
 
 ## Implementation Status
 
 - ✅ `ModelServer` ABC (`model_servers/base.py`)
 - ✅ `PredictModelServer` with action chunking (`model_servers/predict.py`, `model_servers/chunking.py`)
 - ✅ `SessionContext` (`model_servers/base.py`)
-- ✅ Server runner — WebSocket wrapper (`model_servers/serve.py`)
+- ✅ Server runner: WebSocket wrapper (`model_servers/serve.py`)
 - ✅ CogACT reference implementation (`model_servers/dexbotic/cogact.py`)
 - ✅ Batched inference via `PredictModelServer` (`max_batch_size > 1`)
 - ✅ Real-time observation dispatch (`continuous_inference` mode)
-

--- a/docs/rfcs/0004-benchmark-and-episode-execution.md
+++ b/docs/rfcs/0004-benchmark-and-episode-execution.md
@@ -15,7 +15,7 @@ The key architectural insight (from RFC-0001): separating *what* the environment
 
 ## Benchmark ABC
 
-Each benchmark has a unique environment interface (observation structure, action space, reset/step API, success criteria). To add a new benchmark, implement the `Benchmark` ABC — this is the only implementation contract on the benchmark side.
+Each benchmark has a unique environment interface (observation structure, action space, reset/step API, success criteria). To add a new benchmark, implement the `Benchmark` ABC. This is the only implementation contract on the benchmark side.
 
 ```python
 @dataclass
@@ -32,11 +32,11 @@ class Benchmark(ABC):
     async def get_observation(self) -> dict[str, Any]: ...
     async def is_done(self) -> bool: ...
     async def get_result(self) -> EpisodeResult: ...
-    def get_metadata(self) -> dict[str, Any]: ...  # optional — benchmark defaults
-    def render(self) -> np.ndarray | None: ...  # optional — for video recording
+    def get_metadata(self) -> dict[str, Any]: ...  # optional: benchmark defaults
+    def render(self) -> np.ndarray | None: ...  # optional: for video recording
 ```
 
-Six abstract methods form the minimum contract. `get_metadata()` and `render()` are optional overrides. The benchmark implementor focuses only on environment-specific logic — episode loops, communication, and timing are handled by `EpisodeRunner`. Environment handles are stored internally (`self._env`) rather than passed through callers.
+Six abstract methods form the minimum contract. `get_metadata()` and `render()` are optional overrides. The benchmark implementor focuses only on environment-specific logic; episode loops, communication, and timing are handled by `EpisodeRunner`. Environment handles are stored internally (`self._env`) rather than passed through callers.
 
 ## EpisodeRunner
 
@@ -71,7 +71,7 @@ class SyncEpisodeRunner(EpisodeRunner):
 
 ### AsyncEpisodeRunner (→ RFC-0001)
 
-Ties the simulation clock to wall-clock time — the environment keeps advancing whether or not the model has returned an action. If inference hasn't completed, a hold policy is applied (e.g., repeat last action). Used for real-time evaluation.
+Ties the simulation clock to wall-clock time. The environment keeps advancing whether or not the model has returned an action. If inference hasn't completed, a hold policy is applied (e.g., repeat last action). Used for real-time evaluation.
 
 Key mechanisms:
 - **Wall-clock stepping**: `asyncio.sleep(1/hz)` keeps the environment advancing independent of agent inference.
@@ -90,7 +90,7 @@ Each benchmark's simulation environment runs in a Docker container (with GPU acc
 - **Image naming**: `vla-eval/{benchmark_name}:{version}` (e.g., `vla-eval/libero:0.1.0`)
 - **Connection library included**: benchmark images include the `vla-eval` connection library
 - **Port 8080**: exposed for the orchestrator control channel
-- **Model server**: runs outside the container, communicates via WebSocket — unaffected by isolation
+- **Model server**: runs outside the container, communicates via WebSocket, and is unaffected by isolation
 
 ### Container Lifecycle
 
@@ -112,7 +112,7 @@ Orchestrator                    Docker Container
 
 ## Import Resolution
 
-Benchmarks are referenced by full import path (`"module.path:ClassName"`) in config files — no registry or short-name mapping.
+Benchmarks are referenced by full import path (`"module.path:ClassName"`) in config files. There is no registry or short-name mapping.
 
 ```python
 from vla_eval.registry import resolve_import_string
@@ -137,7 +137,7 @@ Coordinates the full evaluation flow:
 
 ## Configuration
 
-Flat YAML — single file contains all parameters. No Hydra-style composition.
+Flat YAML. A single file contains all parameters. No Hydra-style composition.
 
 ```yaml
 server:
@@ -148,7 +148,7 @@ benchmarks:
     tasks: ["libero_spatial", "libero_object"]
     episodes_per_task: 50
     max_steps: 300          # omit to use Benchmark.get_metadata() default
-    params:                 # benchmark-specific — passed to constructor
+    params:                 # benchmark-specific; passed to constructor
       headless: true
       seed: 42
   - benchmark: "vla_eval.benchmarks.libero.benchmark:LIBEROBenchmark"
@@ -163,7 +163,7 @@ The full config is saved alongside results for reproducibility. `vla-eval test -
 
 ## Error Handling
 
-Failures are isolated per episode — one episode failure does not abort the evaluation.
+Failures are isolated per episode. One episode failure does not abort the evaluation.
 
 | Scenario | Behavior |
 |----------|----------|
@@ -195,10 +195,10 @@ Output: structured JSON (`BenchmarkResult`) + human-readable summary table. Infe
 
 ## Logging
 
-- **Execution logs**: episode start/end, connection state, errors — JSON Lines format
+- **Execution logs**: episode start/end, connection state, errors in JSON Lines format
 - **Trajectory recording** (optional): per-episode observation/action sequences in msgpack. Each step: `{"step", "obs", "action", "reward", "done", "timestamp"}`
 - **Video recording** (optional): if `Benchmark.render()` is implemented, `EpisodeRunner` collects frames each step
-- **Metadata**: config file, Docker image version, seed — auto-recorded with results
+- **Metadata**: config file, Docker image version, and seed, auto-recorded with results
 
 ## Implementation Status
 
@@ -216,6 +216,4 @@ Output: structured JSON (`BenchmarkResult`) + human-readable summary table. Infe
 - ✅ Container lifecycle management
 - 🔜 Reference score comparison
 - 🔜 Video and trajectory recording
-
-
 

--- a/docs/rfcs/0005-model-server-isolation.md
+++ b/docs/rfcs/0005-model-server-isolation.md
@@ -9,7 +9,7 @@
 
 ## Summary
 
-Model servers should use PEP 723 inline script metadata ("uv scripts") for dependency isolation. This complements Docker isolation for benchmarks — benchmarks need strong OS-level isolation, while model servers need lightweight Python-level isolation.
+Model servers should use PEP 723 inline script metadata ("uv scripts") for dependency isolation. This complements Docker isolation for benchmarks: benchmarks need strong OS-level isolation, while model servers need lightweight Python-level isolation.
 
 ## Motivation
 
@@ -23,15 +23,15 @@ Currently, model servers run on the host with no isolation.
 
 ### Why Not Docker?
 - GPU passthrough is cumbersome (nvidia-container-toolkit, --gpus all)
-- CUDA/cuDNN pinned in image — host mismatch causes failures
+- CUDA/cuDNN pinned in image; host mismatch causes failures
 - Model checkpoint/HuggingFace cache mounting adds complexity
 - Disproportionate overhead for "one Python script"
 
 ### Why uv Scripts Fit
 - Model servers are fundamentally "one Python script"
-- GPU uses host drivers directly — most natural path
+- GPU uses host drivers directly, the most natural path
 - Python-level isolation sufficient (no C library conflicts between models)
-- uv creates venv + installs deps automatically — zero user friction
+- uv creates venv + installs deps automatically, with zero user friction
 - PEP 723 is a Python standard
 
 ## Design
@@ -74,7 +74,7 @@ vla-eval serve --config configs/model_servers/dexbotic_cogact_libero.yaml
 |---|---|---|
 | Isolation reason | Simulator conflicts (robosuite vs SAPIEN) | Model dep differences (transformers versions) |
 | GPU needed | Often (rendering) | Yes (inference) |
-| Conflict severity | Strong — OS libs, C bindings | Weak — Python packages |
+| Conflict severity | Strong: OS libs, C bindings | Weak: Python packages |
 | Right tool | Docker | uv script |
 
 ### External Contribution Model
@@ -88,8 +88,7 @@ vla-eval serve --config configs/model_servers/dexbotic_cogact_libero.yaml
 - Cache management for overlapping deps across scripts?
 
 ## Implementation Status
-- ✅ PEP 723 inline script metadata — CogACT reference (`model_servers/cogact.py`)
+- ✅ PEP 723 inline script metadata: CogACT reference (`model_servers/cogact.py`)
 - ✅ `vla-eval serve` CLI wrapping `uv run` (`cli/main.py`)
 - ✅ Model server YAML config format (`configs/model_servers/`)
 - ✅ Documentation (`CONTRIBUTING.md`)
-

--- a/docs/rfcs/0006-episode-sharding.md
+++ b/docs/rfcs/0006-episode-sharding.md
@@ -13,16 +13,16 @@ Add episode-level sharding so that N independent OS processes can evaluate disjo
 
 ## Motivation
 
-LIBERO Spatial: 10 tasks × 50 episodes × ~220 steps = ~110,000 steps, executed sequentially. A single evaluation run takes hours. The bottleneck is the serial alternation of CPU simulation and GPU inference — while one is working, the other is idle.
+LIBERO Spatial: 10 tasks × 50 episodes × ~220 steps = ~110,000 steps, executed sequentially. A single evaluation run takes hours. The bottleneck is the serial alternation of CPU simulation and GPU inference: while one is working, the other is idle.
 
 Parallelizing at the episode level is the most impactful optimization because:
-1. Episodes are independent — no shared state between them.
+1. Episodes are independent, with no shared state between them.
 2. Multiple simulation processes can overlap their inference wait time with other simulations.
 3. The model server already accepts multiple WebSocket clients concurrently.
 
 ### Why shell-level processes, not in-process multiprocessing?
 
-Some benchmark simulators (notably LIBERO/robosuite) have internal state that conflicts with Python `multiprocessing` (OpenGL contexts, MuJoCo shared memory, global state in `robosuite.utils`). Shell-level process isolation (`cmd &`) avoids these issues entirely — each process gets its own address space with no shared state.
+Some benchmark simulators (notably LIBERO/robosuite) have internal state that conflicts with Python `multiprocessing` (OpenGL contexts, MuJoCo shared memory, global state in `robosuite.utils`). Shell-level process isolation (`cmd &`) avoids these issues entirely because each process gets its own address space with no shared state.
 
 ## Design
 
@@ -131,7 +131,7 @@ The `_run_via_docker` function forwards `--shard-id` and `--num-shards` to the c
 
 N shard processes connect to the same model server URL. The server already handles multiple WebSocket clients via `websockets.serve` (one coroutine per connection). `PredictModelServer` dispatches each request to `run_in_executor`, so N concurrent requests run in N threads.
 
-This is **not** true GPU batching — requests are serialized on the GPU. True batching requires `BatchPredictModelServer` (RFC-0003, future work). However, even without batching, sharding provides significant speedup because simulation time in one process overlaps with inference time in another.
+This is **not** true GPU batching; requests are serialized on the GPU. True batching requires `BatchPredictModelServer` (RFC-0003, future work). However, even without batching, sharding provides significant speedup because simulation time in one process overlaps with inference time in another.
 
 ## Implementation Scope
 
@@ -147,7 +147,5 @@ Total: ~230 lines of new/changed code.
 
 ## Future Work
 
-- **`vla-eval run-parallel`**: Convenience wrapper that spawns N shard processes + auto-merges. Not needed for v1 — shell scripts suffice.
-
-
+- **`vla-eval run-parallel`**: Convenience wrapper that spawns N shard processes + auto-merges. Not needed for v1; shell scripts suffice.
 

--- a/docs/rfcs/0007-batch-predict-model-server.md
+++ b/docs/rfcs/0007-batch-predict-model-server.md
@@ -69,7 +69,7 @@ Key properties:
 
 ```python
 async def on_observation(self, obs, ctx):
-    # 1. Check chunk buffer — serve cached action if available
+    # 1. Check chunk buffer; serve cached action if available
     if self.chunk_size > 1:
         buf = self._chunk_buffers.get(ctx.session_id)
         if buf and not buf.empty:
@@ -134,6 +134,4 @@ N shard processes produce N concurrent WebSocket connections. The server's async
 - Verify `max_wait_time` triggers partial batch dispatch.
 - Verify chunk buffer serves cached actions without enqueuing.
 - Verify exception in `predict_batch` propagates to all awaiting callers.
-
-
 

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -1,6 +1,6 @@
 # RFCs
 
-Design documents for `vla-evaluation-harness` — a framework for evaluating Vision-Language-Action (VLA) models across robot simulation benchmarks.
+Design documents for `vla-evaluation-harness`, a framework for evaluating Vision-Language-Action (VLA) models across robot simulation benchmarks.
 
 RFCs capture significant architectural decisions and proposed changes. They exist so contributors can understand *why* the system works the way it does, and to provide a lightweight review process for non-trivial changes.
 
@@ -52,7 +52,7 @@ RFCs capture significant architectural decisions and proposed changes. They exis
 |-------|-------------|
 | **Author** | GitHub handle(s) of the author(s) |
 | **Status** | See [Status Definitions](#status-definitions) above |
-| **Type** | *Standards Track* — changes to interfaces, protocols, or behavior. *Informational* — guidelines, conventions, or background |
+| **Type** | *Standards Track*: changes to interfaces, protocols, or behavior. *Informational*: guidelines, conventions, or background |
 | **Created** | Date the RFC was first written |
 | **Requires** | Other RFCs this one depends on, or `—` if none |
 | **Superseded-By** | RFC that replaces this one, or `—` if still active |

--- a/docs/tuning-guide.md
+++ b/docs/tuning-guide.md
@@ -14,7 +14,7 @@ These interact: the optimal value of each depends on the others. Two benchmark s
 
 ## Resource Allocation
 
-By default, `vla-eval` assumes the benchmark host is fully dedicated to the evaluation — all CPUs and GPUs are available for shard containers. If you share the machine with other workloads, use `--cpus` and `--gpus` to restrict resources (see below).
+By default, `vla-eval` assumes the benchmark host is fully dedicated to the evaluation, with all CPUs and GPUs available for shard containers. If you share the machine with other workloads, use `--cpus` and `--gpus` to restrict resources (see below).
 
 When running sharded evaluations, each Docker container receives isolated CPU and GPU resources automatically via [`docker_resources.py`](../src/vla_eval/docker_resources.py):
 
@@ -24,7 +24,7 @@ When running sharded evaluations, each Docker container receives isolated CPU an
 | **CPU** | All host CPUs | Partitioned evenly (e.g. 48 cores / 8 shards = 6 cores each) |
 | **Threads** | Default | `OMP_NUM_THREADS=1`, `MKL_NUM_THREADS=1` |
 
-Thread pinning (`OMP_NUM_THREADS=1`) prevents cross-container contention — without it, each shard spawns one OpenMP thread per visible core, causing massive context-switch overhead (e.g. 8 shards × 48 threads = 384 threads on 48 cores).
+Thread pinning (`OMP_NUM_THREADS=1`) prevents cross-container contention. Without it, each shard spawns one OpenMP thread per visible core, causing massive context-switch overhead (e.g. 8 shards × 48 threads = 384 threads on 48 cores).
 
 Override via CLI flags:
 
@@ -43,7 +43,7 @@ docker:
   cpus: "0-31"
 ```
 
-## Step 1: Measure Demand — λ(N)
+## Step 1: Measure Demand, λ(N)
 
 > "With N shards, how many inference requests/sec does the environment generate?"
 
@@ -58,7 +58,7 @@ Starts an instant-response server and launches N real Docker shards against it. 
 
 **What to look for**: λ(N) grows linearly at first, then flattens at high N due to host contention.
 
-## Step 2: Measure Supply — μ(B)
+## Step 2: Measure Supply, μ(B)
 
 > "How many requests/sec can the model server process under saturation?"
 
@@ -78,17 +78,17 @@ Floods the running model server with saturating clients while sweeping `max_batc
 
 If the server uses chunk buffering (chunk_size > 1), only 1 out of every chunk_size requests triggers GPU inference. Set `--requests-per-client` high enough that each client triggers many inferences (e.g. ≥ chunk_size × 15). Too few requests yields noisy, unreliable throughput numbers.
 
-**What to look for**: μ grows with B but eventually plateaus (or even degrades due to padding overhead). The optimal `max_batch_size` is at the knee — not necessarily the maximum.
+**What to look for**: μ grows with B but eventually plateaus (or even degrades due to padding overhead). The optimal `max_batch_size` is at the knee, not necessarily the maximum.
 
 ## Step 3: Combine the Curves
 
 Read the tables from Step 1 and Step 2.
 
-**Rule of thumb: always keep λ(N) < μ(B\*).** If demand exceeds supply, the server's request queue grows without bound — latency climbs over time, clients eventually hit their response timeout, and you get connection drops, lost episodes, and cascading failures. The correct approach is to maximize demand (more shards = faster wall-clock) while staying strictly below the supply ceiling.
+**Rule of thumb: always keep λ(N) < μ(B\*).** If demand exceeds supply, the server's request queue grows without bound. Latency climbs over time, clients eventually hit their response timeout, and you get connection drops, lost episodes, and cascading failures. The correct approach is to maximize demand (more shards = faster wall-clock) while staying strictly below the supply ceiling.
 
-1. **`max_batch_size = B*`**: Find the optimal B that maximizes μ — pick B at the knee where μ(B) starts to plateau. Larger B does not always help (padding overhead, memory pressure). This sets the supply ceiling.
+1. **`max_batch_size = B*`**: Find the optimal B that maximizes μ. Pick B at the knee where μ(B) starts to plateau. Larger B does not always help (padding overhead, memory pressure). This sets the supply ceiling.
 
-2. **`num_shards = N*`**: Maximize λ while keeping λ(N) < ~80% of μ(B*) — pick the largest N that stays well below the supply ceiling.
+2. **`num_shards = N*`**: Maximize λ while keeping λ(N) < ~80% of μ(B*). Pick the largest N that stays well below the supply ceiling.
    - A ~20% margin absorbs variance in per-step timing, batch fill fluctuations, and GC pauses. Without margin, λ ≈ μ puts you right at the edge where transient spikes cause queue buildup.
    - More shards = faster wall-clock, but you must not cross μ(B*).
    - Also watch for host contention: beyond a certain N, per-shard throughput degrades even if the aggregate λ stays below μ.
@@ -128,7 +128,7 @@ args:
   max_wait_time: 0.05
 ```
 
-Under the hood, `vla-eval serve` resolves `script` to an absolute path, converts `args` into CLI flags (`--key value`; bools become bare `--flag`), and runs `uv run <script> <flags>`. The script's inline metadata (`# /// script`) declares its own dependencies, so `uv` creates an isolated environment automatically — no manual install needed.
+Under the hood, `vla-eval serve` resolves `script` to an absolute path, converts `args` into CLI flags (`--key value`; bools become bare `--flag`), and runs `uv run <script> <flags>`. The script's inline metadata (`# /// script`) declares its own dependencies, so `uv` creates an isolated environment automatically without a manual install.
 
 To run on a specific GPU, set `CUDA_VISIBLE_DEVICES` before the command.
 
@@ -138,9 +138,9 @@ Server configs live in `configs/model_servers/`. The `--sweep-batch-sizes` flag 
 
 Before running the demand/supply benchmarks, you may want to measure the basic timing properties of your setup:
 
-- **`experiments/measure_sim_delay.py`** — Instant server that records per-step timestamps. Run alongside a single Docker shard to measure per-step simulation time. Useful for sanity-checking demand curve results.
+- **`experiments/measure_sim_delay.py`**: Instant server that records per-step timestamps. Run alongside a single Docker shard to measure per-step simulation time. Useful for sanity-checking demand curve results.
 
-- **`experiments/measure_inference_delay.py`** — Sends realistic observations to a running model server and measures per-request latency. Useful for sanity-checking supply curve results and separating cold-start from warm inference.
+- **`experiments/measure_inference_delay.py`**: Sends realistic observations to a running model server and measures per-request latency. Useful for sanity-checking supply curve results and separating cold-start from warm inference.
 
 ## Worked Example: DB-CogACT
 
@@ -152,9 +152,9 @@ DB-CogACT (dexbotic fine-tuned CogACT 7B) is evaluated across three benchmarks w
 | CALVIN ABC→D | GPU EGL (PyBullet) | 7 | 1000 sequences × 5 subtasks | 200×200 |
 | SimplerEnv | GPU (SAPIEN/Vulkan) | 5 | 96 (4 tasks × 24 ep) | 224×224 |
 
-### Supply — μ(B)
+### Supply: μ(B)
 
-The supply curve below was measured with the LIBERO checkpoint (chunk_size=12). **chunk_size directly affects supply**: with chunk_size=C, only 1 out of every C observations triggers GPU inference — the rest are served from the cached action chunk. Smaller chunk_size means more frequent GPU inference, so lower obs/s throughput.
+The supply curve below was measured with the LIBERO checkpoint (chunk_size=12). **chunk_size directly affects supply**: with chunk_size=C, only 1 out of every C observations triggers GPU inference; the rest are served from the cached action chunk. Smaller chunk_size means more frequent GPU inference, so lower obs/s throughput.
 
 ```bash
 # Start server:
@@ -169,7 +169,7 @@ uv run python experiments/bench_supply.py \
     --image-size 256
 ```
 
-**A100-80GB (PCIe)** — chunk_size=12:
+**A100-80GB (PCIe)**, chunk_size=12:
 
 | B (max_batch_size) | μ (obs/s) | Inference latency (p50) |
 |:------------------:|:---------:|:-----------------------:|
@@ -181,7 +181,7 @@ uv run python experiments/bench_supply.py \
 | 24                 | 196.6     | 51.4ms                  |
 | 32                 | 201.4     | 68.4ms                  |
 
-**H100-80GB SXM** — chunk_size=12:
+**H100-80GB SXM**, chunk_size=12:
 
 | B (max_batch_size) | μ (obs/s) | Inference latency (p50) |
 |:------------------:|:---------:|:-----------------------:|
@@ -203,11 +203,11 @@ A100 peaks at B=16 (203.1 obs/s), H100 peaks at B=24 (485.5 obs/s). The pipeline
 | 7 (CALVIN) | ~118 obs/s | ~283 obs/s |
 | 5 (SimplerEnv) | ~85 obs/s | ~202 obs/s |
 
-These are linear estimates (μ ≈ inf/s × C). Actual supply may differ — run `bench_supply.py` with each checkpoint for precise numbers.
+These are linear estimates (μ ≈ inf/s × C). Actual supply may differ; run `bench_supply.py` with each checkpoint for precise numbers.
 
 ### LIBERO Spatial (chunk_size=12, GPU EGL rendering)
 
-#### Demand — λ(N)
+#### Demand: λ(N)
 
 ```bash
 uv run python experiments/bench_demand.py \
@@ -229,7 +229,7 @@ uv run python experiments/bench_demand.py \
 | 80         | 88,000       | 196.8       | 446.8     |
 | 100        | 110,000      | 282.3       | 389.4     |
 
-λ(N) scales nearly linearly through N=80, peaking at 446.8 obs/s. Per-shard throughput gradually decreases from ~11.2 obs/s/shard (N=1) to ~7.3 (N=50), then degrades more sharply at N=64 (~6.4) and N=80 (~5.6) from host-level CPU/Docker overhead. At N=100, aggregate throughput drops to 389.4 obs/s — contention overwhelms parallelism. **Peak demand: N=80, λ≈447 obs/s.**
+λ(N) scales nearly linearly through N=80, peaking at 446.8 obs/s. Per-shard throughput gradually decreases from ~11.2 obs/s/shard (N=1) to ~7.3 (N=50), then degrades more sharply at N=64 (~6.4) and N=80 (~5.6) from host-level CPU/Docker overhead. At N=100, aggregate throughput drops to 389.4 obs/s because contention overwhelms parallelism. **Peak demand: N=80, λ≈447 obs/s.**
 
 #### Derivation
 
@@ -242,11 +242,11 @@ uv run python experiments/bench_demand.py \
 
 1. **`max_batch_size`**: A100 peaks at B=16, H100 at B=24.
 
-2. **`num_shards`**: Per-shard demand is ~7.3 obs/s. With ~20% margin: N ≤ 0.8 × μ(B*) / 7.3 → A100: 0.8×203.1/7.3 ≈ 22, H100: 0.8×485.5/7.3 ≈ 53. Rounded down to **20** and **50** so that LIBERO Spatial's 500 work items divide evenly — 25 episodes/shard (A100) and 10 episodes/shard (H100).
+2. **`num_shards`**: Per-shard demand is ~7.3 obs/s. With ~20% margin: N ≤ 0.8 × μ(B*) / 7.3 → A100: 0.8×203.1/7.3 ≈ 22, H100: 0.8×485.5/7.3 ≈ 53. Rounded down to **20** and **50** so that LIBERO Spatial's 500 work items divide evenly: 25 episodes/shard (A100) and 10 episodes/shard (H100).
 
 3. **`max_wait_time`**: predict_rate = λ(N) / chunk_size. A100: 146/12 ≈ 12.2 → 16/12.2 ≈ 1.31s. H100: 365/12 ≈ 30.4 → 24/30.4 ≈ 0.79s.
 
-**Production result (H100, 50 shards)**: All 4 LIBERO suites (2000 episodes) completed in **~18 min** wall-clock with `max_batch_size=16`, `max_wait_time=0.05` — a ~47× throughput gain over sequential execution. See `docs/reproductions/db-cogact.md` (LIBERO section) for full results.
+**Production result (H100, 50 shards)**: All 4 LIBERO suites (2000 episodes) completed in **~18 min** wall-clock with `max_batch_size=16`, `max_wait_time=0.05`, a ~47× throughput gain over sequential execution. See `docs/reproductions/db-cogact.md` (LIBERO section) for full results.
 
 **Scaling note**: H100 supply (485.5 obs/s) exceeds single-host demand peak (446.8 obs/s at N=80), so one H100 can saturate a full host of Docker shards. A100 (203.1 obs/s) requires ~2 replicas to match peak demand.
 
@@ -254,7 +254,7 @@ uv run python experiments/bench_demand.py \
 
 CALVIN uses PyBullet with GPU EGL rendering (like LIBERO). Physics is CPU but image rendering uses GPU via EGL. Each sequence chains 5 subtasks with up to 360 steps each. PyBullet steps are faster than MuJoCo, giving CALVIN a much higher per-shard observation rate (~36.7 obs/s vs LIBERO's ~11.2 obs/s).
 
-#### Demand — λ(N)
+#### Demand: λ(N)
 
 ```bash
 uv run python experiments/bench_demand.py \
@@ -273,9 +273,9 @@ uv run python experiments/bench_demand.py \
 | 24         | 25,920       | 60.0        | 432.3     |
 | 32         | 34,560       | 87.6        | 394.6     |
 
-λ(N) scales well through N=24, peaking at 432.3 obs/s. Per-shard throughput decreases from ~36.7 obs/s/shard (N=1) to ~23.5 (N=16) to ~18.0 (N=24) to ~12.3 (N=32). At N=32, aggregate throughput drops — CPU/Docker overhead overwhelms parallelism. **Peak demand: N=24, λ≈432 obs/s.**
+λ(N) scales well through N=24, peaking at 432.3 obs/s. Per-shard throughput decreases from ~36.7 obs/s/shard (N=1) to ~23.5 (N=16) to ~18.0 (N=24) to ~12.3 (N=32). At N=32, aggregate throughput drops because CPU/Docker overhead overwhelms parallelism. **Peak demand: N=24, λ≈432 obs/s.**
 
-CALVIN's high per-shard obs rate means demand exceeds the estimated H100 supply (~283 obs/s) at just N=16. This makes CALVIN **supply-bottlenecked** — unlike LIBERO and SimplerEnv where demand is the bottleneck.
+CALVIN's high per-shard obs rate means demand exceeds the estimated H100 supply (~283 obs/s) at just N=16. This makes CALVIN **supply-bottlenecked**, unlike LIBERO and SimplerEnv where demand is the bottleneck.
 
 #### Derivation
 
@@ -286,21 +286,21 @@ CALVIN's high per-shard obs rate means demand exceeds the estimated H100 supply 
 | **num_shards**     | 16                |
 | **max_wait_time**  | 0.42s             |
 
-1. **`max_batch_size`**: H100 peaks at B=24 at chunk_size=12. Optimal B may differ at chunk_size=7 — run `bench_supply.py` with the CALVIN checkpoint to confirm.
+1. **`max_batch_size`**: H100 peaks at B=24 at chunk_size=12. Optimal B may differ at chunk_size=7; run `bench_supply.py` with the CALVIN checkpoint to confirm.
 
-2. **`num_shards`**: Per-shard demand is ~23.5 obs/s at N=16. With ~20% margin: N ≤ 0.8 × 283 / 23.5 ≈ 9.6. However, CALVIN is supply-bottlenecked — even at N=16, demand (376 obs/s) exceeds estimated supply (~283 obs/s). In practice, the server's batch queue absorbs the excess demand without failures because chunk buffering reduces actual predict calls to ~54/s (376/7). Use **16** shards so that 1000 sequences divide into ~62–63 per shard.
+2. **`num_shards`**: Per-shard demand is ~23.5 obs/s at N=16. With ~20% margin: N ≤ 0.8 × 283 / 23.5 ≈ 9.6. However, CALVIN is supply-bottlenecked; even at N=16, demand (376 obs/s) exceeds estimated supply (~283 obs/s). In practice, the server's batch queue absorbs the excess demand without failures because chunk buffering reduces actual predict calls to ~54/s (376/7). Use **16** shards so that 1000 sequences divide into ~62–63 per shard.
 
-3. **`max_wait_time`**: predict_rate = λ(N) / chunk_size. At N=16 (supply-limited, effective λ ≈ 283): 283 / 7 ≈ 40.4 → 24 / 40.4 ≈ 0.59s. In production, `max_wait_time=0.05s` was used — batches fill almost instantly because demand far exceeds supply, so the wait timer rarely fires.
+3. **`max_wait_time`**: predict_rate = λ(N) / chunk_size. At N=16 (supply-limited, effective λ ≈ 283): 283 / 7 ≈ 40.4 → 24 / 40.4 ≈ 0.59s. In production, `max_wait_time=0.05s` was used because batches fill almost instantly when demand far exceeds supply, so the wait timer rarely fires.
 
-**Production result (H100, 16 shards)**: All 1000 sequences completed in **~33 min** wall-clock with `max_batch_size=16`, `max_wait_time=0.05` — a ~16× throughput gain over sequential (513.9 min). See `docs/reproductions/db-cogact.md` (CALVIN section) for full results (Avg Len 4.051, reproducing reference 4.063).
+**Production result (H100, 16 shards)**: All 1000 sequences completed in **~33 min** wall-clock with `max_batch_size=16`, `max_wait_time=0.05`, a ~16× throughput gain over sequential (513.9 min). See `docs/reproductions/db-cogact.md` (CALVIN section) for full results (Avg Len 4.051, reproducing reference 4.063).
 
 **Supply-bottleneck note**: CALVIN's fast PyBullet rendering generates demand faster than the model server can process. The server's internal queue absorbs bursts, but sustained overload would increase latency. To increase throughput: (a) use a faster GPU, (b) reduce num_shards to stay within supply, or (c) run multiple model server replicas behind a load balancer.
 
 ### SimplerEnv WidowX Bridge (chunk_size=5, GPU rendering)
 
-SimplerEnv uses SAPIEN/Vulkan GPU rendering on the benchmark host. Multiple shards compete for GPU memory and compute — like LIBERO/CALVIN (EGL) but with heavier GPU usage per shard.
+SimplerEnv uses SAPIEN/Vulkan GPU rendering on the benchmark host. Multiple shards compete for GPU memory and compute, as in LIBERO/CALVIN (EGL), but with heavier GPU usage per shard.
 
-#### Demand — λ(N)
+#### Demand: λ(N)
 
 ```bash
 uv run python experiments/bench_demand.py \
@@ -320,9 +320,9 @@ uv run python experiments/bench_demand.py \
 | 24         | 42,825       | 298.1       | 143.7 *   |
 | 32         | 41,484       | 300.6       | 138.0 *   |
 
-\* timeout — partial results
+\* timeout, partial results
 
-λ(N) scales sub-linearly from the start because multiple SAPIEN rendering shards contend for GPU resources on the benchmark host. Per-shard throughput drops from ~10.1 obs/s/shard (N=1) to ~7.2 (N=8) to ~6.0 (N=24). At N=32, aggregate throughput actually decreases — GPU contention between rendering shards overwhelms parallelism. **Peak demand: N=24, λ≈144 obs/s.** Far lower than LIBERO's 447 obs/s peak because SAPIEN shards consume significantly more GPU memory per shard than MuJoCo EGL.
+λ(N) scales sub-linearly from the start because multiple SAPIEN rendering shards contend for GPU resources on the benchmark host. Per-shard throughput drops from ~10.1 obs/s/shard (N=1) to ~7.2 (N=8) to ~6.0 (N=24). At N=32, aggregate throughput actually decreases because GPU contention between rendering shards overwhelms parallelism. **Peak demand: N=24, λ≈144 obs/s.** Far lower than LIBERO's 447 obs/s peak because SAPIEN shards consume significantly more GPU memory per shard than MuJoCo EGL.
 
 #### Derivation
 
@@ -333,9 +333,9 @@ uv run python experiments/bench_demand.py \
 | **num_shards**     | 16                |
 | **max_wait_time**  | 0.93s             |
 
-1. **`max_batch_size`**: H100 peaks at B=24 at chunk_size=12. Optimal B may differ at chunk_size=5 — run `bench_supply.py` with the SimplerEnv checkpoint to confirm.
+1. **`max_batch_size`**: H100 peaks at B=24 at chunk_size=12. Optimal B may differ at chunk_size=5; run `bench_supply.py` with the SimplerEnv checkpoint to confirm.
 
-2. **`num_shards`**: Per-shard demand is ~7.2 obs/s at moderate N. With ~20% margin: N ≤ 0.8 × 202 / 7.2 ≈ 22. However, SimplerEnv's GPU rendering saturates demand at N=24 (λ≈144 obs/s) — adding more shards decreases throughput. Rounded down to **16** so that 96 work items (4 tasks × 24 episodes) divide evenly — 6 episodes/shard. λ(16) ≈ 128.4 obs/s, below the ~202 estimated supply ceiling.
+2. **`num_shards`**: Per-shard demand is ~7.2 obs/s at moderate N. With ~20% margin: N ≤ 0.8 × 202 / 7.2 ≈ 22. However, SimplerEnv's GPU rendering saturates demand at N=24 (λ≈144 obs/s), and adding more shards decreases throughput. Rounded down to **16** so that 96 work items (4 tasks × 24 episodes) divide evenly: 6 episodes/shard. λ(16) ≈ 128.4 obs/s, below the ~202 estimated supply ceiling.
 
 3. **`max_wait_time`**: predict_rate = λ(N) / chunk_size = 128.4 / 5 ≈ 25.7 → 24 / 25.7 ≈ 0.93s.
 
@@ -355,7 +355,7 @@ uv run python experiments/bench_demand.py \
 | **Headroom**       | 28%                   | 25%                   | −33% (supply-bottlenecked) | 37%   |
 
 Key takeaways:
-- **Lightweight GPU rendering** (LIBERO, CALVIN via EGL) scales to many more shards — MuJoCo/PyBullet EGL uses minimal GPU memory per shard.
+- **Lightweight GPU rendering** (LIBERO, CALVIN via EGL) scales to many more shards because MuJoCo/PyBullet EGL uses minimal GPU memory per shard.
 - **GPU-rendered benchmarks** (SimplerEnv) saturate much earlier because rendering shards contend for GPU resources on the benchmark host. Spread shards across multiple GPUs to increase demand headroom.
 - **Supply-bottlenecked benchmarks** (CALVIN): Fast per-shard obs rate + small chunk_size can push demand above supply. The server queue absorbs bursts, but sustained overload increases latency. Use fewer shards, a faster GPU, or model server replicas.
 - **chunk_size** directly affects both supply and max_wait_time: larger chunks (LIBERO=12) mean fewer GPU inferences per observation → higher supply ceiling but slower batch fill → longer max_wait_time. Smaller chunks (SimplerEnv=5) → lower supply ceiling but faster batch fill → shorter max_wait_time.

--- a/leaderboard/CLAUDE.md
+++ b/leaderboard/CLAUDE.md
@@ -1,10 +1,10 @@
 # leaderboard/
 
-This directory is a **standalone static leaderboard site** — it is NOT vla-eval output.
+This directory is a **standalone static leaderboard site**. It is NOT vla-eval output.
 
 ## Key distinction
 
-- `leaderboard/data/leaderboard.json` contains scores **reported in published papers**. These are manually curated or produced by the `extract.py` / `refine.py` pipeline — not produced by running `vla-eval`.
+- `leaderboard/data/leaderboard.json` contains scores **reported in published papers**. These are manually curated or produced by the `extract.py` / `refine.py` pipeline, not produced by running `vla-eval`.
 - `vla-eval` is the evaluation harness (the parent repo). Its runtime outputs go to `results/` or user-specified paths, never here.
 
 Do not conflate leaderboard data with vla-eval reproduced results. They are independent.

--- a/leaderboard/CONTRIBUTING.md
+++ b/leaderboard/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to the VLA Leaderboard
 
-> **Note on evaluation protocols:** Benchmark evaluation protocols are not fully standardized across the VLA community. Different papers may use the same benchmark name but differ in training regimes, task subsets, or evaluation conditions — making scores not always directly comparable. This leaderboard records all available results transparently and documents known protocol differences, but gaps remain. We actively welcome contributions: score corrections, missing results, protocol clarifications, and proposals for standardization.
+> **Note on evaluation protocols:** Benchmark evaluation protocols are not fully standardized across the VLA community. Different papers may use the same benchmark name but differ in training regimes, task subsets, or evaluation conditions, so scores are not always directly comparable. This leaderboard records all available results transparently and documents known protocol differences, but gaps remain. We actively welcome contributions: score corrections, missing results, protocol clarifications, and proposals for standardization.
 
 ## Local Setup
 
@@ -20,31 +20,31 @@ Data is split into focused files under `leaderboard/data/`:
 | File | Contents |
 |------|----------|
 | `leaderboard.json` | Curated entries (`last_updated` + `results[]`) |
-| `benchmarks.json` | Benchmark registry (build artifact — see below) |
+| `benchmarks.json` | Benchmark registry (build artifact; see below) |
 | `citations.json` | Per-paper citation counts from Semantic Scholar |
 | `coverage.json` | Per-benchmark coverage stats |
 | `extractions.json` | Packed per-paper extractions (optional, for reproducibility) |
 
 ### Schemas (single source of truth)
 
-Every field in the data files is defined in a JSON Schema with inline descriptions. Consult the schema before writing code, prompts, or docs — do not re-describe field semantics elsewhere.
+Every field in the data files is defined in a JSON Schema with inline descriptions. Consult the schema before writing code, prompts, or docs; do not re-describe field semantics elsewhere.
 
 | Schema | Covers |
 |--------|--------|
-| `leaderboard.schema.json` | `leaderboard.json` — final curated entries |
-| `benchmarks.schema.json` | `benchmarks.json` — registry shape |
+| `leaderboard.schema.json` | `leaderboard.json`: final curated entries |
+| `benchmarks.schema.json` | `benchmarks.json`: registry shape |
 | `extraction.schema.json` | One paper's extract.py output. `extractions.json` is an array of these. |
-| `candidates.schema.json` | `.cache/refine_candidates.json` — refine-stage input |
+| `candidates.schema.json` | `.cache/refine_candidates.json`: refine-stage input |
 
 Per-benchmark protocol (Standard / Scoring / Checks / Methodology) lives in `leaderboard/benchmarks/{key}.md`. Frontmatter compiles into `benchmarks.json`; the markdown body is the LLM-facing protocol prose consumed by `extract.py` and `refine.py`.
 
-**`benchmarks.json` is a build artifact — never edit it directly.** After editing any frontmatter, rebuild:
+**`benchmarks.json` is a build artifact; never edit it directly.** After editing any frontmatter, rebuild:
 
 ```
 python leaderboard/scripts/build_benchmarks_json.py
 ```
 
-CI runs `build_benchmarks_json.py --check` on every PR — if the committed `benchmarks.json` diverges from the md sources, the PR fails. Per-benchmark coverage (reviewed-paper counts) is derived from extraction records by `scan.py`, not stored in `benchmarks.json`.
+CI runs `build_benchmarks_json.py --check` on every PR. If the committed `benchmarks.json` diverges from the md sources, the PR fails. Per-benchmark coverage (reviewed-paper counts) is derived from extraction records by `scan.py`, not stored in `benchmarks.json`.
 
 ## How to Add Results
 
@@ -69,11 +69,11 @@ extract.py run --from-scan   # per-paper LLM extraction → .cache/extractions/
 refine.py main               # protocol gate + per-benchmark LLM refinement → leaderboard.json
 ```
 
-Field semantics live in the schema files above. `extract.py` and `refine.py` both load their respective schemas at runtime — the prompts reference the schema, not duplicate its field rules.
+Field semantics live in the schema files above. `extract.py` and `refine.py` both load their respective schemas at runtime; the prompts reference the schema, not duplicate its field rules.
 
 ## Official Leaderboard Policy
 
-Benchmarks with `official_leaderboard` in their registry entry require **API-synced entries only** — `curated_by` must end with `-api`. Manual paper extractions are prohibited. `validate.py` enforces this.
+Benchmarks with `official_leaderboard` in their registry entry require **API-synced entries only**. `curated_by` must end with `-api`. Manual paper extractions are prohibited. `validate.py` enforces this.
 
 ## CI/CD
 
@@ -83,4 +83,4 @@ Benchmarks with `official_leaderboard` in their registry entry require **API-syn
 
 ## Benchmark Protocols
 
-Per-benchmark Standard, Scoring, Checks, and Methodology axes live in `leaderboard/benchmarks/{key}.md`. That file is the single source — this document does not mirror it.
+Per-benchmark Standard, Scoring, Checks, and Methodology axes live in `leaderboard/benchmarks/{key}.md`. That file is the single source; this document does not mirror it.

--- a/leaderboard/README.md
+++ b/leaderboard/README.md
@@ -2,4 +2,4 @@
 
 **Leaderboard: https://allenai.github.io/vla-evaluation-harness/leaderboard/**
 
-Updated monthly. Missing results or incorrect scores? PRs welcome — see [CONTRIBUTING.md](CONTRIBUTING.md).
+Updated monthly. Missing results or incorrect scores? PRs welcome; see [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
## Summary

- Rewrite em dash usage in README, CONTRIBUTING, CLAUDE, and core docs/RFC Markdown using context-appropriate punctuation or prose.
- Preserve em dash placeholders and sentinel values in tables and RFC metadata, where `—` is the clearest convention.
- Leave generated data, benchmark registry prose, per-codebase reproduction reports, proposal surveys, and code untouched.

## Verification

- `rg -n "—" --glob 'README.md' --glob 'CONTRIBUTING.md' --glob 'CLAUDE.md'` (remaining hits are table/RFC placeholders only)
- `rg -n "—" README.md CONTRIBUTING.md CLAUDE.md docs/architecture.md docs/design-philosophy.md docs/tuning-guide.md docs/rfcs leaderboard/README.md leaderboard/CLAUDE.md leaderboard/CONTRIBUTING.md configs/benchmarks/duobench/README.md docker/README.md docs/reproductions/README.md` (remaining hits are table/RFC placeholders only)
- `git diff --check`
- `UV_CACHE_DIR=/tmp/uv-cache uv run python leaderboard/scripts/build_benchmarks_json.py --check`
- `UV_CACHE_DIR=/tmp/uv-cache uv run python -m pytest tests/test_config_validation.py`
