### PR TITLE
Serve a redirect at the Pages root instead of a 404

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,6 +4,7 @@ on:
     branches: [main]
     paths:
       - 'leaderboard/**'
+      - '.github/workflows/pages.yml'
   workflow_dispatch:
 
 permissions:
@@ -33,6 +34,15 @@ jobs:
           python leaderboard/scripts/scan.py --check
           python leaderboard/scripts/update_citations.py
           mkdir -p _site/leaderboard
+          # The site lives under /leaderboard/; keep the Pages root from 404ing.
+          cat > _site/index.html <<'HTML'
+          <!doctype html>
+          <meta charset="utf-8">
+          <title>VLA Model Leaderboard</title>
+          <link rel="canonical" href="https://allenai.github.io/vla-evaluation-harness/leaderboard/">
+          <meta http-equiv="refresh" content="0; url=./leaderboard/">
+          <p><a href="./leaderboard/">VLA Model Leaderboard</a></p>
+          HTML
           cp leaderboard/site/* _site/leaderboard/
           cp leaderboard/data/leaderboard.json _site/leaderboard/
           cp leaderboard/data/benchmarks.json _site/leaderboard/


### PR DESCRIPTION
## Summary

`https://allenai.github.io/vla-evaluation-harness/` returns 404 today; only `/leaderboard/` works. The deploy step creates `_site/leaderboard/` and never writes anything at the Pages root, and `force_orphan: true` means the published branch is exactly `.nojekyll` + `leaderboard/`.

- Emit `_site/index.html` at the root that redirects to `./leaderboard/`, with `<link rel="canonical">` so `/leaderboard/` stays the indexed URL and a plain anchor as the fallback.
- Add `.github/workflows/pages.yml` to the `push` paths filter. It previously fired only on `leaderboard/**`, so a workflow-only change like this one would never trigger a deploy by itself.

In-repo links (README ×2, `leaderboard/README.md`) already point at `/leaderboard/` and are unaffected.

Verified locally: the workflow YAML parses, and running the heredoc reproduces the intended `_site/index.html` with no stray indentation from the YAML block scalar.

## Checklist

- [x] I have read the relevant contributing guide ([CONTRIBUTING.md](https://github.com/allenai/vla-evaluation-harness/blob/main/CONTRIBUTING.md))
- [x] No code or leaderboard data changed; CI workflows only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSYcGYxkrxtgUUQNmVbdCA
