### PR TITLE
fix(cli): pin output_dir absolute + fail smoke on missing result JSON

### DIFF
--- a/src/vla_eval/cli/main.py
+++ b/src/vla_eval/cli/main.py
@@ -223,6 +223,11 @@ def _run_via_docker(
     # Forward host-side results_dir for recorder._host_translate.
     cmd.extend(["-e", f"VLA_EVAL_HOST_OUTPUT_DIR={results_dir}"])
 
+    # The watchdog runs inside the container; forward the host override so long
+    # episodes (e.g. RoboDojo's 1900-step tasks) aren't killed as stalls.
+    if os.environ.get("VLA_EVAL_WATCHDOG_TIMEOUT_S"):
+        cmd.extend(["-e", f"VLA_EVAL_WATCHDOG_TIMEOUT_S={os.environ['VLA_EVAL_WATCHDOG_TIMEOUT_S']}"])
+
     # Forward stdin/TTY for in-container licence prompts.
     cmd.extend(tty_docker_flags())
 
@@ -344,6 +349,10 @@ def cmd_run(args: argparse.Namespace) -> None:
         return
 
     import anyio
+
+    # Pin output_dir absolute before benchmark code runs: some benchmarks (robotwin,
+    # robodojo) chdir into their sim checkout, silently re-anchoring relative paths.
+    config["output_dir"] = str(Path(config.get("output_dir", "./results")).resolve())
 
     watchdog.start(float(os.environ.get("VLA_EVAL_WATCHDOG_TIMEOUT_S", "1200")))
     orchestrator = Orchestrator(

--- a/src/vla_eval/cli/main.py
+++ b/src/vla_eval/cli/main.py
@@ -352,7 +352,7 @@ def cmd_run(args: argparse.Namespace) -> None:
 
     # Pin output_dir absolute before benchmark code runs: some benchmarks (robotwin,
     # robodojo) chdir into their sim checkout, silently re-anchoring relative paths.
-    config["output_dir"] = str(Path(config.get("output_dir", "./results")).resolve())
+    config["output_dir"] = str(Path(config.get("output_dir") or "./results").resolve())
 
     watchdog.start(float(os.environ.get("VLA_EVAL_WATCHDOG_TIMEOUT_S", "1200")))
     orchestrator = Orchestrator(

--- a/src/vla_eval/cli/smoke.py
+++ b/src/vla_eval/cli/smoke.py
@@ -620,7 +620,10 @@ def run_benchmark_test(test: SmokeTest, timeout: int = 600, *, gpu_id: str | Non
             data = json.loads(Path(json_files[0]).read_text())
             rate = data.get("mean_success", 0)
             return SmokeResult(test, "pass", f"success_rate={rate:.0%}", dt)
-        return SmokeResult(test, "pass", "completed (no result file)", dt)
+        # rc == 0 with no aggregate JSON in the mounted results dir means results were
+        # silently lost (e.g. mis-resolved output_dir) — a failure, not a pass.
+        tail = "\n    ".join(result.stderr.strip().splitlines()[-5:])
+        return SmokeResult(test, "fail", f"completed without result JSON\n    {tail}", dt, stderr=result.stderr)
     finally:
         shutil.rmtree(results_dir, ignore_errors=True)
 

--- a/src/vla_eval/cli/smoke.py
+++ b/src/vla_eval/cli/smoke.py
@@ -622,7 +622,8 @@ def run_benchmark_test(test: SmokeTest, timeout: int = 600, *, gpu_id: str | Non
             return SmokeResult(test, "pass", f"success_rate={rate:.0%}", dt)
         # rc == 0 with no aggregate JSON in the mounted results dir means results were
         # silently lost (e.g. mis-resolved output_dir) — a failure, not a pass.
-        tail = "\n    ".join(result.stderr.strip().splitlines()[-5:])
+        output = result.stderr.strip() or result.stdout.strip()
+        tail = "\n    ".join(output.splitlines()[-5:]) if output else "no output captured"
         return SmokeResult(test, "fail", f"completed without result JSON\n    {tail}", dt, stderr=result.stderr)
     finally:
         shutil.rmtree(results_dir, ignore_errors=True)


### PR DESCRIPTION
## Summary

Two harness-core fixes surfaced while integrating RoboDojo, both general (not RoboDojo-specific):

1. **`output_dir` absolute-pin** (`cli/main.py`): resolve `output_dir` to an absolute path before any benchmark code runs. Benchmarks that `chdir` into their sim checkout (`robotwin`, `robodojo`) would otherwise silently re-anchor a relative `output_dir` mid-run, writing results outside the mounted directory.
2. **Watchdog timeout forwarding** (`cli/main.py`): forward `VLA_EVAL_WATCHDOG_TIMEOUT_S` into the docker container so long-episode benchmarks aren't killed as stalls.
3. **Smoke fail-on-no-result-JSON** (`cli/smoke.py`): when a docker benchmark run exits 0 but writes no aggregate JSON, report **fail** instead of pass.

Mirror of worv-ai/vla-evaluation-harness-public#43.

## Checklist
- [x] `make check` passes (ruff + ty)
- [x] `make test` passes (438 passed / 2 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)