### PR TITLE
fix(docker): use editable_mode=compat for LIBERO-family editable installs

### DIFF
--- a/docker/Dockerfile.libero
+++ b/docker/Dockerfile.libero
@@ -24,7 +24,7 @@ RUN mkdir -p /app/libero \
     && git remote add origin https://github.com/Lifelong-Robot-Learning/LIBERO.git \
     && git fetch -q --depth 1 origin "${LIBERO_REF}" \
     && git checkout -q FETCH_HEAD \
-    && uv pip install --no-cache-dir -e . \
+    && uv pip install --no-cache-dir --config-setting editable_mode=compat -e . \
     && rm -rf /app/libero/.git ~/.cache/uv
 
 # ── Pre-create LIBERO config (suppress interactive prompt) ─────────

--- a/docker/Dockerfile.libero_mem
+++ b/docker/Dockerfile.libero_mem
@@ -24,7 +24,7 @@ RUN mkdir -p /app/libero-mem \
     && git checkout -q FETCH_HEAD \
     && cd /app/libero-mem/thirdparty/robomimic && uv pip install --no-cache-dir -e . \
     && cd /app/libero-mem/thirdparty/robosuite && uv pip install --no-cache-dir -e . \
-    && cd /app/libero-mem && uv pip install --no-cache-dir -e . \
+    && cd /app/libero-mem && uv pip install --no-cache-dir --config-setting editable_mode=compat -e . \
     && rm -rf /app/libero-mem/.git ~/.cache/uv
 
 RUN mkdir -p /root/.libero && printf '\

--- a/docker/Dockerfile.libero_plus
+++ b/docker/Dockerfile.libero_plus
@@ -36,7 +36,7 @@ RUN mkdir -p /app/LIBERO-plus \
     && git remote add origin https://github.com/sylvestf/LIBERO-plus.git \
     && git fetch -q --depth 1 origin "${LIBERO_PLUS_REF}" \
     && git checkout -q FETCH_HEAD \
-    && uv pip install --no-cache-dir -e . \
+    && uv pip install --no-cache-dir --config-setting editable_mode=compat -e . \
     && rm -rf /app/LIBERO-plus/.git ~/.cache/uv
 
 # ── Download LIBERO-Plus MuJoCo assets (≈6.4 GB) ───────────────────

--- a/docker/Dockerfile.libero_pro
+++ b/docker/Dockerfile.libero_pro
@@ -24,7 +24,7 @@ RUN mkdir -p /app/libero-pro \
     && git remote add origin https://github.com/Zxy-MLlab/LIBERO-PRO.git \
     && git fetch -q --depth 1 origin "${LIBERO_PRO_REF}" \
     && git checkout -q FETCH_HEAD \
-    && uv pip install --no-cache-dir -e . \
+    && uv pip install --no-cache-dir --config-setting editable_mode=compat -e . \
     && rm -rf /app/libero-pro/.git ~/.cache/uv
 
 # ── Pre-create LIBERO config (suppress interactive prompt) ─────────

--- a/docker/Dockerfile.robocerebra
+++ b/docker/Dockerfile.robocerebra
@@ -24,7 +24,7 @@ RUN mkdir -p /tmp/RoboCerebra \
     && git remote add origin https://github.com/qiuboxiang/RoboCerebra.git \
     && git fetch -q --depth 1 origin "${ROBOCEREBRA_REF}" \
     && git checkout -q FETCH_HEAD \
-    && cd /tmp/RoboCerebra/LIBERO && uv pip install --no-cache-dir -e . \
+    && cd /tmp/RoboCerebra/LIBERO && uv pip install --no-cache-dir --config-setting editable_mode=compat -e . \
     && uv pip install --no-cache-dir "bddl==1.0.1" h5py \
     && rm -rf /tmp/RoboCerebra/.git ~/.cache/uv
 


### PR DESCRIPTION
## Problem
`ghcr.io/allenai/vla-evaluation-harness/libero:latest` (v0.4.0) fails at runtime with `ModuleNotFoundError: No module named 'libero'` (#92), even though `pip show libero` reports it installed and the build succeeds.

Root cause: #85 switched the LIBERO-family editable installs from `pip install -e .` to `uv pip install -e .`, dropping a comment that warned uv could not handle LIBERO's `find_packages()` setup.py. LIBERO declares `packages=[p for p in find_packages() if p.startswith("libero")]`, but the repo's top-level `libero/` has no `__init__.py`, so `find_packages()` returns `[]`. Plain uv then writes a PEP 660 editable finder with an empty MAPPING that exposes nothing.

## Fix
Add `--config-setting editable_mode=compat` to the affected LIBERO-family installs only: libero, libero_plus, libero_pro, libero_mem's libero-mem, and robocerebra's LIBERO fork. compat writes a `.pth` that puts the source root on `sys.path`, so `libero` resolves as a namespace package. robomimic and robosuite stay on plain uv since their `find_packages()` is non-empty and they were never affected.

## Verification
Rebuilt each image and confirmed `import libero.libero` succeeds from a neutral working directory (the failure only reproduces in the image toolchain, not locally). Fixed images pushed to `:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)