### PR TITLE
fix(docker): resolve omniverse-kit across indexes in the behavior1k image

### DIFF
--- a/docker/Dockerfile.behavior1k
+++ b/docker/Dockerfile.behavior1k
@@ -49,7 +49,11 @@ RUN uv pip install --no-cache-dir \
 # Full package list mirrors BEHAVIOR-1K setup.sh `install_isaac_packages`.
 # Installing only the metapackage (isaacsim) leaves
 # `isaacsim.simulation_app` unimportable at runtime.
+# unsafe-best-match: uv's default first-index strategy pins each name to
+# pypi.nvidia.com, which lacks omniverse-kit==106.5.0.162521 (pypi.org only).
+# Everything here is exact-pinned, so cross-index resolution is safe.
 RUN uv pip install --no-cache-dir \
+        --index-strategy unsafe-best-match \
         "omniverse-kit==106.5.0.162521" \
         "isaacsim-kernel==4.5.0.0" \
         "isaacsim-app==4.5.0.0" \


### PR DESCRIPTION
The v0.4.0 behavior1k image build fails at the Isaac Sim install step:

```
No solution found when resolving dependencies:
Because there is no version of omniverse-kit==106.5.0.162521 ...
hint: omniverse-kit was found on https://pypi.nvidia.com/, but not at the requested version.
```

uv's default first-index strategy pins each package name to the first index that carries it, and `--extra-index-url https://pypi.nvidia.com` takes priority over pypi.org. The nvidia index carries `omniverse-kit` at other versions but not `106.5.0.162521`, which is published on pypi.org only, so resolution dead-ends. This is a regression from the pip-to-uv conversion in #85 (pip merges indexes; the image was only `docker build --check`ed there).

Fix: add `--index-strategy unsafe-best-match` to that one RUN. All 26 packages in the step are exact-pinned, so cross-index resolution stays reproducible and the dependency-confusion concern behind uv's default does not apply. `UV_EXCLUDE_NEWER` is unaffected: uv only warns on the nvidia wheels' missing upload dates.

Verified with a local uv dry-run (py3.10, `UV_EXCLUDE_NEWER` kept): resolves 81 packages including `omniverse-kit==106.5.0.162521` and the extscache wheels. behavior1k is the only Dockerfile using an extra index, so no other image is affected.