### PR TITLE
leaderboard: make extract.py survive usage-limit windows diagnosably

### DIFF
--- a/leaderboard/scripts/extract.py
+++ b/leaderboard/scripts/extract.py
@@ -488,6 +488,10 @@ class LLMError(RuntimeError):
     pass
 
 
+class UsageLimitError(LLMError):
+    """The account's usage window is exhausted; retrying now cannot succeed."""
+
+
 @functools.lru_cache(maxsize=1)
 def _extraction_schema() -> dict:
     """Load the authoritative per-paper extraction schema."""
@@ -660,9 +664,16 @@ def _call_claude_cli(
     except subprocess.TimeoutExpired as e:
         raise LLMError(f"timed out after {timeout}s") from e
 
+    # Log first: a failed stream is exactly the one that needs inspecting.
+    if log_path is not None:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text(result.stdout, encoding="utf-8")
+
     n_tool_calls = 0
     seen_result = False
     stream_success = False
+    error: LLMError | None = None
+    resets_at = None
     for line in result.stdout.splitlines():
         line = line.strip()
         if not line:
@@ -671,8 +682,13 @@ def _call_claude_cli(
             evt = json.loads(line)
         except json.JSONDecodeError:
             continue
-        if evt.get("is_error"):
-            raise LLMError(f"error: {evt.get('subtype')}")
+        if evt.get("type") == "rate_limit_event":
+            info = evt.get("rate_limit_info") or {}
+            if info.get("status") == "rejected":
+                resets_at = info.get("resetsAt")
+                error = UsageLimitError(f"usage limit reached (resetsAt={resets_at})")
+        if evt.get("is_error") and error is None:
+            error = LLMError(f"error: {evt.get('subtype')} (api_error_status={evt.get('api_error_status')})")
         if evt.get("type") == "assistant":
             for block in evt.get("message", {}).get("content", []):
                 if block.get("type") == "tool_use":
@@ -684,10 +700,8 @@ def _call_claude_cli(
             # If the stream's own result event reports success, trust it.
             stream_success = not evt.get("is_error", False) and evt.get("subtype") == "success"
 
-    if log_path is not None:
-        log_path.parent.mkdir(parents=True, exist_ok=True)
-        log_path.write_text(result.stdout, encoding="utf-8")
-
+    if error is not None and not stream_success:
+        raise error
     if result.returncode != 0 and not stream_success:
         raise LLMError(f"exit {result.returncode}: {result.stderr[:500]}")
     if not seen_result:
@@ -704,13 +718,15 @@ def _call_claude_cli_with_retry(
     log_path: Path | None,
     retries: int = 1,
 ) -> int:
-    """Retry once on transient failure."""
+    """Retry once on transient failure. Usage-limit failures are terminal, not transient."""
     last_err: LLMError | None = None
     for attempt in range(retries + 1):
         try:
             return _call_claude_cli(
                 system_prompt, user_prompt, extra_add_dirs, model=model, timeout=timeout, log_path=log_path
             )
+        except UsageLimitError:
+            raise
         except LLMError as e:
             last_err = e
             if attempt < retries:
@@ -994,6 +1010,8 @@ def _run_one_batch(
             log_path=log_path,
             retries=1,
         )
+    except UsageLimitError:
+        raise
     except LLMError as e:
         print(f"    LLM error for batch ({len(todo)} papers): {e}")
         return {aid: None for aid in todo}
@@ -1064,7 +1082,12 @@ def extract_batch(
     if not todo:
         return results
 
-    batch_results = _run_one_batch(todo, all_rules, model, timeout)
+    try:
+        batch_results = _run_one_batch(todo, all_rules, model, timeout)
+    except UsageLimitError as e:
+        print(f"    usage limit reached — skipping batch ({len(todo)} papers): {e}")
+        results.update({aid: None for aid in todo})
+        return results
     results.update(batch_results)
 
     # Fallback: if >=50% of the batch failed, retry remaining ones one-by-one.
@@ -1073,7 +1096,11 @@ def extract_batch(
     if len(todo) > 1 and len(failed_ids) >= len(todo) // 2:
         print(f"    batch degraded ({len(failed_ids)}/{len(todo)} failed) — retrying per-paper")
         for aid in failed_ids:
-            single = _run_one_batch([aid], all_rules, model, timeout)
+            try:
+                single = _run_one_batch([aid], all_rules, model, timeout)
+            except UsageLimitError as e:
+                print(f"    usage limit reached — stopping per-paper retries: {e}")
+                break
             results.update(single)
 
     return results

--- a/leaderboard/tests/test_extract_usage_limit.py
+++ b/leaderboard/tests/test_extract_usage_limit.py
@@ -1,0 +1,78 @@
+"""Unit tests for extract's usage-limit handling.
+
+A usage-limit rejection used to surface as ``LLMError("error: success")``
+with no log written (the log write sat after the raise), and then trigger a
+per-paper retry storm against a window that cannot recover mid-run.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import extract  # noqa: E402
+
+
+def _stream(*events: dict) -> str:
+    return "\n".join(json.dumps(e) for e in events)
+
+
+def _call(stdout: str, log_path: Path, returncode: int = 0) -> int:
+    proc = subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
+    with patch.object(extract.subprocess, "run", return_value=proc):
+        return extract._call_claude_cli("s", "u", [], model="m", timeout=5, log_path=log_path)
+
+
+def test_rejected_rate_limit_raises_usage_limit_error(tmp_path):
+    stdout = _stream(
+        {"type": "rate_limit_event", "rate_limit_info": {"status": "rejected", "resetsAt": 1786398000}},
+        {"type": "result", "subtype": "success", "is_error": True},
+    )
+    log = tmp_path / "batch.log"
+    with pytest.raises(extract.UsageLimitError, match="1786398000"):
+        _call(stdout, log)
+    assert log.read_text() == stdout
+
+
+def test_error_event_writes_log_before_raising(tmp_path):
+    stdout = _stream({"type": "result", "subtype": "success", "is_error": True, "api_error_status": 529})
+    log = tmp_path / "batch.log"
+    with pytest.raises(extract.LLMError, match="529"):
+        _call(stdout, log)
+    assert log.read_text() == stdout
+
+
+def test_successful_stream_unaffected(tmp_path):
+    stdout = _stream(
+        {"type": "rate_limit_event", "rate_limit_info": {"status": "allowed"}},
+        {"type": "result", "subtype": "success", "is_error": False},
+    )
+    assert _call(stdout, tmp_path / "batch.log") == 0
+
+
+def test_usage_limit_skips_batch_and_per_paper_fallback(tmp_path, monkeypatch):
+    aids = ["2601.00001", "2601.00002"]
+    monkeypatch.setattr(extract, "CACHE_DIR", tmp_path / "papers")
+    monkeypatch.setattr(extract, "EXTRACTIONS_RAW_DIR", tmp_path / "raw")
+    for aid in aids:
+        (tmp_path / "papers" / aid).mkdir(parents=True)
+        (tmp_path / "papers" / aid / "paper.md").write_text("x")
+
+    calls = []
+
+    def fake_retry(*args, **kwargs):
+        calls.append(args)
+        raise extract.UsageLimitError("usage limit reached")
+
+    monkeypatch.setattr(extract, "_call_claude_cli_with_retry", fake_retry)
+    results = extract.extract_batch(aids, "rules", "m", resume=False)
+    assert results == {aid: None for aid in aids}
+    assert len(calls) == 1


### PR DESCRIPTION
During the 2026-08 monthly leaderboard run, exhausting the Claude usage window mid-extraction produced the worst possible failure shape: 6 of 9 batches died with the message `LLMError("error: success")`, zero logs on disk (the log write sat after the raise inside the stream loop), and the >=50%-degraded fallback then re-ran all ~30 papers of each dead batch individually against a window that cannot recover mid-run.

Three changes in `leaderboard/scripts/extract.py`:

- Write the stream log **before** parsing, so a failed call is exactly the one that leaves evidence.
- Classify a `rate_limit_event` with `status: "rejected"` as a new `UsageLimitError` carrying `resetsAt`, and only raise stream errors when the turn did not end in success (the CLI can emit `is_error: true` with `subtype: "success"`, which is where "error: success" came from).
- Treat `UsageLimitError` as terminal: no in-call retry, no per-paper fallback storm; the batch returns cleanly as failed so a later resume run picks the papers up.

4 unit tests cover the rejection path, log-before-raise, an unaffected success stream, and the skipped fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXQdGZXPiAP9VQau3mX11b
