### PR TITLE
Bump root uv exclude-newer cutoff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ testpaths = ["tests", "leaderboard/tests"]
 # Pin resolution to a known-good date so `uv sync` from a fresh clone
 # won't pick up a newly-published (and potentially compromised) dep
 # version without explicit intent. Bump when intentionally upgrading.
-exclude-newer = "2026-04-22"
+exclude-newer = "2026-07-07"
 
 [tool.ruff]
 line-length = 119

--- a/src/vla_eval/benchmarks/libero/benchmark.py
+++ b/src/vla_eval/benchmarks/libero/benchmark.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from typing import Any
+from typing import Any, cast
 
 import math
 
@@ -142,7 +142,7 @@ class LIBEROBenchmark(StepBenchmark):
             kwargs.setdefault("weights_only", False)
             return _original_torch_load(*args, **kwargs)
 
-        torch.load = _patched_load
+        torch.load = cast(Any, _patched_load)
 
         from libero.libero import benchmark
 

--- a/src/vla_eval/benchmarks/robotwin/benchmark.py
+++ b/src/vla_eval/benchmarks/robotwin/benchmark.py
@@ -18,7 +18,7 @@ import os
 import sys
 import types
 from contextlib import contextmanager
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 
@@ -260,6 +260,9 @@ class RoboTwinBenchmark(StepBenchmark):
         from envs import CONFIGS_PATH
 
         embodiment_type = args.get("embodiment")
+        if not isinstance(embodiment_type, list) or not all(isinstance(item, str) for item in embodiment_type):
+            raise ValueError(f"RoboTwin config {config_path!r} must define embodiment as a list of strings")
+        embodiment_type = cast(list[str], embodiment_type)
         with open(os.path.join(CONFIGS_PATH, "_embodiment_config.yml")) as f:
             _embodiment_types = yaml.safe_load(f)
 

--- a/src/vla_eval/model_servers/dexbotic/cogact.py
+++ b/src/vla_eval/model_servers/dexbotic/cogact.py
@@ -293,7 +293,9 @@ class CogACTModelServer(PredictModelServer):
         # Tokenize and pad input_ids
         all_ids = [tokenizer_image_token(p, self._tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt") for p in prompts]
         max_len = max(ids.shape[0] for ids in all_ids)
-        pad_id = self._tokenizer.pad_token_id if self._tokenizer.pad_token_id is not None else 0
+        pad_id = getattr(self._tokenizer, "pad_token_id", None)
+        if pad_id is None:
+            pad_id = 0
         padded = torch.full((B, max_len), pad_id, dtype=torch.long)
         attention_mask = torch.zeros(B, max_len, dtype=torch.long)
         for i, ids in enumerate(all_ids):

--- a/src/vla_eval/orchestrator.py
+++ b/src/vla_eval/orchestrator.py
@@ -309,7 +309,8 @@ class Orchestrator:
                     ep_result = cast(EpisodeResult, raw)
                     collector.record(task_name, ep_result)
                     ep_dict = dict(ep_result)
-                    success = bool((ep_dict.get("metrics") or {}).get("success"))
+                    metrics = ep_dict.get("metrics")
+                    success = bool(metrics.get("success")) if isinstance(metrics, dict) else False
                     logger.info(
                         "  [%d/%d] %s ep%d: %s (steps=%d)",
                         item_idx + 1,


### PR DESCRIPTION
## Summary

- Bump the root `[tool.uv].exclude-newer` cutoff from `2026-04-22` to `2026-07-07`.
- Keep `uv.lock` out of the PR intentionally; this repo ignores `uv.lock` and pins resolution through `pyproject.toml`.
- Fix the small set of type issues exposed by the refreshed toolchain (`ty 0.0.56`):
  - mark LIBERO's intentional `torch.load` monkeypatch with an explicit cast
  - validate RoboTwin `embodiment` config before indexing it
  - avoid static attribute assumptions for CogACT's dynamic tokenizer
  - guard orchestrator metric extraction before `.get()`

## Verification

- `uv lock --upgrade`
- `uv run --python 3.11 ruff check`
- `uv run --python 3.11 ruff format --check`
- `uv run --python 3.11 ty check`
- `UV_TORCH_BACKEND=auto uv sync --python 3.11 --all-extras --dev`
- `uv run --python 3.11 pytest tests/`
  - `352 passed, 3 skipped`
- `uv sync --python 3.11 --no-install-project --dev --group leaderboard`
- `uv run --python 3.11 pytest leaderboard/tests/`
  - `6 passed`
