### PR TITLE
chore: use a generic descriptor for the external model-server caller in docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ CLI (cli/main.py)
 - **Episode-level error isolation**: One episode failure never aborts the entire evaluation.
 - **anyio-based async**: asyncio-compatible, not trio. Use anyio primitives for new async code.
 - **Parallel evaluation**: Environment parallelism via episode sharding + inference parallelism via batch forward passes.
-- **Recording goes through SQLite**: per-episode step rows + episode results + per-eval metadata live in `<output_dir>/recording-<eval_id>.sqlite`. WAL mode + `json_patch` UPSERT lets shards AND the model server (e.g. reflex-train) write concurrently and field-union step rows for the same `(sid, eid, step_id)`. `vla-eval merge` materialises the human-readable per-episode jsonl + per-benchmark aggregate JSON from that DB.
+- **Recording goes through SQLite**: per-episode step rows + episode results + per-eval metadata live in `<output_dir>/recording-<eval_id>.sqlite`. WAL mode + `json_patch` UPSERT lets shards AND the model server (e.g. a training pipeline) write concurrently and field-union step rows for the same `(sid, eid, step_id)`. `vla-eval merge` materialises the human-readable per-episode jsonl + per-benchmark aggregate JSON from that DB.
 
 ### Recording flow
 
@@ -61,7 +61,7 @@ CLI (cli/main.py)
 - Recording is configured at the **benchmark config's top-level `recording:` key** (sibling of `params`). The orchestrator reads this dict — `output_dir`, `filename_stem`, `record_video`, `record_step`, `video_fps` — and builds the recorder. Benchmarks are not involved in recording policy; they only decide *what* to record (which obs frame, which step fields).
 - Benchmark calls `recorder.record_video(frame)` / `recorder.record_step(row)`; the recorder buffers per-episode and flushes in one transaction at episode end.
 - `filename_stem` (default `"ep{episode_idx:04d}_{status}"`) is a `str.format` template against the task dict's serializable fields + `{status}`. The orchestrator validates it against the first task at startup so a typo fails fast.
-- Model server (optional, used by external callers like reflex-train) receives `(sid, eid, eval_id, db_path)` in the `EPISODE_START` WS payload and opens a `vla_eval.recording.StepRecorder` to push its own step rows. Field-union with the benchmark's rows is automatic via SQLite `json_patch`.
+- Model server (optional, used by external callers like a training pipeline) receives `(sid, eid, eval_id, db_path)` in the `EPISODE_START` WS payload and opens a `vla_eval.recording.StepRecorder` to push its own step rows. Field-union with the benchmark's rows is automatic via SQLite `json_patch`.
 - `vla-eval merge -c <config> [--eval-id <id>]` reads the DB and emits per-episode jsonl + a `BenchmarkResult`-shaped aggregate JSON. Single-shard `vla-eval run` invokes this inline; sharded runs delegate to `scripts/run_sharded.sh` which calls `vla-eval merge` once after `wait`.
 - `vla-eval run --no-save` skips recording entirely (in-memory only).
 

--- a/src/vla_eval/model_servers/base.py
+++ b/src/vla_eval/model_servers/base.py
@@ -29,7 +29,7 @@ class SessionContext:
             or ``""`` when recording is disabled.
         recording_db_path: Path to the SQLite file the harness writes to, or
             ``""`` when recording is disabled. External callers (e.g.
-            reflex-train) open a :class:`vla_eval.recording.StepRecorder` at
+            a training pipeline) open a :class:`vla_eval.recording.StepRecorder` at
             this path to record per-step inference traces alongside the
             benchmark's step rows.
         task: Task metadata dict sent by the client in ``EPISODE_START``.

--- a/src/vla_eval/runners/base.py
+++ b/src/vla_eval/runners/base.py
@@ -28,7 +28,7 @@ class EpisodeRunner(ABC):
         ``recorder`` (when active) is forwarded to ``benchmark.start_episode``
         so video frames and step rows are captured. The runner also bundles
         ``{sid, eid, eval_id, db_path}`` into the ``EPISODE_START`` WS payload
-        so model-server code (e.g. reflex-train) can open its own
+        so model-server code (e.g. a training pipeline) can open its own
         :class:`vla_eval.recording.StepRecorder` against the same SQLite file
         and field-union its inference traces with the benchmark's step rows.
         """

--- a/tests/test_recording_sqlite.py
+++ b/tests/test_recording_sqlite.py
@@ -213,7 +213,7 @@ def test_multi_writer_field_union(tmp_path: Path) -> None:
 
 
 def test_step_recorder_external_caller(tmp_path: Path) -> None:
-    """StepRecorder is the convenience API model-server code (e.g. reflex-train) uses.
+    """StepRecorder is the convenience API model-server code (e.g. a training pipeline) uses.
 
     It opens its own RecordingStore against the DB path the harness forwards in
     EPISODE_START, buffers rows in memory, and flushes them in a single


### PR DESCRIPTION
Generalizes the example external model-server caller named in two docstrings, `CLAUDE.md`, and one test docstring to the neutral descriptor **"a training pipeline"**. The mechanism being described (external model-server callers opening their own `StepRecorder` against the recording SQLite DB and field-unioning step rows) is unchanged.

Doc/comment-only; no logic touched. `ruff check` and `ruff format --check` pass on the touched Python files.
