### PR TITLE
scripts: make run_sharded.sh cleanup work outside interactive shells

### DIFF
--- a/scripts/run_sharded.sh
+++ b/scripts/run_sharded.sh
@@ -66,9 +66,15 @@ if [[ -z "$EVAL_ID" ]]; then
   EVAL_ID="$(uuidgen 2>/dev/null || python3 -c 'import uuid; print(uuid.uuid4())')"
 fi
 
+# kill -- -$$ only works when this script leads its own process group, which is
+# true under an interactive shell but not under CI, a container, or another script.
+pids=()
 cleanup() {
   echo "Cleaning up background processes..."
-  kill -- -$$ 2>/dev/null || true
+  local pid
+  for pid in "${pids[@]}"; do
+    kill -- "-$pid" 2>/dev/null || kill "$pid" 2>/dev/null || true
+  done
 }
 trap cleanup EXIT
 
@@ -95,11 +101,13 @@ if [[ -n "$RENDER" ]]; then
 fi
 
 echo "Launching ${NUM_SHARDS} shards..."
-pids=()
+set -m  # each shard leads its own process group, so cleanup() can signal its whole tree
 for i in $(seq 0 $((NUM_SHARDS - 1))); do
-  vla-eval run "${RUN_OPTS[@]}" --shard-id "$i" --num-shards "$NUM_SHARDS" &
+  # </dev/null: with -m, background jobs keep terminal stdin; a shard reading it would stop on SIGTTIN
+  vla-eval run "${RUN_OPTS[@]}" --shard-id "$i" --num-shards "$NUM_SHARDS" </dev/null &
   pids+=($!)
 done
+set +m
 
 echo "Waiting for all shards to finish..."
 failed=0
@@ -108,6 +116,7 @@ for pid in "${pids[@]}"; do
     failed=$((failed + 1))
   fi
 done
+pids=()  # all shards reaped; keep the trap from signaling reused PIDs during merge
 
 if [[ "$failed" -gt 0 ]]; then
   echo "ERROR: $failed of $NUM_SHARDS shards failed." >&2


### PR DESCRIPTION
## Summary

Fixes #122.

`cleanup()` used `kill -- -$$`, which signals the process group led by the script — a group that only exists when an interactive shell made the script a job leader. Under any non-interactive parent (CI, a container, a scheduler payload, or `run_simpler_seeds.sh`, which calls this script in its seed loop), the kill silently no-ops and an interrupted run orphans every shard to PID 1, each holding its GPU and benchmark container.

The fix is the approach proposed in #122 (thanks @rakhimovv, credited as co-author): each shard is launched in its own process group via `set -m`, and the trap signals those groups by tracked PID, which works regardless of the script's own group leadership and additionally reaps shard children (renderer, docker client) the old code could never reach. Two hardening details on top: shard stdin is explicitly `/dev/null` (with `-m`, background jobs would otherwise keep terminal stdin and could stop on SIGTTIN), and `pids` is cleared once the wait loop reaps all shards so the trap cannot signal reused PIDs while merge runs.

## Verification

All with a fake `vla-eval` on PATH driving the real script, under a non-interactive parent (`setsid`):

- **Interrupted run (SIGTERM mid-shards)**: before, 3/3 shards orphaned to PID 1 (reproduced on main); after, cleanup reaps 3/3 shards and 3/3 of their children.
- **Interactive Ctrl-C**: verified through a pty that the EXIT trap reaps everything — needed because `set -m` moves shards out of the terminal's foreground group, so they no longer receive SIGINT directly.
- **All shards succeed**: exit 0, merge runs, no self-SIGTERM (the old trap also killed the script itself on successful interactive runs).
- **All shards fail**: exit 1 with the error summary, merge still runs.
- **Early exit before launch (missing config)**: no `set -u` crash in the trap (`pids=()` now declared above it).

## Checklist

- [x] I have read the relevant contributing guide (CONTRIBUTING.md)

**Code changes:**
- [x] `make check` passes (ruff + ty) — no Python touched
- [x] `make test` passes (pytest) — no Python touched
- [ ] Smoke-tested affected configs — n/a, shell-only change, exercised as above
- [ ] I have updated relevant documentation — n/a

Smoke test commands run:
```
fake vla-eval shim + setsid harness exercising: TERM mid-run, pty Ctrl-C,
success, all-shards-fail, and missing-config paths (details above)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKXxEtFYcTnbSZtSu83xP4