### PR TITLE
fix: fixed-seed shuffle before sharding; surface num_errors at the benchmark level

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ wait
 vla-eval merge -c configs/benchmarks/libero/spatial.yaml -o results/libero_spatial.json
 ```
 
-Each shard gets a deterministic slice via round-robin. Results merge with episode-level deduplication; if a shard fails, re-run only that shard.
+Work items are shuffled with a fixed seed before the round-robin split, so no shard ends up holding a single episode index across every task; each shard then runs its slice task by task. Results merge with episode-level deduplication; if a shard fails, re-run only that shard.
 
 Benchmark containers run as root by default, so `output_dir` ends up root-owned and the host-side `vla-eval merge` fails with `Permission denied`. Set `docker.user: host` in the eval YAML (or an explicit `"<uid>:<gid>"`) to run the containers as the invoking user.
 

--- a/src/vla_eval/cli/main.py
+++ b/src/vla_eval/cli/main.py
@@ -425,7 +425,9 @@ def cmd_run(args: argparse.Namespace) -> None:
 
     # Print final summary
     for r in results:
-        print(f"\n{r['benchmark']}: {r.get('mean_success', 0.0):.1%}")
+        errs = r.get("num_errors", 0)
+        tail = f"  (⚠ {errs} episodes errored)" if errs else ""
+        print(f"\n{r['benchmark']}: {r.get('mean_success', 0.0):.1%}{tail}")
 
     # Single-shard runs auto-merge: write per-episode jsonl + aggregate JSON from
     # the SQLite recording, since there are no other shard processes to coordinate

--- a/src/vla_eval/orchestrator.py
+++ b/src/vla_eval/orchestrator.py
@@ -6,6 +6,7 @@ import inspect
 import json
 import logging
 import math
+import random
 import re
 import traceback
 import uuid
@@ -48,6 +49,19 @@ def _effective_recording_config(raw: dict[str, Any] | None, *, no_save: bool) ->
     if no_save:
         return None
     return {**_DEFAULT_RECORDING_CONFIG, **(raw or {})}
+
+
+_SHARD_SHUFFLE_SEED = 42
+
+
+def _shard_work_items(work_items: list[Any], num_shards: int, shard_id: int) -> list[Any]:
+    """Fixed-seed shuffle so a shard never collects one episode index across every task
+    (gcd(num_shards, episodes_per_task) > 1 does that); re-sort by task to keep env rebuilds rare."""
+    items = list(work_items)
+    random.Random(_SHARD_SHUFFLE_SEED).shuffle(items)
+    mine = [w for i, w in enumerate(items) if i % num_shards == shard_id]
+    mine.sort(key=lambda w: w[0])
+    return mine
 
 
 def _accepted_init_params(benchmark_cls: type[Any]) -> set[str]:
@@ -100,8 +114,9 @@ class Orchestrator:
         3. Determine ``max_steps``: if config omits it, the benchmark's
            ``get_metadata()["max_steps"]`` is used.
         4. Build a flat list of (task, episode) work items.
-        5. If sharding is enabled, select this shard's subset via round-robin
-           (``item_index % num_shards == shard_id``).
+        5. If sharding is enabled, shuffle the list with a fixed seed, take this
+           shard's round-robin slice (``item_index % num_shards == shard_id``),
+           and re-sort it by task so env rebuilds stay rare.
         6. Run each work item via the runner. Recording goes through SQLite.
            Failures are isolated per episode.
 
@@ -298,7 +313,7 @@ class Orchestrator:
             (task_idx, task, ep) for task_idx, task in enumerate(tasks) for ep in range(cfg.episodes_per_task)
         ]
         if self.num_shards is not None and self.shard_id is not None:
-            work_items = [w for i, w in enumerate(work_items) if i % self.num_shards == self.shard_id]
+            work_items = _shard_work_items(work_items, self.num_shards, self.shard_id)
             logger.info("Shard %d/%d: %d episodes assigned", self.shard_id, self.num_shards, len(work_items))
 
         collector = ResultCollector(benchmark_name=name, mode=cfg.mode, metric_keys=benchmark.get_metric_keys())

--- a/src/vla_eval/results/collector.py
+++ b/src/vla_eval/results/collector.py
@@ -47,6 +47,7 @@ class BenchmarkResult(TypedDict):
     created_at: str
     tasks: list[TaskResult]
     config: dict[str, Any]
+    num_errors: NotRequired[int]
     seed: NotRequired[int | None]
     metric_keys: NotRequired[dict[str, str]]
 
@@ -170,6 +171,8 @@ class ResultCollector:
             tasks=tasks,
             config=config,
         )
+
+        result["num_errors"] = self.error_count
 
         # Promote seed to top level for reproducibility
         seed = _extract_seed(config)

--- a/src/vla_eval/results/merge.py
+++ b/src/vla_eval/results/merge.py
@@ -133,6 +133,7 @@ def _build_aggregate(
         body["metric_keys"] = metric_keys
         _aggregate_metrics(body, all_episodes, metric_keys)
     body["num_episodes_total"] = episode_count
+    body["num_errors"] = sum(t.get("num_errors", 0) for t in tasks_out)
     return body
 
 

--- a/tests/test_collector_errors.py
+++ b/tests/test_collector_errors.py
@@ -1,0 +1,27 @@
+"""Harness errors stay in the success denominator but are surfaced at the top level."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from vla_eval.results.collector import EpisodeResult, ResultCollector
+
+
+def _collector(*failure_reasons: str | None) -> ResultCollector:
+    c = ResultCollector(benchmark_name="B", mode="sync", metric_keys={"success": "mean"})
+    for i, reason in enumerate(failure_reasons):
+        ep: dict[str, Any] = {"episode_id": i, "metrics": {"success": reason is None}}
+        if reason:
+            ep["failure_reason"] = reason
+        c.record("task", cast(EpisodeResult, ep))
+    return c
+
+
+def test_num_errors_promoted_to_benchmark_level() -> None:
+    result = _collector(None, "timeout", None, "exception").get_benchmark_result()
+    assert result["num_errors"] == 2
+    assert result.get("mean_success") == 0.5  # errors still count as failures
+
+
+def test_num_errors_present_when_zero() -> None:
+    assert _collector(None, None).get_benchmark_result()["num_errors"] == 0

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -18,7 +18,7 @@ import numpy as np
 import pytest
 import websockets.exceptions
 
-from vla_eval.orchestrator import Orchestrator, _merge_observation_params
+from vla_eval.orchestrator import Orchestrator, _merge_observation_params, _shard_work_items
 
 from tests.conftest import BrokenTracker, RecordingTracker, StubBenchmark
 
@@ -97,6 +97,19 @@ def test_unforwardable_observation_params_warn(caplog) -> None:
     assert any(
         record.levelname == "WARNING" and "quat_no_antipodal" in record.getMessage() for record in caplog.records
     )
+
+
+def test_shard_work_items_mixes_episode_indices_and_stays_task_sorted() -> None:
+    """num_shards == episodes_per_task used to give shard k only episode k of every task."""
+    tasks, eps, shards = 10, 50, 50
+    items = [(t, {"name": f"t{t}"}, e) for t in range(tasks) for e in range(eps)]
+    slices = [_shard_work_items(items, shards, k) for k in range(shards)]
+
+    assert sorted(w for s in slices for w in s) == sorted(items)
+    assert all(len(s) == tasks * eps // shards for s in slices)
+    assert all(len({e for _, _, e in s}) > 1 for s in slices)
+    assert all([t for t, _, _ in s] == sorted(t for t, _, _ in s) for s in slices)
+    assert _shard_work_items(items, shards, 3) == slices[3]
 
 
 @pytest.mark.anyio

--- a/tests/test_recording_sqlite.py
+++ b/tests/test_recording_sqlite.py
@@ -394,6 +394,7 @@ def test_merge_db_emits_per_episode_jsonl_and_aggregate(tmp_path: Path) -> None:
     assert body["mode"] == "sync"
     assert body["seed"] == 7
     assert body["harness_version"] == "test"
+    assert isinstance(body["num_errors"], int)
     assert body["server_info"] == {"model_server": "EchoServer"}
     assert body["metric_keys"] == {"success": "mean"}
     assert body["mean_success"] == pytest.approx(2 / 3, abs=1e-4)


### PR DESCRIPTION
## Summary

**Sharding (#128).** Work items are task-major and split by `index % num_shards`, so whenever `gcd(num_shards, episodes_per_task) > 1` a shard stops seeing a mix of episode indices. With the defaults (`run_sharded.sh` 50 shards, LIBERO 50 episodes/task) shard k gets exactly episode k of every task, and LIBERO seeds the initial state from that index, so per-index difficulty piles onto single shards. Fix: shuffle the list with a fixed seed (42) before the round-robin split, then re-sort each shard's slice by task so task switches (env rebuilds) stay as rare as before. Same permutation on every shard, so slices stay disjoint and complete.

**Error visibility (#129).** The success denominator is unchanged: harness errors still count as failures, by design. What was missing is the count where aggregate consumers look. `num_errors` is now also set at the top level of `BenchmarkResult` (both the live collector and `vla-eval merge`, always present, 0 when clean), which makes it flow into the wandb/trackio run summary via the existing scalar promotion, and the final one-line summary shows it when non-zero. A completion-conditional rate is derivable from `num_episodes`, `num_errors`, `mean_success`; not adding a second headline number.

## Tests

- `_shard_work_items`: 10 tasks × 50 eps × 50 shards → slices are disjoint, cover everything, each shard holds more than one episode index, each slice is task-sorted, deterministic.
- Collector: top-level `num_errors` counts `failure_reason` episodes and is present when 0; `mean_success` still treats them as failures.
- Merge: aggregate body carries `num_errors`.

Closes #128
Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)