### PR TITLE
Add MolmoSpaces-Bench to the external leaderboard list

### DIFF
--- a/leaderboard/CONTRIBUTING.md
+++ b/leaderboard/CONTRIBUTING.md
@@ -73,7 +73,7 @@ Field semantics live in the schema files above. `extract.py` and `refine.py` bot
 
 ## External Leaderboard Policy
 
-Benchmarks whose authors maintain their own leaderboard (RoboArena, RoboChallenge, RoboCasa365, RoboDojo) are **link-out only**:
+Benchmarks whose authors maintain their own leaderboard (RoboArena, RoboChallenge, RoboCasa365, RoboDojo, MolmoSpaces-Bench) are **link-out only**:
 
 - Set `external_only: true` and `official_leaderboard: <url>` in the benchmark's `.md` frontmatter. The site renders these as link cards; results stay on the official board.
 - `leaderboard.json` must contain **zero** rows for these benchmarks. `validate.py` enforces this. Do not build scrapers or API mirrors: mirrored rows go stale between syncs, need manual model-to-paper mapping, and diverge from the authoritative source (the previous RoboChallenge/RoboArena API sync was retired for these reasons in 2026-07).

--- a/leaderboard/benchmarks/molmospaces.md
+++ b/leaderboard/benchmarks/molmospaces.md
@@ -1,0 +1,24 @@
+---
+benchmark: molmospaces
+display_name: MolmoSpaces-Bench
+paper_url: https://arxiv.org/abs/2602.11337
+metric:
+  name: success_rate
+  unit: '%'
+  range:
+  - 0
+  - 100
+  higher_is_better: true
+official_leaderboard: https://molmospaces.allen.ai/leaderboard
+external_only: true
+detail_notes: "&ldquo;MolmoSpaces: A Large-Scale Open Ecosystem for Robot Navigation and Manipulation&rdquo; (<a href='https://arxiv.org/abs/2602.11337'>2602.11337</a>). Results live on the official leaderboard; this site does not mirror them."
+---
+
+**External-only**: results are maintained exclusively on the [official leaderboard](https://molmospaces.allen.ai/leaderboard). This registry entry exists to link out; `leaderboard.json` must contain **zero** rows for this benchmark.
+
+The official board ranks policies per task and separates entries that trained on MolmoSpaces in-distribution data from those that did not, so a flat mirror here would drop that distinction. vla-eval integrates MolmoSpaces-Bench for running evaluations (see `configs/benchmarks/molmospaces/`), which is independent of this leaderboard entry.
+
+If papers begin reporting MolmoSpaces-Bench numbers routinely, paper extraction can be enabled by removing `external_only` and defining the full protocol here.
+
+## Checks
+- Any candidate row for this benchmark must be rejected entirely while `external_only` is set. Do not retain rows with `overall_score = null`.

--- a/leaderboard/data/benchmarks.json
+++ b/leaderboard/data/benchmarks.json
@@ -322,6 +322,22 @@
     },
     "detail_notes": "Standard protocol: 5-task VLA evaluation (ShellGameTouch, InterceptMedium, RememberColor3/5/9) from the MIKASA paper, endorsed by MemoryVLA (ICLR 2026). <code>overall_score</code> = arithmetic mean of 5 tasks. Entries using non-standard task sets (e.g., ELMUR 4-task) have <code>overall_score</code> = null."
   },
+  "molmospaces": {
+    "display_name": "MolmoSpaces-Bench",
+    "paper_url": "https://arxiv.org/abs/2602.11337",
+    "metric": {
+      "name": "success_rate",
+      "unit": "%",
+      "range": [
+        0,
+        100
+      ],
+      "higher_is_better": true
+    },
+    "official_leaderboard": "https://molmospaces.allen.ai/leaderboard",
+    "external_only": true,
+    "detail_notes": "&ldquo;MolmoSpaces: A Large-Scale Open Ecosystem for Robot Navigation and Manipulation&rdquo; (<a href='https://arxiv.org/abs/2602.11337'>2602.11337</a>). Results live on the official leaderboard; this site does not mirror them."
+  },
   "rlbench": {
     "display_name": "RLBench",
     "paper_url": "https://arxiv.org/abs/1909.12271",


### PR DESCRIPTION
## Summary

Registers [MolmoSpaces-Bench](https://molmospaces.allen.ai/leaderboard) as a link-out entry in the leaderboard's external leaderboard list, same treatment as RoboArena / RoboChallenge / RoboCasa365 / RoboDojo.

- New `leaderboard/benchmarks/molmospaces.md` with `external_only: true` + `official_leaderboard`, rebuilt into `leaderboard/data/benchmarks.json`.
- Reason for link-out rather than mirroring: the official board ranks per task and splits entries by whether a policy trained on MolmoSpaces in-distribution data ("Split by MolmoSpaces Data"), so a flat copy here would go stale and drop that distinction.
- `leaderboard.json` keeps zero rows for this benchmark, as `validate.py` enforces.
- Added it to the external-leaderboard list in `leaderboard/CONTRIBUTING.md`.

Verified locally: dropdown shows "MolmoSpaces-Bench ↗" under **External leaderboards**, and selecting it renders the link-out panel with the paper title and the button to the official board.

## Checklist

- [x] I have read the relevant contributing guide ([leaderboard/CONTRIBUTING.md](https://github.com/allenai/vla-evaluation-harness/blob/main/leaderboard/CONTRIBUTING.md))

**Leaderboard data changes:**
- [x] `python leaderboard/scripts/validate.py` passes
- [x] `python leaderboard/scripts/build_benchmarks_json.py --check` passes (benchmarks.json regenerated from the md source, not hand-edited)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSYcGYxkrxtgUUQNmVbdCA
