### PR TITLE
fix(serve): import the asyncio server instead of the websockets.serve alias

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "rich>=13.0",
     "tqdm",
     "typing_extensions>=4.0; python_version < '3.11'",  # NotRequired backport for results/collector.py
-    "websockets>=12.0",
+    "websockets>=13.0",  # 13.0 adds websockets.asyncio.server, the implementation serve.py imports
 ]
 
 [dependency-groups]

--- a/src/vla_eval/model_servers/serve.py
+++ b/src/vla_eval/model_servers/serve.py
@@ -40,6 +40,13 @@ import anyio
 from anyio.to_thread import run_sync as _run_in_thread
 import websockets
 
+# Import the implementation directly rather than through the top-level ``websockets.serve``
+# alias.  That alias resolves to ``websockets.legacy.server`` on <=13.x and to this module
+# from 14.0 on, and the two call ``process_request`` with different arguments: the legacy
+# one passes ``(path, Headers)``, this one passes ``(connection, Request)``.  Naming the
+# module keeps one calling convention on every version the project supports.
+from websockets.asyncio.server import serve as ws_serve
+
 from vla_eval.model_servers.base import ModelServer, SessionContext
 from vla_eval.types import Action
 from vla_eval.protocol.messages import Message, MessageType, make_hello_payload, pack_message, unpack_message
@@ -307,7 +314,7 @@ async def serve_async(
     process_request = _make_process_request(model_server)
     async with anyio.create_task_group() as tg:
         tg.start_soon(_backpressure_monitor, backpressure_threshold)
-        async with websockets.serve(
+        async with ws_serve(
             handler,
             host,
             port,

--- a/tests/test_tuning_benchmarks.py
+++ b/tests/test_tuning_benchmarks.py
@@ -161,6 +161,23 @@ async def test_config_partial_error_still_applies_valid(echo_server_url: str):
     assert data["config"]["max_batch_size"] == 4
 
 
+def test_serve_uses_the_asyncio_implementation_not_the_alias():
+    """``serve.py`` must not go back to the top-level ``websockets.serve`` alias.
+
+    The alias resolves to ``websockets.legacy.server`` on <=13.x, which calls
+    ``process_request(path, Headers)``.  ``_make_process_request`` builds a
+    ``(connection, Request)`` callback, so under the alias every request raises
+    ``AttributeError: 'Headers' object has no attribute 'path'`` and websockets
+    answers 500.  The tests above cannot see it, because a dev install resolves
+    a version where the alias happens to point at the right implementation.
+    """
+    import websockets.asyncio.server
+
+    from vla_eval.model_servers import serve as serve_mod
+
+    assert serve_mod.ws_serve is websockets.asyncio.server.serve
+
+
 @pytest.mark.anyio
 async def test_set_server_config_helper(echo_server_url: str):
     """set_server_config() from bench_supply should work end-to-end."""


### PR DESCRIPTION
## Summary

Thanks for this harness; it has been useful to us.

While running model servers I found that the HTTP control plane, and in fact the whole server, is broken on any `websockets` below 14, which `pyproject.toml` currently admits.

`serve.py` calls the top-level [`websockets.serve`](https://github.com/allenai/vla-evaluation-harness/blob/e1ee9adf64396e155eb10ae1dd3f5dbf9a12d26c/src/vla_eval/model_servers/serve.py#L310). That name is an alias, and it does not point at the same implementation on every version:

```
websockets 13.1 -> websockets.legacy.server
websockets 14.0 -> websockets.asyncio.server
websockets 16.0 -> websockets.asyncio.server
```

The two implementations call `process_request` differently. The legacy one passes `(path, Headers)`; the new one passes `(connection, Request)`. `_make_process_request` is written for the second, so on the legacy path the second argument is a `Headers` object with no `.path` and every request raises:

```
AttributeError: 'Headers' object has no attribute 'path'
```

websockets turns that into an HTTP 500. The server does log `opening handshake failed` with the traceback, so it is diagnosable, but the client only sees `InvalidStatusCode: server rejected WebSocket connection: HTTP 500`. Since the hook runs on every incoming connection, the WebSocket handshake is rejected along with `/health` and `/config`, so no client can connect at all.

## What this changes

Two lines of substance: import `serve` from `websockets.asyncio.server` directly, and move the floor from `websockets>=12.0` to `>=13.0`.

`websockets.asyncio.server` first appears in 13.0, which is why the floor has to move; 12.0 has no such module. It is not a Python 3.8 tradeoff, though. 13.1 is the last release supporting 3.8 and it ships that module, and I checked the import there specifically:

```console
$ uv run --isolated --with 'websockets==13.1' --python 3.8 python -c "import websockets.asyncio.server; print('ok')"
ok
```

So the alias goes away, one calling convention is left, and `requires-python = ">=3.8"` still holds.

I first wrote this as an adapter inside `_make_process_request` that handled both argument shapes. Naming the implementation is smaller and leaves one code path instead of two, so I replaced it. Happy to go back to the adapter if you would rather not move the floor.

## How I verified it

The full suite passes on both implementations. I ran it against the installed 16.0 and again with 13.1 shadowed onto the path:

```
websockets 16.0: 529 passed
websockets 13.1: 529 passed
```

Before the change, 13.1 fails the control-plane tests with a real server, not a synthetic callback:

```
ERROR websockets.server:server.py:219 opening handshake failed
AttributeError: 'Headers' object has no attribute 'path'
```

The new test asserts that `serve.py` holds `websockets.asyncio.server.serve` rather than the alias. It pins the implementation rather than the calling convention, since `_make_process_request` was never the broken part. It is worth noting that nothing in CI currently exercises websockets below 14, so a `websockets==13.1` leg would be the thing that keeps this from regressing.

I ran `uv run --no-sync ruff check`, `ruff format --check`, `ty check` and `pytest`, which is what the `check` and `test` targets run.

## Checklist

- [x] I have read the relevant contributing guide ([CONTRIBUTING.md](https://github.com/allenai/vla-evaluation-harness/blob/main/CONTRIBUTING.md) or [leaderboard/CONTRIBUTING.md](https://github.com/allenai/vla-evaluation-harness/blob/main/leaderboard/CONTRIBUTING.md))

**Code changes:**
- [x] `make check` passes (ruff + ty)
- [x] `make test` passes (pytest), on websockets 16.0 and 13.1
- [ ] Smoke-tested affected configs (if benchmarks, model servers, or Docker were changed)
- [ ] I have updated relevant documentation (if applicable)

Smoke test commands run:
```
None. This touches the shared HTTP control plane rather than any single config, and
the change is covered by tests/test_tuning_benchmarks.py. Tell me which smoke configs
you want and I will run them.
```
