### PR TITLE
chore(robodojo): bump upstream pin to ee67a14

### DIFF
--- a/configs/benchmarks/robodojo/README.md
+++ b/configs/benchmarks/robodojo/README.md
@@ -22,7 +22,7 @@ they must be present in the clone:
 
 ```bash
 git clone --recurse-submodules https://github.com/RoboDojo-Benchmark/RoboDojo.git
-git -C RoboDojo checkout --recurse-submodules e9ef978fd5d78845bc0812ea0a1e7229f274051f
+git -C RoboDojo checkout --recurse-submodules ee67a1468510da7624a089164402359f2afc72c8
 docker build -t robodojo:cuda12.8 RoboDojo
 docker/build.sh robodojo --base-image robodojo:cuda12.8 --accept-license robodojo
 ```

--- a/docker/Dockerfile.robodojo
+++ b/docker/Dockerfile.robodojo
@@ -5,7 +5,7 @@
 # COPY'd into the build context, so clone with --recurse-submodules):
 #
 #   git clone --recurse-submodules https://github.com/RoboDojo-Benchmark/RoboDojo.git
-#   git -C RoboDojo checkout --recurse-submodules e9ef978fd5d78845bc0812ea0a1e7229f274051f
+#   git -C RoboDojo checkout --recurse-submodules ee67a1468510da7624a089164402359f2afc72c8
 #   docker build -t robodojo:cuda12.8 RoboDojo
 #   docker/build.sh robodojo --base-image robodojo:cuda12.8 --accept-license robodojo
 #


### PR DESCRIPTION
Bumps the RoboDojo checkout pin from e9ef978 to ee67a14 (upstream main).

What changes between the two pins in code: parallel-env default sim setting, articulation `reset_drive_targets` fix, websocket ping/timeout options in `eval_env.py`, and corrected instruction strings for `insert_key` and `sort_nesting_dolls_by_size` (upstream verified unchanged evaluation scores). The rest is checkpoint/demo download scripts and XPolicyLab submodule bumps.

The `robodojo` image must be rebuilt after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RrD6xRErSGXe87Fp1QZr6r