### PR TITLE
fix(docker): pin scikit-build-core for ruckig in the simpler image

### DIFF
--- a/docker/Dockerfile.simpler
+++ b/docker/Dockerfile.simpler
@@ -32,7 +32,10 @@ RUN mkdir -p /app/simpler_env_src \
 # ── Install simulation stack ──────────────────────────────────────────
 # sapien imports pkg_resources, removed from conda-forge setuptools >=70.
 RUN uv pip install --no-cache-dir "setuptools<70"
-RUN cd /app/ManiSkill2_real2sim && uv pip install --no-cache-dir -e .
+# ruckig 0.17.3's pyproject uses cmake.targets, removed in scikit-build-core >= 0.10.
+RUN printf 'scikit-build-core<0.10\n' > /tmp/build-constraints.txt \
+    && cd /app/ManiSkill2_real2sim \
+    && uv pip install --no-cache-dir --build-constraints /tmp/build-constraints.txt -e .
 RUN cd /app/simpler_env_src && uv pip install --no-cache-dir -e .
 
 # opencv-python 4.12 pulls numpy>=2, but SimplerEnv needs numpy 1.24.

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -51,7 +51,8 @@ BASE_IMAGE="${BASE_IMAGE:-${REGISTRY}/base:${TAG}}"
 # "Inspecting build dependencies" status line to stdout even without a TTY, and
 # either alone leaks one or the other into the captured value, which breaks
 # setuptools-scm parsing inside the Docker build.
-HARNESS_VERSION="$(NO_COLOR=1 uvx -q hatch -q version 2>/dev/null || echo "0.0.0")"
+# Env override lets a post-tag checkout (e.g. tag + build fixes) stamp the release version.
+HARNESS_VERSION="${HARNESS_VERSION:-$(NO_COLOR=1 uvx -q hatch -q version 2>/dev/null || echo "0.0.0")}"
 
 is_license_accepted() {
   local n="$1"


### PR DESCRIPTION
The v0.4.0 image rebuild caught this: ruckig 0.17.3 declares `cmake.targets`, removed in scikit-build-core >= 0.10, so the uv build-isolation env fails to compile it inside Dockerfile.simpler. Constrain the build backend via `uv pip install --build-constraints`. Also allow `HARNESS_VERSION` env override in build.sh so post-tag checkouts can stamp the release version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S82fGpMKXQKKX64ZsumcWz