### PR TITLE
cli: fall back to the worv-ai mirror when an allenai image pull fails

### DIFF
--- a/src/vla_eval/cli/_docker.py
+++ b/src/vla_eval/cli/_docker.py
@@ -8,6 +8,9 @@ from pathlib import Path
 
 from vla_eval.cli._console import stderr_console as _stderr_console
 
+# Public mirror for images the allenai org has not granted public read on (issue #73).
+_REGISTRY_MIRRORS = {"ghcr.io/allenai/vla-evaluation-harness/": "ghcr.io/worv-ai/vla-evaluation-harness-public/"}
+
 
 def dev_src_mount_flags() -> list[str]:
     """Volume flags mounting the host checkout's ``src/`` over the image's (``--dev``).
@@ -63,7 +66,14 @@ def ensure_image_local(docker: str, image: str, auto_yes: bool) -> None:
             sys.exit(0)
 
     con.print(f"Pulling {image} ...")
-    ret = subprocess.call([docker, "pull", image])
-    if ret != 0:
-        con.print(f"[red]ERROR: docker pull failed (exit code {ret}).[/red]")
-        sys.exit(1)
+    if subprocess.call([docker, "pull", image]) == 0:
+        return
+    for primary, mirror_prefix in _REGISTRY_MIRRORS.items():
+        if image.startswith(primary):
+            mirror = mirror_prefix + image.removeprefix(primary)
+            con.print(f"[yellow]Pull failed; retrying from public mirror: {mirror}[/yellow]")
+            if subprocess.call([docker, "pull", mirror]) == 0:
+                subprocess.call([docker, "tag", mirror, image])
+                return
+    con.print(f"[red]ERROR: docker pull failed for {image}.[/red]")
+    sys.exit(1)

--- a/tests/test_docker_pull_mirror.py
+++ b/tests/test_docker_pull_mirror.py
@@ -1,0 +1,57 @@
+"""Tests for the registry mirror fallback in cli._docker.ensure_image_local."""
+
+from unittest.mock import patch
+
+import pytest
+
+from vla_eval.cli import _docker
+
+IMAGE = "ghcr.io/allenai/vla-evaluation-harness/duobench:0.4.0"
+MIRROR = "ghcr.io/worv-ai/vla-evaluation-harness-public/duobench:0.4.0"
+
+
+def _run(call_results: dict[str, int]) -> list[list[str]]:
+    """Run ensure_image_local with canned `docker pull` exit codes; return recorded calls."""
+    calls: list[list[str]] = []
+
+    def fake_call(cmd):
+        calls.append(cmd)
+        if cmd[1] == "pull":
+            return call_results[cmd[2]]
+        return 0
+
+    with patch.object(_docker, "image_exists_locally", return_value=False):
+        with patch.object(_docker.subprocess, "call", side_effect=fake_call):
+            _docker.ensure_image_local("docker", IMAGE, auto_yes=True)
+    return calls
+
+
+def test_primary_pull_success_skips_mirror():
+    calls = _run({IMAGE: 0})
+    assert [c[1] for c in calls] == ["pull"]
+
+
+def test_fallback_pulls_mirror_and_retags():
+    calls = _run({IMAGE: 1, MIRROR: 0})
+    assert calls[1] == ["docker", "pull", MIRROR]
+    assert calls[2] == ["docker", "tag", MIRROR, IMAGE]
+
+
+def test_both_registries_failing_exits():
+    with pytest.raises(SystemExit):
+        _run({IMAGE: 1, MIRROR: 1})
+
+
+def test_non_allenai_image_has_no_mirror():
+    other = "ghcr.io/example/thing:1.0"
+    calls: list[list[str]] = []
+
+    def fake_call(cmd):
+        calls.append(cmd)
+        return 1
+
+    with patch.object(_docker, "image_exists_locally", return_value=False):
+        with patch.object(_docker.subprocess, "call", side_effect=fake_call):
+            with pytest.raises(SystemExit):
+                _docker.ensure_image_local("docker", other, auto_yes=True)
+    assert [c[1] for c in calls] == ["pull"]


### PR DESCRIPTION
Some benchmark images are not publicly readable under `ghcr.io/allenai` (org-level package grants lag behind releases), which keeps generating support questions (#8, #73).

`ensure_image_local` (the single pull choke point for `vla-eval run`) now retries a failed `ghcr.io/allenai/vla-evaluation-harness/*` pull against the public mirror `ghcr.io/worv-ai/vla-evaluation-harness-public/*` and retags the result under the canonical name, so configs and the local-image cache keep working unchanged. Images with no mirror keep the old behavior (clear error, exit 1).

Covered by 4 unit tests (primary success, fallback + retag, both-fail exit, non-allenai image untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXQdGZXPiAP9VQau3mX11b
