### PR TITLE
fix(deps): declare typing_extensions for Python < 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "pyyaml>=6.0",          # Security fixes (CVE-2020-14343) + Python 3.11
     "rich>=13.0",
     "tqdm",
+    "typing_extensions>=4.0; python_version < '3.11'",  # NotRequired backport for results/collector.py
     "websockets>=12.0",
 ]
 


### PR DESCRIPTION
## Summary

Follow-up to #97 (found during the same py3.8 compatibility sweep). `results/collector.py` imports `NotRequired` from `typing_extensions` at runtime when `sys.version_info < (3, 11)`, but `typing_extensions` was never a declared dependency — py3.8–3.10 environments (all the older benchmark images) only worked because a transitive dependency happened to provide it.

Declare it explicitly with an environment marker: `typing_extensions>=4.0; python_version < '3.11'` (`NotRequired` landed in typing_extensions 4.0). On 3.11+ the marker excludes it entirely, so dev/CI environments are unchanged. Verified `uv pip compile --python-version 3.8` now resolves it (`typing-extensions==4.13.2`) and `uv lock` regenerates cleanly (lockfile is gitignored).

## Checklist

- [x] I have read the relevant contributing guide ([CONTRIBUTING.md](https://github.com/allenai/vla-evaluation-harness/blob/main/CONTRIBUTING.md) or [leaderboard/CONTRIBUTING.md](https://github.com/allenai/vla-evaluation-harness/blob/main/leaderboard/CONTRIBUTING.md))

**Code changes:**
- [x] `make check` passes (ruff + ty)
- [x] `make test` passes (pytest, 435 passed / 2 skipped)
- [ ] Smoke-tested affected configs (metadata-only change; no runtime behavior)
- [ ] I have updated relevant documentation (not applicable)

Smoke test commands run:
```
uv pip compile pyproject.toml --python-version 3.8 | grep typing-extensions
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PkgrMY4LfeFVSbceU1G2P