### PR TITLE
fix(recording): make video.py importable on Python 3.8/3.9

### DIFF
--- a/src/vla_eval/benchmarks/video.py
+++ b/src/vla_eval/benchmarks/video.py
@@ -71,11 +71,12 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     import numpy as np
 
-logger = logging.getLogger(__name__)
+    # A `str.format`-style template, or a callable taking the resolved context (caller's start() context +
+    # injected ``status``) and returning a filename relative to ``output_dir``.  Annotation-only: evaluating
+    # this at runtime breaks Python < 3.10 (benchmark images ship interpreters as old as 3.8).
+    FilenameSpec = str | Callable[[Mapping[str, Any]], str]
 
-# A `str.format`-style template, or a callable taking the resolved context (caller's start() context +
-# injected ``status``) and returning a filename relative to ``output_dir``.
-FilenameSpec = str | Callable[[Mapping[str, Any]], str]
+logger = logging.getLogger(__name__)
 
 
 class EpisodeVideoRecorder:


### PR DESCRIPTION
## Summary

Fixes #95.

`FilenameSpec = str | Callable[[Mapping[str, Any]], str]` in `src/vla_eval/benchmarks/video.py` is a module-level assignment, so `from __future__ import annotations` does not defer its evaluation: on Python 3.8 `collections.abc.Callable` is not subscriptable (the exact `TypeError: 'ABCMeta' object is not subscriptable` from the issue) and on 3.9 the `|` union is unsupported. Any benchmark image with an older interpreter (libero family, calvin, rlbench — all conda `python=3.8`) crashed at episode start whenever video recording was enabled, since `EpisodeRecorder.__init__` lazily imports this module.

Fix: move the alias under `if TYPE_CHECKING:`. It is only referenced in annotations, which the future import already stringifies, so there is no runtime behavior change.

Verified by loading the module standalone (its module-level imports are stdlib-only):
- old code on Python 3.8 → reproduces the reported `TypeError`
- fixed code on Python 3.8 and 3.11 → loads fine

A `vermin` sweep of `src/vla_eval/` shows no other runtime-evaluated < 3.10 incompatibilities (`types.py`/`collector.py` are already properly guarded). Affected published images (libero, libero_pro, libero_plus, libero_mem, robocerebra, calvin) will be rebuilt and re-pushed after this merges.

## Checklist

- [x] I have read the relevant contributing guide ([CONTRIBUTING.md](https://github.com/allenai/vla-evaluation-harness/blob/main/CONTRIBUTING.md) or [leaderboard/CONTRIBUTING.md](https://github.com/allenai/vla-evaluation-harness/blob/main/leaderboard/CONTRIBUTING.md))

**Code changes:**
- [x] `make check` passes (ruff + ty)
- [x] `make test` passes (pytest, 435 passed / 2 skipped)
- [x] Smoke-tested affected configs (if benchmarks, model servers, or Docker were changed)
- [ ] I have updated relevant documentation (if applicable — none needed)

Smoke test commands run:
```
# standalone module-load check on the affected interpreter (module imports are stdlib-only)
uv run --python 3.8 --no-project python load_test.py src/vla_eval/benchmarks/video.py
# full in-image verification happens at the post-merge rebuild of the py3.8 images
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PkgrMY4LfeFVSbceU1G2P