### PR TITLE
docs: point sharded runs at docker.user for root-owned outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ vla-eval merge -c configs/benchmarks/libero/spatial.yaml -o results/libero_spati
 
 Each shard gets a deterministic slice via round-robin. Results merge with episode-level deduplication; if a shard fails, re-run only that shard.
 
+Benchmark containers run as root by default, so `output_dir` ends up root-owned and the host-side `vla-eval merge` fails with `Permission denied`. Set `docker.user: host` in the eval YAML (or an explicit `"<uid>:<gid>"`) to run the containers as the invoking user.
+
 ### Batch Model Server (GPU parallelism)
 
 Enable batching in the model server config by setting `max_batch_size > 1`:

--- a/scripts/run_sharded.sh
+++ b/scripts/run_sharded.sh
@@ -123,8 +123,10 @@ if [[ "$failed" -gt 0 ]]; then
 fi
 
 echo "Materializing per-episode jsonl + aggregate JSON via 'vla-eval merge'..."
-vla-eval merge "${MERGE_OPTS[@]}" || \
+vla-eval merge "${MERGE_OPTS[@]}" || {
   echo "WARNING: merge failed; the SQLite recording still has the raw data — rerun 'vla-eval merge' manually." >&2
+  echo "         If it failed with 'Permission denied', the shard containers ran as root; set 'docker.user: host' in the config." >&2
+}
 
 if [[ "$failed" -gt 0 ]]; then
   exit 1


### PR DESCRIPTION
## Summary

- README (Episode Sharding): note that containers run as root, so the host-side `vla-eval merge` hits `Permission denied` on the root-owned `output_dir`, and that `docker.user: host` (or `"<uid>:<gid>"`) fixes it.
- `run_sharded.sh`: the merge-failure warning now names that cause and the fix.

`docker.user` already existed (opt-in) but was documented only in the `DockerConfig` docstring. The default stays root: running every image as the host uid is not verified against upstream libraries that write to `$HOME`.

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)